### PR TITLE
[experiment] Document markup — annotate a drawing while signing, saved back to the record

### DIFF
--- a/docs/markup-m2-agent-plan.md
+++ b/docs/markup-m2-agent-plan.md
@@ -1,0 +1,101 @@
+# Document Markup — M2 remainder: agent-team work plan
+
+> Branch: `exp/document-markup`. M2-1 (markup interaction layer) + the per-template
+> `Allow_Markup__c` toggle are **already built, deployed to `docgen-test`, and compile clean**.
+> This plan breaks the REMAINDER of M2 into agent-sized chunks. **Review before spinning up agents.**
+
+## What already exists (do not rebuild — call into it)
+
+In `force-app/main/default/pages/DocGenSignaturePdf.page`:
+
+- **`MarkupLayer`** (IIFE) — per-page overlay capture. API: `init(viewerPages)`, `setActive(on)`, `setTool(t)`, `setColor(c)`, `undo()`, `clear()`, `hasMarks()`, **`pageImage(pageIndex)` → transparent PNG dataURL of that page's marks (or null)**, `palette()`.
+- **`DocGenPdfViewer.getPages()`** → `[{ pageIndex, pageNum, wrapEl, cssW, cssH, scale, widthPts, heightPts }]` (PDF points per page = the flatten target size).
+- **`markupAllowed`** (JS var) — set from `validateToken` response `allowMarkup` (per-template toggle).
+- **`markupMode`**, `enterMarkup()`, `exitMarkup()`, `initMarkupLayer()` — mode plumbing; button wired.
+- Existing helpers reused by the flatten work: **`sourcePdfBase64`** (served source PDF), **`b64ToBytes` / `bytesToB64`**, **`compositeAndFinalize(...)`** (approve path → `saveCompositedSignedPdf`), **`handleDecline()`** (→ `declineSignature` RemoteAction), `PDFLib` global.
+
+Backend already shipped: `DocGenSignatureController.validateToken` returns `allowMarkup`; `saveCompositedSignedPdf` (approve) and `declineSignature` (reject) RemoteActions exist.
+
+## The shared seam (built in Chunk A, consumed by C & D)
+
+One JS function both the approve and reject paths call:
+
+```
+// markupFlattenMode: 'raster' (v1) | 'vector' (future). Returns a Promise.
+function flattenMarkupInto(doc /* PDFLib doc */, pdfLibPages /* doc.getPages() */) { ... }
+```
+
+- For each `DocGenPdfViewer.getPages()` entry where `MarkupLayer.pageImage(pageIndex)` is non-null:
+  raster → `doc.embedPng(pngBytes)` then `pdfLibPages[pageIndex].drawImage(png, {x:0, y:0, width: widthPts, height: heightPts})` (full-bleed; PNG is transparent so it overlays cleanly).
+- `markupFlattenMode === 'vector'` → **stub**: `console.warn` + fall back to the raster branch until vector is implemented.
+- Module var `var markupFlattenMode = 'raster';` declared alongside `markupAllowed`.
+
+---
+
+## Chunks
+
+### Chunk A — Frontend: raster flatten + approve path · agent: `docgen-vf-frontend`
+
+File: `pages/DocGenSignaturePdf.page` only.
+
+1. Add `var markupFlattenMode = 'raster';` next to `markupAllowed`.
+2. Implement `flattenMarkupInto(doc, pdfLibPages)` per the seam above (raster + vector stub).
+3. In `compositeAndFinalize`, after `doc.getPages()` + font embed and **before** the signature-spot
+   draw loop, chain `flattenMarkupInto(doc, pages)` when `markupAllowed && MarkupLayer.hasMarks()`
+   (so signatures render on top of markup). `embedPng` is async — fold into the existing promise chain.
+   **Acceptance:** approving with marks → composited PDF (saved by existing `saveCompositedSignedPdf`)
+   shows markup beneath the signature; **no-markup path is byte-for-byte unchanged**.
+
+### Chunk B — Backend: `saveMarkupDocument` · agent: `docgen-apex-backend`
+
+File: `classes/DocGenSignatureController.cls`.
+
+- Add `@AuraEnabled @RemoteAction public static SavePdfSignatureResult saveMarkupDocument(String token, String base64Pdf, String ipAddress, String userAgent)`.
+- Mirror `saveCompositedSignedPdf` security exactly: 64-hex token check; `DocGenSignatureGuestSecurity.assertSignerWritableFields(token)` + `assertAuditCreateable(token)`; resolve signer→request→`Related_Record_Id__c` + template name via the SAME `WITH SYSTEM_MODE` token-bound query (record id comes from the token, **never** from the client); expiry check.
+- Insert `ContentVersion` (Title `<templateName> - Markup`, `VersionData = base64Decode`, `FirstPublishLocationId = Related_Record_Id__c`) + `ContentDocumentLink` to the related record (ShareType `V`) — mirror how `saveCompositedSignedPdf` lands the final doc on the record. Create a `DocGen_Signature_Audit__c` row (hash the bytes into `Document_Hash_SHA256__c`).
+- **Do NOT** set signer `Status='Signed'`, set request status, or publish any platform event.
+- Return `SavePdfSignatureResult{ success = true }`.
+  **Acceptance:** a valid guest token saves the PDF to its OWN related record + audit, with signer/request status untouched; a foreign token can only ever reach its own bound record (IDOR-safe).
+
+### Chunk C — Frontend: reject-with-markup wire · agent: `docgen-vf-frontend` · depends A + B
+
+File: `pages/DocGenSignaturePdf.page`.
+
+- In `handleDecline`: when `markupAllowed && MarkupLayer.hasMarks()`, load `sourcePdfBase64` into pdf-lib, `await flattenMarkupInto(doc, doc.getPages())`, `doc.save()` → `bytesToB64`, invoke `saveMarkupDocument(token, b64, ip, ua)`; then proceed to the existing `declineSignature` call. Show progress; if the markup save fails, surface a warning but still allow the decline to complete.
+  **Acceptance:** rejecting with marks → marked-up PDF on the record AND signer `Declined` + reason; rejecting without marks → unchanged.
+
+### Chunk D — Vector-flatten org-setting seam · agent: `docgen-apex-backend` (+ 2-line frontend) · depends A
+
+- Field `DocGen_Settings__c.Markup_Vector_Flatten__c` (Checkbox, default false) + permset reads (Admin/User edit, Guest read), mirroring an existing `DocGen_Settings__c` field.
+- Read the setting where DocGen settings are already read; add `markupVectorFlatten` (Boolean) to `SignatureInitResponse`; set it in `validateSignerToken`.
+- Frontend (2 lines): in the `validateToken` callback set `markupFlattenMode = result.markupVectorFlatten ? 'vector' : 'raster';`.
+  **Acceptance:** setting flows to the page; flatten stays raster (vector still stubbed). Pure seam — lowest priority, can ship last.
+
+### Chunk E — Tests + deploy + smoke · agent: `docgen-qa-release` · depends A,B,C,D
+
+- Apex tests in `DocGenSignaturePdfTests.cls` for `saveMarkupDocument`: happy path (CV linked to related record + audit row; signer NOT Signed; request NOT Signed); invalid token; expired token; **IDOR** (foreign token saves only to its own bound record).
+- prettier; deploy all M2 to `docgen-test`; run `DocGenSignaturePdfTests` + `RunLocalTests` (100% / ≥75%).
+- Document the manual front-end walkthrough (Apex can't unit-test pdf-lib): mint token → draw → approve → confirm marked-up + signed PDF on the record; draw → reject → confirm marked-up PDF on the record.
+
+### Chunk F — Security review (merge gate) · agent: `docgen-security-reviewer` · depends B
+
+- Read-only audit of `saveMarkupDocument`: token format + binding; record id resolved server-side only; FLS guards present; `SYSTEM_MODE` justified inline; no `VersionData`/foreign-doc leak; `base64Pdf` size/DoS consideration; ContentDocumentLink visibility correct. Produces findings; does not edit.
+
+---
+
+## Sequencing & conflict control
+
+`DocGenSignaturePdf.page` is a single large file edited by A, C, and D-frontend → **one frontend
+agent owns it serially** to avoid conflicts.
+
+- **Wave 1 (parallel):** A (frontend) ‖ B (backend).
+- **Wave 2:** same frontend agent does C, then D's 2-line frontend bit; `docgen-apex-backend` does D's field/controller/permset (parallel with the frontend, different files).
+- **Wave 3:** E (QA, after all) ‖ F (security, after B).
+
+Net: **2 builder agents** (1 frontend serial: A→C→D-fe; 1 backend: B + D-be) + **QA** + **security**.
+
+## Out of scope for M2 (note, don't build)
+
+- Implementing the actual vector flatten (D only builds the seam/switch).
+- Editing/moving marks after placement (capture model supports undo/clear only in v1).
+- Mobile-Safari inline-PDF edge cases (desktop-first, as elsewhere).

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -4,6 +4,12 @@ public without sharing class DocGenSignatureController {
     // PIN verification settings
     private static final Integer PIN_EXPIRATION_MINUTES = 10;
     private static final Integer MAX_PIN_ATTEMPTS = 3;
+    // Defensive cap on the guest-supplied markup PDF (base64 chars) to bound heap/DoS.
+    // ~8M base64 chars ≈ 6MB decoded, matched to the synchronous RemoteAction heap ceiling
+    // so an oversized payload fails cleanly here instead of a raw LimitException mid-decode.
+    // Raster markup PDFs can be large (full-page transparent PNG overlays); the future
+    // vector flatten mode is the real size fix — this is only a guard rail.
+    private static final Integer MAX_MARKUP_BASE64_LENGTH = 8000000;
 
     public class SignatureInitResponse {
         @AuraEnabled
@@ -32,6 +38,14 @@ public without sharing class DocGenSignatureController {
         public Boolean isSignerToken;
         @AuraEnabled
         public Boolean requiresPin;
+        // M2: whether the request's template enables PDF markup (draw/annotate).
+        @AuraEnabled
+        public Boolean allowMarkup;
+        // M2 (Chunk D): org-level flatten mode seam. true => the page should flatten
+        // markup as vector once vector flattening ships; false (default) => raster.
+        // Vector is still stubbed, so the page falls back to raster regardless today.
+        @AuraEnabled
+        public Boolean markupVectorFlatten;
         // Signer form fields to render during e-signing. PUBLIC-SAFE projection
         // only — {key,label,type,required,choices}. The writeback flags and the
         // base-object field API names from the template config are deliberately
@@ -249,7 +263,7 @@ public without sharing class DocGenSignatureController {
         // SYSTEM_MODE on the SOQL below; documented FLS describe signal here.
         DocGenFlsGuard.guestAssertAccessible(
             DocGen_Template__c.sObjectType,
-            new Set<String>{ 'Name', 'Form_Fields_Config__c' }
+            new Set<String>{ 'Name', 'Form_Fields_Config__c', 'Allow_Markup__c' }
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
         List<DocGen_Signer__c> signers = [
@@ -268,7 +282,8 @@ public without sharing class DocGenSignatureController {
                 Signature_Request__r.Related_Record_Id__c,
                 Signature_Request__r.Template__c,
                 Signature_Request__r.Template__r.Name,
-                Signature_Request__r.Template__r.Form_Fields_Config__c
+                Signature_Request__r.Template__r.Form_Fields_Config__c,
+                Signature_Request__r.Template__r.Allow_Markup__c
             FROM DocGen_Signer__c
             WHERE Secure_Token__c = :token
             WITH SYSTEM_MODE
@@ -699,6 +714,16 @@ public without sharing class DocGenSignatureController {
         if (parentReq.Template__c != null && parentReq.Template__r != null) {
             res.formFields = DocGenFieldWritebackService.publicFormFields(parentReq.Template__r.Form_Fields_Config__c);
         }
+
+        // M2: per-template markup toggle — the page shows the Mark Up tools only when on.
+        res.allowMarkup = (parentReq.Template__r != null && parentReq.Template__r.Allow_Markup__c == true);
+
+        // M2 (Chunk D): org-level flatten-mode seam. DocGen_Settings__c is a hierarchy
+        // custom setting read everywhere else via getOrgDefaults() (see DocGenSetupController
+        // / sendPinEmail); reuse that mechanism. getOrgDefaults() never returns null, but the
+        // checkbox can be null for a brand-new org with no saved row — default to false.
+        DocGen_Settings__c docGenSettings = DocGen_Settings__c.getOrgDefaults();
+        res.markupVectorFlatten = (docGenSettings != null && docGenSettings.Markup_Vector_Flatten__c == true);
 
         return res;
     }
@@ -2842,6 +2867,209 @@ public without sharing class DocGenSignatureController {
                 );
             }
         }
+
+        result.success = true;
+        return result;
+    }
+
+    /**
+     * Markup-save for the document-markup path (M2, Chunk B).
+     *
+     * The browser flattens the signer's markup annotations onto the source PDF with
+     * pdf-lib and posts the finished PDF here. This is NOT a signature: it lands a
+     * marked-up copy of the document on the request's related record and writes an
+     * audit row for tamper-evidence, but it deliberately does NOT touch signer or
+     * request Status__c and never publishes a platform event. Used by the
+     * reject-with-markup path (Chunk C) so a declining signer's annotations are
+     * still preserved on the record alongside the decline.
+     *
+     * IDOR-safe: the related record id is resolved from the token-bound request
+     * (Related_Record_Id__c), never from a client parameter — a foreign token can
+     * only ever land its markup on its own bound record. Mirrors saveCompositedSignedPdf's
+     * security guards exactly (token format, guest CRUD/FLS gates, SYSTEM_MODE,
+     * expiry check).
+     */
+    @AuraEnabled
+    @RemoteAction
+    public static SavePdfSignatureResult saveMarkupDocument(
+        String token,
+        String base64Pdf,
+        String ipAddress,
+        String userAgent
+    ) {
+        SavePdfSignatureResult result = new SavePdfSignatureResult();
+        result.success = false;
+
+        if (String.isBlank(token) || token.length() != 64 || !Pattern.matches('[a-fA-F0-9]{64}', token)) {
+            throw new AuraHandledException('Invalid security token.');
+        }
+        if (String.isBlank(base64Pdf)) {
+            throw new AuraHandledException('No markup document was provided.');
+        }
+        // Guard rail against a guest posting a pathologically large payload (heap/DoS).
+        if (base64Pdf.length() > MAX_MARKUP_BASE64_LENGTH) {
+            throw new AuraHandledException('Markup document is too large.');
+        }
+
+        DocGenSignatureGuestSecurity.assertSignerWritableFields(token);
+        DocGenSignatureGuestSecurity.assertAuditCreateable(token);
+
+        DocGenFlsGuard.guestAssertAccessible(
+            DocGen_Signer__c.sObjectType,
+            new Set<String>{
+                'Status__c',
+                'Signer_Name__c',
+                'Signer_Email__c',
+                'Signature_Request__c',
+                'Role_Name__c',
+                'Contact__c',
+                'CreatedDate',
+                'PIN_Verified_At__c',
+                'Secure_Token__c'
+            }
+        );
+        // Per-template markup toggle is the SERVER-SIDE control (not just a UI hint),
+        // so the Template field read is FLS-guarded separately — mirrors validateSignerToken.
+        DocGenFlsGuard.guestAssertAccessible(
+            DocGen_Template__c.sObjectType,
+            new Set<String>{ 'Name', 'Allow_Markup__c' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<DocGen_Signer__c> signers = [
+            SELECT
+                Id,
+                Status__c,
+                Signer_Name__c,
+                Signer_Email__c,
+                Signature_Request__c,
+                Signature_Request__r.Related_Record_Id__c,
+                Signature_Request__r.Template__r.Name,
+                Signature_Request__r.Template__r.Allow_Markup__c,
+                Role_Name__c,
+                Contact__c,
+                CreatedDate,
+                PIN_Verified_At__c
+            FROM DocGen_Signer__c
+            WHERE Secure_Token__c = :token
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (signers.isEmpty()) {
+            throw new AuraHandledException('Signer not found.');
+        }
+
+        DocGen_Signer__c signer = signers[0];
+        if (signer.CreatedDate.addHours(TOKEN_EXPIRATION_HOURS) < System.now()) {
+            throw new AuraHandledException('This signature link has expired.');
+        }
+        // Terminal-state guard — once a signer has signed or declined, no further
+        // markup may be appended under their token (mirrors saveCompositedSignedPdf's
+        // already-signed reject; declined is also terminal for this token).
+        if (signer.Status__c == 'Signed') {
+            throw new AuraHandledException('You have already signed this document.');
+        }
+        if (signer.Status__c == 'Declined') {
+            throw new AuraHandledException('You have already declined this request.');
+        }
+        // Email verification is required before any document write, same as signing.
+        if (signer.PIN_Verified_At__c == null) {
+            throw new AuraHandledException('Email verification is required before signing.');
+        }
+        // Enforce the per-template Allow_Markup__c toggle server-side. Requests on the
+        // merged-approval flow always carry a Template__c, so a null template / null /
+        // false all mean markup is not enabled — reject rather than silently save.
+        Boolean markupEnabled =
+            signer.Signature_Request__r != null &&
+            signer.Signature_Request__r.Template__r != null &&
+            signer.Signature_Request__r.Template__r.Allow_Markup__c == true;
+        if (!markupEnabled) {
+            throw new AuraHandledException('Markup is not enabled for this document.');
+        }
+
+        // Related record id comes from the token-bound request ONLY (IDOR-safe).
+        String baseName = (signer.Signature_Request__r != null &&
+            signer.Signature_Request__r.Template__r != null)
+            ? signer.Signature_Request__r.Template__r.Name
+            : null;
+        Id relatedRecordId = signer.Signature_Request__r != null
+            ? (Id) signer.Signature_Request__r.Related_Record_Id__c
+            : null;
+
+        Blob markupBytes = EncodingUtil.base64Decode(base64Pdf);
+        String markupTitle = String.isNotBlank(baseName) ? (baseName + ' - Markup') : 'Markup Document';
+
+        // Land the marked-up PDF on the related record. Mirrors saveCompositedSignedPdf's
+        // final-doc write: FirstPublishLocationId on the CV + an explicit ContentDocumentLink
+        // (ShareType 'V', Visibility 'AllUsers') so the document is visible on the record.
+        ContentVersion cv = new ContentVersion();
+        cv.Title = markupTitle;
+        cv.PathOnClient = markupTitle + '.pdf';
+        cv.VersionData = markupBytes;
+        if (relatedRecordId != null) {
+            cv.FirstPublishLocationId = relatedRecordId;
+        }
+        DocGenFlsGuard.guestAssertCreateable(cv, new Set<String>{ 'Title', 'PathOnClient', 'VersionData' });
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        Database.insert(cv, AccessLevel.SYSTEM_MODE);
+
+        if (relatedRecordId != null) {
+            // Best-effort share — never block the markup save on the link.
+            try {
+                ContentVersion savedCv = [
+                    SELECT Id, ContentDocumentId
+                    FROM ContentVersion
+                    WHERE Id = :cv.Id
+                    WITH SYSTEM_MODE
+                    LIMIT 1
+                ];
+                ContentDocumentLink cdl = new ContentDocumentLink();
+                cdl.ContentDocumentId = savedCv.ContentDocumentId;
+                cdl.LinkedEntityId = relatedRecordId;
+                cdl.ShareType = 'V';
+                cdl.Visibility = 'AllUsers';
+                DocGenFlsGuard.guestAssertCreateable(
+                    cdl,
+                    new Set<String>{ 'ContentDocumentId', 'LinkedEntityId', 'ShareType', 'Visibility' }
+                );
+                /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+                Database.insert(cdl, AccessLevel.SYSTEM_MODE);
+            } catch (Exception shareErr) {
+                System.debug(
+                    LoggingLevel.ERROR,
+                    'DocGen: failed to share markup document with related record: ' + shareErr.getMessage()
+                );
+            }
+        }
+
+        // Audit row — tamper-evidence only. Note: signer/request Status__c are NOT
+        // changed and no platform event is published. This is a markup-save, not a
+        // signature.
+        DocGen_Signature_Audit__c audit = new DocGen_Signature_Audit__c();
+        audit.Signature_Request__c = signer.Signature_Request__c;
+        audit.Signer__c = signer.Id;
+        audit.Signer_Name__c = signer.Signer_Name__c;
+        audit.Signer_Email__c = signer.Signer_Email__c;
+        audit.Contact__c = signer.Contact__c;
+        audit.Signed_Date__c = System.now();
+        audit.IP_Address__c = resolveClientIp(ipAddress);
+        audit.User_Agent__c = String.isNotBlank(userAgent) ? userAgent.left(255) : 'Unknown';
+        audit.Document_Hash_SHA256__c = EncodingUtil.convertToHex(Crypto.generateDigest('SHA-256', markupBytes));
+        DocGenFlsGuard.guestAssertCreateable(
+            audit,
+            new Set<String>{
+                'Signature_Request__c',
+                'Signer__c',
+                'Signer_Name__c',
+                'Signer_Email__c',
+                'Contact__c',
+                'Signed_Date__c',
+                'IP_Address__c',
+                'User_Agent__c',
+                'Document_Hash_SHA256__c'
+            }
+        );
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        Database.insert(new List<DocGen_Signature_Audit__c>{ audit }, false, AccessLevel.SYSTEM_MODE);
 
         result.success = true;
         return result;

--- a/force-app/main/default/classes/DocGenSignaturePdfTests.cls
+++ b/force-app/main/default/classes/DocGenSignaturePdfTests.cls
@@ -4,6 +4,14 @@ private class DocGenSignaturePdfTests {
     // 64-char hex tokens (the only valid Secure_Token__c shape).
     private static final String SIGNER_TOKEN = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
     private static final String FOREIGN_TOKEN = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    // Markup-enabled signer: request carries a Template__c with Allow_Markup__c=true and the
+    // signer is PIN-verified, so saveMarkupDocument's gates (size, expiry, terminal-state, PIN,
+    // per-template toggle) all pass and the happy/IDOR paths reach the document write.
+    private static final String MARKUP_TOKEN = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1111111111111111cccccccccccccccc';
+    // Markup-enabled request but signer is NOT PIN-verified (exercises the PIN gate).
+    private static final String MARKUP_NOPIN_TOKEN = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2222222222222222dddddddddddddddd';
+    // Markup-enabled request whose signer is already Declined (exercises the terminal-state gate).
+    private static final String MARKUP_DECLINED_TOKEN = 'cccccccccccccccccccccccccccccccc3333333333333333eeeeeeeeeeeeeeee';
 
     @testSetup
     static void setup() {
@@ -65,6 +73,65 @@ private class DocGenSignaturePdfTests {
             Sort_Order__c = 1
         );
         Database.insert(foreignSigner, AccessLevel.SYSTEM_MODE);
+
+        // ---- Markup-enabled fixtures (M2, Chunk E) ---------------------------------
+        // A template with the per-template markup toggle ON. saveMarkupDocument reads
+        // Template__r.Allow_Markup__c server-side and rejects when null/false.
+        DocGen_Template__c markupTmpl = new DocGen_Template__c(
+            Name = 'Markup Enabled Template',
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF',
+            Allow_Markup__c = true
+        );
+        Database.insert(markupTmpl, AccessLevel.SYSTEM_MODE);
+
+        // Request on the markup-enabled template, bound to the same Account.
+        DocGen_Signature_Request__c markupReq = new DocGen_Signature_Request__c(
+            Template__c = markupTmpl.Id,
+            Related_Record_Id__c = acc.Id,
+            Status__c = 'Sent',
+            Signing_Order__c = 'Parallel'
+        );
+        Database.insert(markupReq, AccessLevel.SYSTEM_MODE);
+
+        // PIN-verified signer → happy/IDOR path reaches the document write.
+        DocGen_Signer__c markupSigner = new DocGen_Signer__c(
+            Signature_Request__c = markupReq.Id,
+            Signer_Name__c = 'Mark Upton',
+            Signer_Email__c = 'mark@test.com',
+            Role_Name__c = 'Signer',
+            Secure_Token__c = MARKUP_TOKEN,
+            Status__c = 'Pending',
+            Sort_Order__c = 1,
+            PIN_Verified_At__c = System.now()
+        );
+        // NOT PIN-verified signer on the same markup-enabled request → exercises the PIN gate.
+        DocGen_Signer__c markupNoPinSigner = new DocGen_Signer__c(
+            Signature_Request__c = markupReq.Id,
+            Signer_Name__c = 'No Pin Signer',
+            Signer_Email__c = 'nopin@test.com',
+            Role_Name__c = 'Signer',
+            Secure_Token__c = MARKUP_NOPIN_TOKEN,
+            Status__c = 'Pending',
+            Sort_Order__c = 2
+        );
+        // Already-Declined signer → exercises the terminal-state gate (PIN-verified so the
+        // Declined check is the one that fires).
+        DocGen_Signer__c markupDeclinedSigner = new DocGen_Signer__c(
+            Signature_Request__c = markupReq.Id,
+            Signer_Name__c = 'Declined Signer',
+            Signer_Email__c = 'declined@test.com',
+            Role_Name__c = 'Signer',
+            Secure_Token__c = MARKUP_DECLINED_TOKEN,
+            Status__c = 'Declined',
+            Sort_Order__c = 3,
+            PIN_Verified_At__c = System.now()
+        );
+        Database.insert(
+            new List<DocGen_Signer__c>{ markupSigner, markupNoPinSigner, markupDeclinedSigner },
+            AccessLevel.SYSTEM_MODE
+        );
     }
 
     private static DocGen_Signer__c getSigner(String token) {
@@ -1178,5 +1245,251 @@ private class DocGenSignaturePdfTests {
             threw = true;
         }
         System.assert(threw, 'A null snapshot data map must throw rather than fall back to the live record');
+    }
+
+    // =========================================================================
+    // M2 — saveMarkupDocument (document-markup reject-with-markup path, Chunk B/E).
+    // Lands a flattened markup PDF on the request's OWN Related_Record_Id__c + an
+    // audit row, WITHOUT setting signer/request Status='Signed' and without
+    // publishing any platform event. Record id is resolved server-side from the
+    // token (IDOR-safe), never passed by the client.
+    // =========================================================================
+
+    @isTest
+    static void testSaveMarkupDocument_success() {
+        Account acc = [SELECT Id FROM Account WHERE Name = 'PDF Sign Test Co' LIMIT 1];
+        DocGen_Signer__c signer = getSigner(MARKUP_TOKEN);
+        Id requestId = signer.Signature_Request__c;
+
+        Test.startTest();
+        DocGenSignatureController.SavePdfSignatureResult result = DocGenSignatureController.saveMarkupDocument(
+            MARKUP_TOKEN,
+            EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.7 markup')),
+            '203.0.113.7',
+            'UA'
+        );
+        Test.stopTest();
+
+        System.assertEquals(true, result.success, 'Markup save must succeed for a valid token');
+
+        // A marked-up document is linked to the token-bound related record (the setup Account).
+        List<ContentDocumentLink> links = [
+            SELECT ContentDocumentId
+            FROM ContentDocumentLink
+            WHERE LinkedEntityId = :acc.Id
+        ];
+        System.assert(!links.isEmpty(), 'A markup document is linked to the related record');
+        Set<Id> docIds = new Set<Id>();
+        for (ContentDocumentLink link : links) {
+            docIds.add(link.ContentDocumentId);
+        }
+        System.assertEquals(1, docIds.size(), 'Exactly one markup document landed on the related record');
+
+        // An audit row was written for the markup save.
+        List<DocGen_Signature_Audit__c> audits = [
+            SELECT Document_Hash_SHA256__c, IP_Address__c
+            FROM DocGen_Signature_Audit__c
+            WHERE Signer__c = :signer.Id
+        ];
+        System.assertEquals(1, audits.size(), 'One audit row created for the markup save');
+        System.assert(
+            String.isNotBlank(audits[0].Document_Hash_SHA256__c),
+            'Markup audit records the SHA-256 of the saved PDF for tamper-evidence'
+        );
+
+        // Status must NOT change — this is a markup save, not a signature.
+        DocGen_Signer__c after = [SELECT Status__c FROM DocGen_Signer__c WHERE Id = :signer.Id];
+        System.assertNotEquals('Signed', after.Status__c, 'Markup save must NOT mark the signer Signed');
+        System.assertEquals('Pending', after.Status__c, 'Signer status is left untouched by the markup save');
+
+        DocGen_Signature_Request__c req = [
+            SELECT Status__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :requestId
+        ];
+        System.assertNotEquals('Signed', req.Status__c, 'Markup save must NOT flip the request to Signed');
+        System.assertEquals('Sent', req.Status__c, 'Request status is left untouched by the markup save');
+    }
+
+    @isTest
+    static void testSaveMarkupDocument_invalidToken() {
+        Test.startTest();
+        try {
+            DocGenSignatureController.saveMarkupDocument(
+                'not-a-hex-token',
+                EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.7 markup')),
+                '1.1.1.1',
+                'UA'
+            );
+            System.assert(false, 'A malformed (non-64-hex) token must be rejected');
+        } catch (Exception e) {
+            // AuraHandledException
+        }
+        Test.stopTest();
+    }
+
+    @isTest
+    static void testSaveMarkupDocument_blankPdf() {
+        Test.startTest();
+        try {
+            DocGenSignatureController.saveMarkupDocument(SIGNER_TOKEN, '', '1.1.1.1', 'UA');
+            System.assert(false, 'A blank markup PDF must be rejected');
+        } catch (Exception e) {
+            // AuraHandledException
+        }
+        Test.stopTest();
+    }
+
+    @isTest
+    static void testSaveMarkupDocument_expiredToken() {
+        // Backdate CreatedDate past the 48h expiry window (mirrors the getSourcePdf expiry test).
+        // Uses the markup-enabled+PIN-verified signer so the expiry check (which runs BEFORE the
+        // terminal-state/PIN/toggle gates) is unambiguously the gate that rejects it.
+        DocGen_Signer__c signer = getSigner(MARKUP_TOKEN);
+        Test.setCreatedDate(signer.Id, System.now().addHours(-49));
+
+        Test.startTest();
+        try {
+            DocGenSignatureController.saveMarkupDocument(
+                MARKUP_TOKEN,
+                EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.7 markup')),
+                '1.1.1.1',
+                'UA'
+            );
+            System.assert(false, 'An expired token must be rejected');
+        } catch (Exception e) {
+            // AuraHandledException
+        }
+        Test.stopTest();
+    }
+
+    @isTest
+    static void testSaveMarkupDocument_markupNotEnabled() {
+        // SIGNER_TOKEN's request is Template__c-null → Allow_Markup__c is not enabled.
+        // The signer is PIN-verified-agnostic here; the toggle check rejects it.
+        DocGen_Signer__c signer = getSigner(SIGNER_TOKEN);
+        signer.PIN_Verified_At__c = System.now();
+        Database.update(signer, AccessLevel.SYSTEM_MODE);
+
+        Test.startTest();
+        try {
+            DocGenSignatureController.saveMarkupDocument(
+                SIGNER_TOKEN,
+                EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.7 markup')),
+                '1.1.1.1',
+                'UA'
+            );
+            System.assert(false, 'A request without an Allow_Markup__c=true template must be rejected');
+        } catch (Exception e) {
+            // AuraHandledException — the per-template Allow_Markup__c=true gate rejects it.
+            // (AuraHandledException.getMessage() returns the generic "Script-thrown exception"
+            // in test context, so we assert the throw rather than the message text.)
+        }
+        Test.stopTest();
+    }
+
+    @isTest
+    static void testSaveMarkupDocument_pinNotVerified() {
+        // Markup-enabled request, but this signer has not verified their email PIN.
+        Test.startTest();
+        try {
+            DocGenSignatureController.saveMarkupDocument(
+                MARKUP_NOPIN_TOKEN,
+                EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.7 markup')),
+                '1.1.1.1',
+                'UA'
+            );
+            System.assert(false, 'A signer who has not verified their email must be rejected');
+        } catch (Exception e) {
+            // AuraHandledException — the PIN_Verified_At__c != null gate rejects it.
+        }
+        Test.stopTest();
+    }
+
+    @isTest
+    static void testSaveMarkupDocument_declinedSigner() {
+        // Markup-enabled request whose signer already Declined → terminal state, no further markup.
+        Test.startTest();
+        try {
+            DocGenSignatureController.saveMarkupDocument(
+                MARKUP_DECLINED_TOKEN,
+                EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.7 markup')),
+                '1.1.1.1',
+                'UA'
+            );
+            System.assert(false, 'A signer in a terminal (Declined) state must be rejected');
+        } catch (Exception e) {
+            // AuraHandledException — the terminal-state (Declined) gate rejects it.
+        }
+        Test.stopTest();
+    }
+
+    // NOTE: the 16,000,000-char base64 size cap is a simple String.length() guard in
+    // saveMarkupDocument; it is deliberately NOT unit-tested here because materializing a
+    // 16M-char string blows the Apex test heap. The guard is verified by inspection.
+
+    @isTest
+    static void testSaveMarkupDocument_idor() {
+        // The markup PDF is linked ONLY to the record bound to the token's request,
+        // resolved server-side — the caller never passes a record id, so it cannot
+        // target an arbitrary record.
+        DocGen_Signer__c signer = getSigner(MARKUP_TOKEN);
+        DocGen_Signature_Request__c boundReq = [
+            SELECT Related_Record_Id__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :signer.Signature_Request__c
+        ];
+        Id boundRecordId = (Id) boundReq.Related_Record_Id__c;
+
+        Test.startTest();
+        DocGenSignatureController.SavePdfSignatureResult result = DocGenSignatureController.saveMarkupDocument(
+            MARKUP_TOKEN,
+            EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.7 markup')),
+            '1.1.1.1',
+            'UA'
+        );
+        Test.stopTest();
+
+        System.assertEquals(true, result.success);
+
+        // CDL queries must be filtered by Id (platform restriction). Resolve the just-created
+        // markup CV, then prove ITS document link targets only the token-bound related record.
+        ContentVersion markupCv = [
+            SELECT ContentDocumentId
+            FROM ContentVersion
+            WHERE Title LIKE '%Markup%'
+            ORDER BY CreatedDate DESC
+            LIMIT 1
+        ];
+        List<ContentDocumentLink> links = [
+            SELECT LinkedEntityId
+            FROM ContentDocumentLink
+            WHERE ContentDocumentId = :markupCv.ContentDocumentId
+        ];
+        System.assert(!links.isEmpty(), 'Markup document is linked to the related record');
+
+        // The method controls exactly one record-targeting link: the token-bound record.
+        // (Publishing a CV via FirstPublishLocationId also creates an automatic link to the
+        // running user — a 005 owner link — which is platform behavior, not a record target.)
+        Boolean linkedToBoundRecord = false;
+        for (ContentDocumentLink link : links) {
+            Id linked = link.LinkedEntityId;
+            if (linked == boundRecordId) {
+                linkedToBoundRecord = true;
+            } else {
+                // The only other permissible link is the automatic owner (User) link.
+                System.assertEquals(
+                    'User',
+                    linked.getSObjectType().getDescribe().getName(),
+                    'Markup document must not be linked to any record other than the token-bound one ' +
+                        '(record id resolved server-side, IDOR-safe). Unexpected link to: ' +
+                        linked
+                );
+            }
+        }
+        System.assert(
+            linkedToBoundRecord,
+            'Markup document is linked to the token-bound related record (the only record target)'
+        );
     }
 }

--- a/force-app/main/default/classes/DocGenSignaturePdfTests.cls
+++ b/force-app/main/default/classes/DocGenSignaturePdfTests.cls
@@ -347,6 +347,166 @@ private class DocGenSignaturePdfTests {
         Test.stopTest();
     }
 
+    // =========================================================================
+    // Merged-approval (exp/document-markup, M1) — prepareApprovalForMerge +
+    // attachMergedSourceAndSend. The client merges a pre-existing record PDF with
+    // the tagged approval-template PDF between the two calls.
+    // =========================================================================
+
+    @isTest
+    static void testPrepareApprovalForMerge_createsDraftAndReturnsPdf() {
+        Account acc = new Account(Name = 'Drawing Approval Co', Industry = 'Manufacturing');
+        insert acc;
+        Id templateId = createHtmlSignatureTemplate(
+            '<html><body><h1>Approval — {Name}</h1><p>Approve: {@Signature_Approver:1:Full}</p></body></html>'
+        );
+        String signersJson = JSON.serialize(
+            new List<Map<String, Object>>{
+                new Map<String, Object>{
+                    'signerName' => 'Dana Approver',
+                    'signerEmail' => 'dana@test.com',
+                    'roleName' => 'Approver',
+                    'contactId' => ''
+                }
+            }
+        );
+
+        Test.startTest();
+        Map<String, String> result = DocGenSignatureSenderController.prepareApprovalForMerge(
+            templateId,
+            acc.Id,
+            signersJson,
+            'Parallel',
+            null
+        );
+        Test.stopTest();
+
+        System.assertNotEquals(null, result.get('requestId'), 'Draft request Id returned');
+        System.assert(String.isNotBlank(result.get('viewingPdfBase64')), 'Approval-template viewing PDF returned');
+        Id requestId = (Id) result.get('requestId');
+
+        DocGen_Signature_Request__c req = [
+            SELECT Status__c, Template__c, Source_Document_Id__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :requestId
+        ];
+        System.assertEquals('Draft', req.Status__c, 'Phase 1 leaves the request in Draft (not yet sent)');
+        System.assertEquals(templateId, req.Template__c, 'Approval template recorded');
+        System.assertNotEquals(null, req.Source_Document_Id__c, 'Stub template-only source set until phase 2');
+
+        System.assertEquals(
+            1,
+            [SELECT COUNT() FROM DocGen_Signer__c WHERE Signature_Request__c = :requestId],
+            'One signer created'
+        );
+        List<DocGen_Signature_Placement__c> placements = [
+            SELECT Tag_Text__c
+            FROM DocGen_Signature_Placement__c
+            WHERE Signature_Request__c = :requestId
+        ];
+        System.assertEquals(1, placements.size(), 'One placement for the single signature tag');
+        System.assertEquals('@@SIG-0@@', placements[0].Tag_Text__c, 'Deterministic sentinel stored on the placement');
+    }
+
+    @isTest
+    static void testAttachMergedSourceAndSend_sendsAndRepoints() {
+        Account acc = new Account(Name = 'Merge Send Co', Industry = 'Manufacturing');
+        insert acc;
+        Id templateId = createHtmlSignatureTemplate(
+            '<html><body><p>Approve: {@Signature_Approver:1:Full}</p></body></html>'
+        );
+        String signersJson = JSON.serialize(
+            new List<Map<String, Object>>{
+                new Map<String, Object>{
+                    'signerName' => 'Dana Approver',
+                    'signerEmail' => 'dana@test.com',
+                    'roleName' => 'Approver',
+                    'contactId' => ''
+                }
+            }
+        );
+
+        Test.startTest();
+        Map<String, String> prep = DocGenSignatureSenderController.prepareApprovalForMerge(
+            templateId,
+            acc.Id,
+            signersJson,
+            'Parallel',
+            null
+        );
+        Id requestId = (Id) prep.get('requestId');
+
+        // Stand in for the client-side merge of [drawing, approval].
+        String mergedBase64 = EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.7 merged drawing + approval page'));
+        List<DocGenSignatureSenderController.SignerResult> results = DocGenSignatureSenderController.attachMergedSourceAndSend(
+            requestId,
+            mergedBase64
+        );
+        Test.stopTest();
+
+        System.assertEquals(1, results.size(), 'One signer result returned');
+        System.assert(
+            results[0].signerUrl != null && results[0].signerUrl.contains('DocGenSignaturePdf'),
+            'Invitation targets the guided PDF page: ' + results[0].signerUrl
+        );
+
+        DocGen_Signature_Request__c req = [
+            SELECT Status__c, Source_Document_Id__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :requestId
+        ];
+        System.assertEquals('Sent', req.Status__c, 'Phase 2 flips the request to Sent');
+
+        // Source now points at the merged CV, shared with the request so the guest's
+        // getSourcePdfBase64 can read it (same pattern as the single-template guided path;
+        // the SIGNED output is what the finalizer links back to the related record).
+        ContentVersion mergedCv = [
+            SELECT ContentDocumentId
+            FROM ContentVersion
+            WHERE Id = :req.Source_Document_Id__c
+            LIMIT 1
+        ];
+        Integer links = [
+            SELECT COUNT()
+            FROM ContentDocumentLink
+            WHERE ContentDocumentId = :mergedCv.ContentDocumentId AND LinkedEntityId = :requestId
+        ];
+        System.assert(links > 0, 'Merged signing source is shared with the request for guest read');
+    }
+
+    @isTest
+    static void testAttachMergedSourceAndSend_rejectsNonDraft() {
+        Account acc = new Account(Name = 'Non Draft Co');
+        insert acc;
+        Id templateId = createHtmlSignatureTemplate(
+            '<html><body><p>Approve: {@Signature_Approver:1:Full}</p></body></html>'
+        );
+        String signersJson = '[{"signerName":"Dana","signerEmail":"dana@test.com","roleName":"Approver","contactId":""}]';
+
+        Test.startTest();
+        Map<String, String> prep = DocGenSignatureSenderController.prepareApprovalForMerge(
+            templateId,
+            acc.Id,
+            signersJson,
+            'Parallel',
+            null
+        );
+        Id requestId = (Id) prep.get('requestId');
+        String mergedBase64 = EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.7 merged'));
+        // First call sends it.
+        DocGenSignatureSenderController.attachMergedSourceAndSend(requestId, mergedBase64);
+
+        // Second call must be rejected — the request is no longer Draft.
+        Boolean threw = false;
+        try {
+            DocGenSignatureSenderController.attachMergedSourceAndSend(requestId, mergedBase64);
+        } catch (Exception e) {
+            threw = true;
+        }
+        Test.stopTest();
+        System.assert(threw, 'A non-Draft request cannot be re-sent');
+    }
+
     @isTest
     static void testSignatureTagStrippedInNormalGeneration() {
         // Leak fix: {@Signature_*} must be stripped from a normally-generated document

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -1224,6 +1224,106 @@ public with sharing class DocGenSignatureSenderController {
             }
         }
 
+        // Render the tagged viewing document (sentinels + frozen snapshot). Extracted to
+        // renderGuidedViewing so the merged-approval path (prepareApprovalForMerge) builds
+        // a byte-compatible viewing PDF through the SAME code and gets identical sentinels.
+        GuidedViewingDraft draft = renderGuidedViewing(templateId, relatedRecordId, signerInputs, tpls[0].Name);
+        placements = draft.placements;
+        List<String> sentinels = draft.sentinels;
+        String frozenJson = draft.frozenJson;
+        String fileTitle = draft.fileTitle;
+
+        // Render the viewing PDF (invisible sentinels) → standalone ContentVersion.
+        ContentVersion viewCv = new ContentVersion();
+        viewCv.Title = fileTitle;
+        viewCv.PathOnClient = fileTitle + '.pdf';
+        viewCv.VersionData = draft.viewingBlob;
+        DocGenFlsGuard.assertCreateable(viewCv, new Set<String>{ 'Title', 'PathOnClient', 'VersionData' });
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        Database.insert(viewCv, AccessLevel.SYSTEM_MODE);
+
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c();
+        req.Template__c = templateId;
+        req.Related_Record_Id__c = relatedRecordId;
+        req.Source_Document_Id__c = viewCv.Id;
+        req.Status__c = 'Sent';
+        req.Signing_Order__c = String.isNotBlank(signingOrder) ? signingOrder : 'Parallel';
+        if (String.isNotBlank(documentTitleFormat)) {
+            req.Document_Title_Format__c = documentTitleFormat;
+        }
+        req.Secure_Token__c = generateRequestVerificationToken();
+        Set<String> reqFields = new Set<String>{
+            'Template__c',
+            'Related_Record_Id__c',
+            'Source_Document_Id__c',
+            'Status__c',
+            'Signing_Order__c',
+            'Document_Title_Format__c',
+            'Secure_Token__c'
+        };
+        if (String.isNotBlank(frozenJson)) {
+            // #156: snapshot persisted to a ContentVersion (no 131072-char cap) and referenced
+            // by Id, so large templates get a true frozen snapshot instead of a live re-merge.
+            req.Frozen_Document_CV_Id__c = DocGenSignatureService.saveFrozenSnapshotCv(frozenJson);
+            req.Snapshot_Hash__c = DocGenSignatureService.hashFrozenDocument(frozenJson);
+            req.Snapshot_Taken_At__c = System.now();
+            reqFields.addAll(new Set<String>{ 'Frozen_Document_CV_Id__c', 'Snapshot_Hash__c', 'Snapshot_Taken_At__c' });
+        }
+        DocGenFlsGuard.assertCreateable(req, reqFields);
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        Database.insert(req, AccessLevel.SYSTEM_MODE);
+
+        // Share the standalone viewing CV with the guest signer so the signing-page
+        // preview (getSourcePdfBase64) can read it (see shareViewingDocumentWithGuest).
+        shareViewingDocumentWithGuest(viewCv.Id, req.Id);
+
+        // Create signers at the PDF-viewer page (templateId=null skips the classic
+        // placement creation — we create sentinel-keyed placements below).
+        List<SignerResult> results = createSignersAndNotify(
+            req.Id,
+            null,
+            fileTitle,
+            signerInputs,
+            true,
+            getSigningPdfPagePath()
+        );
+
+        // Map placements → signers by role and persist (shared with prepareApprovalForMerge).
+        createGuidedPlacementRecords(req.Id, placements, sentinels);
+
+        return results;
+    }
+
+    /**
+     * Small struct returned by renderGuidedViewing: the rendered sentinel-bearing viewing
+     * PDF plus the placement/sentinel/frozen-snapshot metadata the caller needs to persist.
+     */
+    private class GuidedViewingDraft {
+        Blob viewingBlob;
+        String fileTitle;
+        String frozenJson;
+        List<PlacementInfo> placements;
+        List<String> sentinels;
+    }
+
+    /**
+     * Shared tagged-viewing render for the guided PDF path. Merges the template against the
+     * record, synthesizes a "Signatures" block for tag-less templates (#170 option b),
+     * swaps each placement tag to a unique invisible @@SIG-n@@ sentinel, freezes that body
+     * for the completion re-render, and renders the sentinel-bearing viewing PDF.
+     *
+     * NO DML — callers persist the ContentVersion / request / placements. Used by
+     * createGuidedPdfSignatureRequest (template-only source) and prepareApprovalForMerge
+     * (the client merges this PDF with a pre-existing record PDF before it becomes the
+     * signing source). Sentinels are deterministic (@@SIG-i@@ by index), so both callers
+     * — and the deferred phase-2 placement create — stay in lockstep.
+     */
+    private static GuidedViewingDraft renderGuidedViewing(
+        Id templateId,
+        String relatedRecordId,
+        List<Map<String, Object>> signerInputs,
+        String fileTitle
+    ) {
         // Merge the template against the live record (point-in-time body).
         Map<String, Object> mergeData = DocGenService.mergeTemplateForSignature(templateId, relatedRecordId);
         String templateType = (String) mergeData.get('templateType');
@@ -1236,6 +1336,7 @@ public with sharing class DocGenSignatureSenderController {
             body = (String) mergeData.get('documentXml');
         }
 
+        List<PlacementInfo> placements = getTemplateSignaturePlacements(templateId);
         if (placements.isEmpty()) {
             // Option (b) for tag-less legacy templates (#170): synthesize a "Signatures"
             // block (one Full + Date per signer) and append it to the merged body so the
@@ -1293,64 +1394,25 @@ public with sharing class DocGenSignatureSenderController {
         // @@FF-<key>@@ sentinel for the drawn-path client to stamp the value onto.
         viewingHtml = applyFormFieldViewingSentinels(viewingHtml);
 
-        // Render the viewing PDF (invisible sentinels) → standalone ContentVersion.
-        Blob viewingBlob = Blob.toPdf(viewingHtml);
-        String fileTitle = tpls[0].Name;
-        ContentVersion viewCv = new ContentVersion();
-        viewCv.Title = fileTitle;
-        viewCv.PathOnClient = fileTitle + '.pdf';
-        viewCv.VersionData = viewingBlob;
-        DocGenFlsGuard.assertCreateable(viewCv, new Set<String>{ 'Title', 'PathOnClient', 'VersionData' });
-        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-        Database.insert(viewCv, AccessLevel.SYSTEM_MODE);
+        GuidedViewingDraft d = new GuidedViewingDraft();
+        d.viewingBlob = Blob.toPdf(viewingHtml);
+        d.fileTitle = fileTitle;
+        d.frozenJson = frozenJson;
+        d.placements = placements;
+        d.sentinels = sentinels;
+        return d;
+    }
 
-        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c();
-        req.Template__c = templateId;
-        req.Related_Record_Id__c = relatedRecordId;
-        req.Source_Document_Id__c = viewCv.Id;
-        req.Status__c = 'Sent';
-        req.Signing_Order__c = String.isNotBlank(signingOrder) ? signingOrder : 'Parallel';
-        if (String.isNotBlank(documentTitleFormat)) {
-            req.Document_Title_Format__c = documentTitleFormat;
-        }
-        req.Secure_Token__c = generateRequestVerificationToken();
-        Set<String> reqFields = new Set<String>{
-            'Template__c',
-            'Related_Record_Id__c',
-            'Source_Document_Id__c',
-            'Status__c',
-            'Signing_Order__c',
-            'Document_Title_Format__c',
-            'Secure_Token__c'
-        };
-        if (String.isNotBlank(frozenJson)) {
-            // #156: snapshot persisted to a ContentVersion (no 131072-char cap) and referenced
-            // by Id, so large templates get a true frozen snapshot instead of a live re-merge.
-            req.Frozen_Document_CV_Id__c = DocGenSignatureService.saveFrozenSnapshotCv(frozenJson);
-            req.Snapshot_Hash__c = DocGenSignatureService.hashFrozenDocument(frozenJson);
-            req.Snapshot_Taken_At__c = System.now();
-            reqFields.addAll(new Set<String>{ 'Frozen_Document_CV_Id__c', 'Snapshot_Hash__c', 'Snapshot_Taken_At__c' });
-        }
-        DocGenFlsGuard.assertCreateable(req, reqFields);
-        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-        Database.insert(req, AccessLevel.SYSTEM_MODE);
-
-        // Share the standalone viewing CV with the guest signer so the signing-page
-        // preview (getSourcePdfBase64) can read it (see shareViewingDocumentWithGuest).
-        shareViewingDocumentWithGuest(viewCv.Id, req.Id);
-
-        // Create signers at the PDF-viewer page (templateId=null skips the classic
-        // placement creation — we create sentinel-keyed placements below).
-        List<SignerResult> results = createSignersAndNotify(
-            req.Id,
-            null,
-            fileTitle,
-            signerInputs,
-            true,
-            getSigningPdfPagePath()
-        );
-
-        // Map placements → signers by role (fallback: first signer), Tag_Text__c = sentinel.
+    /**
+     * Creates DocGen_Signature_Placement__c rows for a guided request: maps each placement
+     * to a signer by role (fallback: first signer) and stores the sentinel in Tag_Text__c.
+     * Shared by createGuidedPdfSignatureRequest and the merged-approval phase-1 path.
+     */
+    private static void createGuidedPlacementRecords(
+        Id requestId,
+        List<PlacementInfo> placements,
+        List<String> sentinels
+    ) {
         DocGenFlsGuard.assertAccessible(
             DocGen_Signer__c.sObjectType,
             new Set<String>{ 'Role_Name__c', 'Signature_Request__c', 'Sort_Order__c' }
@@ -1359,7 +1421,7 @@ public with sharing class DocGenSignatureSenderController {
         List<DocGen_Signer__c> signerRecs = [
             SELECT Id, Role_Name__c
             FROM DocGen_Signer__c
-            WHERE Signature_Request__c = :req.Id
+            WHERE Signature_Request__c = :requestId
             WITH SYSTEM_MODE
             ORDER BY Sort_Order__c ASC
         ];
@@ -1381,7 +1443,7 @@ public with sharing class DocGenSignatureSenderController {
             placementRecords.add(
                 new DocGen_Signature_Placement__c(
                     Signer__c = signer.Id,
-                    Signature_Request__c = req.Id,
+                    Signature_Request__c = requestId,
                     Document_Index__c = 0,
                     Sequence_Order__c = p.sequence,
                     Placement_Type__c = p.placementType,
@@ -1408,7 +1470,245 @@ public with sharing class DocGenSignatureSenderController {
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
             Database.insert(placementRecords, AccessLevel.SYSTEM_MODE);
         }
+    }
 
+    /**
+     * MERGED-APPROVAL (exp/document-markup, M1) — phase 1 of 2.
+     *
+     * Renders the approval/signature template's tagged viewing PDF and stands up a DRAFT
+     * guided request (signers + placements + frozen snapshot) WITHOUT notifying anyone.
+     * Returns the viewing PDF as base64 so the client can merge it with a pre-existing
+     * record PDF (e.g. an A3 technical drawing) via docGenPdfMerger, then call
+     * attachMergedSourceAndSend with the combined bytes. The merged document — drawing
+     * pages + the tagged approval page — becomes the signing source, so the appended
+     * template carries the {@Signature_*}/synthetic sign-spots (mainline guided model; we
+     * never sign a bare tag-less PDF — that path was removed in v3.18). Source_Document_Id__c
+     * initially points at the template-only viewing CV; phase 2 repoints it to the merge.
+     *
+     * Returns: { requestId, viewingPdfBase64, fileTitle }.
+     */
+    @AuraEnabled
+    public static Map<String, String> prepareApprovalForMerge(
+        Id templateId,
+        String relatedRecordId,
+        String signersJson,
+        String signingOrder,
+        String documentTitleFormat
+    ) {
+        DocGenFlsGuard.assertAccessible(
+            DocGen_Template__c.sObjectType,
+            new Set<String>{ 'Name', 'Document_Title_Format__c' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Template__c> tpls = [
+            SELECT Id, Name, Document_Title_Format__c
+            FROM DocGen_Template__c
+            WHERE Id = :templateId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (tpls.isEmpty()) {
+            throw new AuraHandledException('Template not found.');
+        }
+        if (String.isBlank(relatedRecordId)) {
+            throw new AuraHandledException('A related record Id is required.');
+        }
+        if (String.isBlank(documentTitleFormat) && String.isNotBlank(tpls[0].Document_Title_Format__c)) {
+            documentTitleFormat = tpls[0].Document_Title_Format__c;
+        }
+
+        List<Object> rawInputs = (List<Object>) JSON.deserializeUntyped(signersJson);
+        List<Map<String, Object>> signerInputs = new List<Map<String, Object>>();
+        for (Object item : rawInputs) {
+            signerInputs.add((Map<String, Object>) item);
+        }
+        if (signerInputs.isEmpty()) {
+            throw new AuraHandledException('At least one signer is required.');
+        }
+
+        GuidedViewingDraft draft = renderGuidedViewing(templateId, relatedRecordId, signerInputs, tpls[0].Name);
+
+        // Standalone template-only viewing CV. Phase 2 swaps Source_Document_Id__c to the
+        // merged drawing+approval PDF; this stub keeps the request valid in the meantime.
+        ContentVersion viewCv = new ContentVersion();
+        viewCv.Title = draft.fileTitle;
+        viewCv.PathOnClient = draft.fileTitle + '.pdf';
+        viewCv.VersionData = draft.viewingBlob;
+        DocGenFlsGuard.assertCreateable(viewCv, new Set<String>{ 'Title', 'PathOnClient', 'VersionData' });
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        Database.insert(viewCv, AccessLevel.SYSTEM_MODE);
+
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c();
+        req.Template__c = templateId;
+        req.Related_Record_Id__c = relatedRecordId;
+        req.Source_Document_Id__c = viewCv.Id;
+        req.Status__c = 'Draft';
+        req.Signing_Order__c = String.isNotBlank(signingOrder) ? signingOrder : 'Parallel';
+        if (String.isNotBlank(documentTitleFormat)) {
+            req.Document_Title_Format__c = documentTitleFormat;
+        }
+        req.Secure_Token__c = generateRequestVerificationToken();
+        Set<String> reqFields = new Set<String>{
+            'Template__c',
+            'Related_Record_Id__c',
+            'Source_Document_Id__c',
+            'Status__c',
+            'Signing_Order__c',
+            'Document_Title_Format__c',
+            'Secure_Token__c'
+        };
+        if (String.isNotBlank(draft.frozenJson)) {
+            req.Frozen_Document_CV_Id__c = DocGenSignatureService.saveFrozenSnapshotCv(draft.frozenJson);
+            req.Snapshot_Hash__c = DocGenSignatureService.hashFrozenDocument(draft.frozenJson);
+            req.Snapshot_Taken_At__c = System.now();
+            reqFields.addAll(new Set<String>{ 'Frozen_Document_CV_Id__c', 'Snapshot_Hash__c', 'Snapshot_Taken_At__c' });
+        }
+        DocGenFlsGuard.assertCreateable(req, reqFields);
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        Database.insert(req, AccessLevel.SYSTEM_MODE);
+
+        // Signers WITHOUT notification — emails go out in phase 2 once the merged
+        // drawing+approval PDF is the signing source (sendEmails=false).
+        createSignersAndNotify(req.Id, null, draft.fileTitle, signerInputs, false, getSigningPdfPagePath());
+        createGuidedPlacementRecords(req.Id, draft.placements, draft.sentinels);
+
+        Map<String, String> result = new Map<String, String>();
+        result.put('requestId', req.Id);
+        result.put('viewingPdfBase64', EncodingUtil.base64Encode(draft.viewingBlob));
+        result.put('fileTitle', draft.fileTitle);
+        return result;
+    }
+
+    /**
+     * MERGED-APPROVAL (exp/document-markup, M1) — phase 2 of 2.
+     *
+     * Stores the client-merged PDF (pre-existing record PDF + the tagged approval page from
+     * phase 1) as the signing source, shares it with the guest, flips the request to
+     * 'Sent', and sends the signer invitations (deferred from phase 1). Signers and
+     * placements already exist from phase 1; their @@SIG-n@@ sentinels are position-
+     * independent, so they resolve against the approval page wherever it sits in the merge.
+     */
+    @AuraEnabled
+    public static List<SignerResult> attachMergedSourceAndSend(Id requestId, String mergedPdfBase64) {
+        if (requestId == null) {
+            throw new AuraHandledException('A request Id is required.');
+        }
+        if (String.isBlank(mergedPdfBase64)) {
+            throw new AuraHandledException('Merged PDF data is required.');
+        }
+        DocGenFlsGuard.assertAccessible(
+            DocGen_Signature_Request__c.sObjectType,
+            new Set<String>{ 'Status__c', 'Source_Document_Id__c', 'Template__c' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Signature_Request__c> reqs = [
+            SELECT Id, Status__c, Source_Document_Id__c, Template__r.Name
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :requestId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (reqs.isEmpty()) {
+            throw new AuraHandledException('Signature request not found.');
+        }
+        DocGen_Signature_Request__c req = reqs[0];
+        if (req.Status__c != 'Draft') {
+            throw new AuraHandledException('This request has already been sent.');
+        }
+
+        String fileTitle = (req.Template__r != null && String.isNotBlank(req.Template__r.Name))
+            ? req.Template__r.Name
+            : 'Approval Document';
+
+        ContentVersion mergedCv = new ContentVersion();
+        mergedCv.Title = fileTitle;
+        mergedCv.PathOnClient = fileTitle + '.pdf';
+        mergedCv.VersionData = EncodingUtil.base64Decode(mergedPdfBase64);
+        DocGenFlsGuard.assertCreateable(mergedCv, new Set<String>{ 'Title', 'PathOnClient', 'VersionData' });
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        Database.insert(mergedCv, AccessLevel.SYSTEM_MODE);
+
+        req.Source_Document_Id__c = mergedCv.Id;
+        req.Status__c = 'Sent';
+        DocGenFlsGuard.assertUpdateable(req, new Set<String>{ 'Source_Document_Id__c', 'Status__c' });
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        Database.update(req, AccessLevel.SYSTEM_MODE);
+
+        // Share the merged signing source with the guest so getSourcePdfBase64 can read it.
+        shareViewingDocumentWithGuest(mergedCv.Id, req.Id);
+
+        // Send the initial invitations now (guided PDF page URLs), respecting signing order.
+        List<SignerResult> results = sendGuidedInvitations(req.Id, fileTitle);
+        return results;
+    }
+
+    /**
+     * Builds guided-PDF-page invitations from a request's EXISTING signer tokens and sends
+     * them (respecting Sequential order). Used to send the deferred phase-1 invitations
+     * after the merged source is attached. Unlike resendSignatureRequest it does NOT rotate
+     * tokens and always targets the guided PDF page.
+     */
+    private static List<SignerResult> sendGuidedInvitations(Id requestId, String documentTitle) {
+        DocGenFlsGuard.assertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'Signing_Order__c' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        DocGen_Signature_Request__c reqCheck = [
+            SELECT Signing_Order__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :requestId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        Boolean isSequential = reqCheck.Signing_Order__c == 'Sequential';
+
+        DocGenFlsGuard.assertAccessible(
+            DocGen_Signer__c.sObjectType,
+            new Set<String>{
+                'Signer_Name__c',
+                'Signer_Email__c',
+                'Role_Name__c',
+                'Secure_Token__c',
+                'Contact__c',
+                'Sort_Order__c'
+            }
+        );
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Signer__c> signers = [
+            SELECT Id, Signer_Name__c, Signer_Email__c, Role_Name__c, Secure_Token__c, Contact__c
+            FROM DocGen_Signer__c
+            WHERE Signature_Request__c = :requestId
+            WITH SYSTEM_MODE
+            ORDER BY Sort_Order__c ASC
+        ];
+
+        String urlBase = getSiteBaseUrl() + getSigningPdfPagePath() + '?token=';
+        List<SignerResult> results = new List<SignerResult>();
+        List<DocGenSignatureEmailService.SignerEmail> emailList = new List<DocGenSignatureEmailService.SignerEmail>();
+        for (Integer i = 0; i < signers.size(); i++) {
+            DocGen_Signer__c s = signers[i];
+            SignerResult sr = new SignerResult();
+            sr.signerId = s.Id;
+            sr.signerName = s.Signer_Name__c;
+            sr.signerEmail = s.Signer_Email__c;
+            sr.roleName = s.Role_Name__c;
+            sr.signerUrl = urlBase + s.Secure_Token__c;
+            results.add(sr);
+
+            // Sequential: only invite the first signer now; later signers are invited as
+            // each prior one completes (existing completion flow).
+            if (isSequential && i > 0) {
+                continue;
+            }
+            emailList.add(
+                new DocGenSignatureEmailService.SignerEmail(
+                    s.Signer_Name__c,
+                    s.Signer_Email__c,
+                    s.Role_Name__c,
+                    sr.signerUrl,
+                    s.Contact__c
+                )
+            );
+        }
+        DocGenSignatureEmailService.sendSignatureRequestEmails(emailList, documentTitle, requestId);
         return results;
     }
 

--- a/force-app/main/default/lwc/docGenSignatureSender/docGenPdfMerger.js
+++ b/force-app/main/default/lwc/docGenSignatureSender/docGenPdfMerger.js
@@ -1,0 +1,428 @@
+/**
+ * Pure JavaScript PDF merger. No external dependencies.
+ * Combines multiple PDF documents into a single PDF.
+ *
+ * Public API:
+ *   mergePdfs(pdfBytesArray) → Uint8Array
+ *
+ * Takes an array of PDF files as Uint8Arrays (or ArrayBuffers),
+ * parses their object graphs, renumbers to avoid collisions,
+ * flattens the page trees, and writes a single merged PDF.
+ *
+ * Same philosophy as docGenZipWriter.js — raw binary manipulation,
+ * zero dependencies, runs entirely client-side to avoid Apex heap.
+ */
+
+// ---------------------------------------------------------------------------
+// Encoding helpers
+// ---------------------------------------------------------------------------
+
+/** latin1 gives 1:1 byte↔char mapping — byte offsets = string offsets */
+function latin1Decode(bytes) {
+    return new TextDecoder('latin1').decode(bytes);
+}
+
+function latin1Encode(str) {
+    const bytes = new Uint8Array(str.length);
+    for (let i = 0; i < str.length; i++) {
+        bytes[i] = str.charCodeAt(i) & 0xff;
+    }
+    return bytes;
+}
+
+function concat(arrays) {
+    let total = 0;
+    for (const a of arrays) total += a.length;
+    const result = new Uint8Array(total);
+    let off = 0;
+    for (const a of arrays) {
+        result.set(a, off);
+        off += a.length;
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Reference renumbering
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts a full dictionary (<< ... >>) from the string starting at or after pos.
+ * Handles nested << >> correctly so we don't stop at an inner >>.
+ */
+function extractDict(str, pos) {
+    const start = str.indexOf('<<', pos);
+    if (start === -1) return '';
+    let depth = 0;
+    let i = start;
+    while (i < str.length - 1) {
+        if (str[i] === '<' && str[i + 1] === '<') {
+            depth++;
+            i += 2;
+        } else if (str[i] === '>' && str[i + 1] === '>') {
+            depth--;
+            if (depth === 0) return str.substring(start, i + 2);
+            i += 2;
+        } else {
+            i++;
+        }
+    }
+    return str.substring(start); // unterminated — return what we have
+}
+
+/**
+ * Replaces all indirect references (N 0 R) in dictionary text.
+ * Only call on dictionary text, never on stream binary data.
+ */
+function renumberRefs(text, numMap) {
+    return text.replace(/\b(\d+)(\s+0\s+R)\b/g, (match, numStr, rest) => {
+        const num = parseInt(numStr, 10);
+        return numMap.has(num) ? numMap.get(num) + rest : match;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// PDF Parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses a PDF file into its object graph and page tree.
+ *
+ * Returns:
+ *   objects  — Map<number, {num, dictText, streamBytes}>
+ *   pageNums — ordered array of leaf page object numbers
+ *   rootNum  — catalog object number
+ */
+function parsePdf(bytes) {
+    if (!(bytes instanceof Uint8Array)) bytes = new Uint8Array(bytes);
+    const str = latin1Decode(bytes);
+
+    if (!str.startsWith('%PDF-')) {
+        throw new Error('Not a valid PDF file');
+    }
+
+    // --- Find all indirect objects: "N 0 obj" ... "endobj" ---
+    const objects = new Map();
+    const objRe = /\b(\d+)\s+0\s+obj\b/g;
+    let m;
+
+    while ((m = objRe.exec(str)) !== null) {
+        const num = parseInt(m[1], 10);
+        const headerEnd = m.index + m[0].length;
+        const endIdx = str.indexOf('endobj', headerEnd);
+        if (endIdx === -1) continue;
+
+        const body = str.substring(headerEnd, endIdx);
+        const si = body.indexOf('stream');
+        let dictText;
+        let streamBytes = null;
+
+        if (si !== -1 && body.indexOf('endstream') > si) {
+            // Object has a stream — split dict from binary data
+            dictText = body.substring(0, si);
+
+            // Stream data starts after "stream" + EOL
+            let dStart = headerEnd + si + 6; // 'stream'.length
+            if (bytes[dStart] === 0x0d) dStart++;
+            if (bytes[dStart] === 0x0a) dStart++;
+
+            // Use /Length (direct value) when available for precise extraction
+            const lenMatch = dictText.match(/\/Length\s+(\d+)(?!\s+\d+\s+R)/);
+            if (lenMatch) {
+                const len = parseInt(lenMatch[1], 10);
+                streamBytes = bytes.slice(dStart, dStart + len);
+            } else {
+                // Fallback: scan to endstream, trim trailing EOL
+                const esIdx = str.indexOf('endstream', dStart);
+                let dEnd = esIdx;
+                if (bytes[dEnd - 1] === 0x0a) dEnd--;
+                if (bytes[dEnd - 1] === 0x0d) dEnd--;
+                streamBytes = bytes.slice(dStart, dEnd);
+            }
+        } else {
+            dictText = body;
+        }
+
+        // Last occurrence wins (handles incremental updates)
+        objects.set(num, { num, dictText, streamBytes });
+    }
+
+    // --- Find root catalog ---
+    // Follow the spec: startxref → xref location → trailer/root
+    let rootNum = null;
+
+    // Primary: use startxref to find xref, then extract /Root
+    const startxrefIdx = str.lastIndexOf('startxref');
+    if (startxrefIdx !== -1) {
+        const xrefOffsetMatch = str.substring(startxrefIdx + 9).match(/\s*(\d+)/);
+        if (xrefOffsetMatch) {
+            const xrefOffset = parseInt(xrefOffsetMatch[1], 10);
+            const atOffset = str.substring(xrefOffset, xrefOffset + 10).trimStart();
+
+            if (atOffset.startsWith('xref')) {
+                // Traditional xref table — trailer dict follows
+                const trailerIdx = str.indexOf('trailer', xrefOffset);
+                if (trailerIdx !== -1) {
+                    // Extract full trailer dict (handle nested << >>)
+                    const trailerDict = extractDict(str, trailerIdx);
+                    if (trailerDict.includes('/Encrypt')) {
+                        throw new Error('Encrypted PDFs cannot be merged');
+                    }
+                    const rm = trailerDict.match(/\/Root\s+(\d+)\s+0\s+R/);
+                    if (rm) rootNum = parseInt(rm[1], 10);
+                }
+            } else {
+                // Cross-reference stream (PDF 1.5+) — the object dict IS the trailer
+                const objMatch = str.substring(xrefOffset).match(/(\d+)\s+0\s+obj/);
+                if (objMatch) {
+                    const dictStart = xrefOffset + objMatch.index + objMatch[0].length;
+                    const streamIdx = str.indexOf('stream', dictStart);
+                    const endIdx = str.indexOf('endobj', dictStart);
+                    const dictEnd = streamIdx !== -1 && streamIdx < endIdx ? streamIdx : endIdx;
+                    const dictText = str.substring(dictStart, dictEnd);
+                    if (dictText.includes('/Encrypt')) {
+                        throw new Error('Encrypted PDFs cannot be merged');
+                    }
+                    const rm = dictText.match(/\/Root\s+(\d+)\s+0\s+R/);
+                    if (rm) rootNum = parseInt(rm[1], 10);
+                }
+            }
+        }
+    }
+
+    // Fallback: scan for traditional trailer keyword anywhere
+    if (rootNum === null) {
+        const tidx = str.lastIndexOf('trailer');
+        if (tidx !== -1) {
+            const trailerDict = extractDict(str, tidx);
+            if (trailerDict.includes('/Encrypt')) {
+                throw new Error('Encrypted PDFs cannot be merged');
+            }
+            const rm = trailerDict.match(/\/Root\s+(\d+)\s+0\s+R/);
+            if (rm) rootNum = parseInt(rm[1], 10);
+        }
+    }
+
+    // Fallback: scan all objects for xref stream with /Root
+    if (rootNum === null) {
+        for (const [, obj] of objects) {
+            if (obj.dictText.includes('/Root')) {
+                const rm = obj.dictText.match(/\/Root\s+(\d+)\s+0\s+R/);
+                if (rm) {
+                    rootNum = parseInt(rm[1], 10);
+                    break;
+                }
+            }
+        }
+    }
+
+    if (rootNum === null) throw new Error('PDF root catalog not found');
+
+    // --- Resolve catalog → /Pages tree ---
+    const catalog = objects.get(rootNum);
+    if (!catalog) throw new Error('Catalog object ' + rootNum + ' missing');
+    const pm = catalog.dictText.match(/\/Pages\s+(\d+)\s+0\s+R/);
+    if (!pm) throw new Error('/Pages reference not found in catalog');
+
+    // Walk page tree — /Pages nodes have /Kids, /Page leaves do not
+    function walkPages(objNum, visited) {
+        if (visited.has(objNum)) return [];
+        visited.add(objNum);
+        const obj = objects.get(objNum);
+        if (!obj) return [];
+
+        const km = obj.dictText.match(/\/Kids\s*\[([\s\S]*?)\]/);
+        if (km) {
+            // Intermediate /Pages node — recurse into children
+            const refs = [...km[1].matchAll(/(\d+)\s+0\s+R/g)];
+            const pages = [];
+            for (const r of refs) pages.push(...walkPages(parseInt(r[1], 10), visited));
+            return pages;
+        }
+        // Leaf /Page object
+        return [objNum];
+    }
+
+    const pageNums = walkPages(parseInt(pm[1], 10), new Set());
+
+    return { objects, rootNum, pageNums };
+}
+
+// ---------------------------------------------------------------------------
+// Inheritable attribute resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Walks up the page tree to find /MediaBox.
+ * Must be called BEFORE renumbering (uses original /Parent refs).
+ */
+function resolveMediaBox(objects, pageNum) {
+    const visited = new Set();
+    let num = pageNum;
+    while (num != null && !visited.has(num)) {
+        visited.add(num);
+        const obj = objects.get(num);
+        if (!obj) break;
+        const mb = obj.dictText.match(/\/MediaBox\s*\[([^\]]+)\]/);
+        if (mb) return mb[0];
+        const pr = obj.dictText.match(/\/Parent\s+(\d+)\s+0\s+R/);
+        num = pr ? parseInt(pr[1], 10) : null;
+    }
+    return '/MediaBox [0 0 612 792]'; // US Letter fallback
+}
+
+// ---------------------------------------------------------------------------
+// PDF Writer
+// ---------------------------------------------------------------------------
+
+/** Serializes one indirect object to bytes. */
+function writeObject(num, dictText, streamBytes) {
+    const hdr = num + ' 0 obj';
+    if (streamBytes) {
+        // Ensure /Length matches actual stream size
+        let dict = dictText;
+        if (/\/Length\s+\d+(?!\s+\d+\s+R)/.test(dict)) {
+            dict = dict.replace(/\/Length\s+\d+(?!\s+\d+\s+R)/, '/Length ' + streamBytes.length);
+        }
+        const pre = latin1Encode(hdr + dict + 'stream\n');
+        const post = latin1Encode('\nendstream\nendobj\n');
+        return concat([pre, streamBytes, post]);
+    }
+    return latin1Encode(hdr + dictText + 'endobj\n');
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Merges multiple PDFs into a single document.
+ *
+ * @param {Array<Uint8Array|ArrayBuffer>} pdfBytesArray - PDFs to merge, in order
+ * @returns {Uint8Array} Merged PDF bytes
+ */
+export function mergePdfs(pdfBytesArray) {
+    if (!pdfBytesArray || pdfBytesArray.length === 0) {
+        throw new Error('No PDFs provided');
+    }
+    if (pdfBytesArray.length === 1) {
+        const b = pdfBytesArray[0];
+        return b instanceof Uint8Array ? b : new Uint8Array(b);
+    }
+
+    // 1. Parse all input PDFs
+    const parsed = pdfBytesArray.map((b) => parsePdf(b));
+
+    // 2. Resolve inherited /MediaBox BEFORE renumbering
+    //    Pages can inherit /MediaBox from ancestor /Pages nodes.
+    //    Since we flatten the tree, we must attach it explicitly.
+    for (const pdf of parsed) {
+        for (const pageNum of pdf.pageNums) {
+            const obj = pdf.objects.get(pageNum);
+            if (obj && !obj.dictText.includes('/MediaBox')) {
+                const mb = resolveMediaBox(pdf.objects, pageNum);
+                obj.dictText = obj.dictText.replace(/<</, '<< ' + mb);
+            }
+        }
+    }
+
+    // 3. Renumber objects across all PDFs (sequential, no gaps)
+    let nextNum = 1;
+    const allObjs = [];
+    const allPages = [];
+
+    for (const pdf of parsed) {
+        const numMap = new Map();
+        for (const oldNum of pdf.objects.keys()) {
+            numMap.set(oldNum, nextNum++);
+        }
+
+        for (const [oldNum, obj] of pdf.objects) {
+            const newNum = numMap.get(oldNum);
+            const isPage = pdf.pageNums.includes(oldNum);
+
+            allObjs.push({
+                newNum,
+                dictText: renumberRefs(obj.dictText, numMap),
+                streamBytes: obj.streamBytes,
+                isPage
+            });
+        }
+
+        // Collect pages in tree order (not object scan order)
+        for (const pageNum of pdf.pageNums) {
+            allPages.push(numMap.get(pageNum));
+        }
+    }
+
+    // 4. Allocate new structural objects
+    const newPagesNum = nextNum++;
+    const newCatalogNum = nextNum++;
+
+    // 5. Point all pages to the new /Pages parent
+    for (const obj of allObjs) {
+        if (obj.isPage) {
+            obj.dictText = obj.dictText.replace(/\/Parent\s+\d+\s+0\s+R/, '/Parent ' + newPagesNum + ' 0 R');
+        }
+    }
+
+    // 6. Write the merged PDF
+    const parts = [];
+    const offsets = new Map();
+    let off = 0;
+
+    // Header + binary comment (tells readers this isn't plain text)
+    const hdr = latin1Encode('%PDF-1.7\n%\xe2\xe3\xcf\xd3\n');
+    parts.push(hdr);
+    off += hdr.length;
+
+    // All objects from all input PDFs
+    for (const obj of allObjs) {
+        offsets.set(obj.newNum, off);
+        const b = writeObject(obj.newNum, obj.dictText, obj.streamBytes);
+        parts.push(b);
+        off += b.length;
+    }
+
+    // New /Pages — flat tree with all pages as direct children
+    const kids = allPages.map((n) => n + ' 0 R').join(' ');
+    offsets.set(newPagesNum, off);
+    const pagesBytes = latin1Encode(
+        newPagesNum + ' 0 obj\n<< /Type /Pages /Kids [' + kids + '] /Count ' + allPages.length + ' >>\nendobj\n'
+    );
+    parts.push(pagesBytes);
+    off += pagesBytes.length;
+
+    // New /Catalog
+    offsets.set(newCatalogNum, off);
+    const catBytes = latin1Encode(
+        newCatalogNum + ' 0 obj\n<< /Type /Catalog /Pages ' + newPagesNum + ' 0 R >>\nendobj\n'
+    );
+    parts.push(catBytes);
+    off += catBytes.length;
+
+    // Cross-reference table
+    const xrefStart = off;
+    let xref = 'xref\n0 ' + nextNum + '\n';
+    // Object 0: head of free list (always present)
+    xref += '0000000000 65535 f \n';
+    for (let i = 1; i < nextNum; i++) {
+        const o = offsets.get(i);
+        xref += String(o).padStart(10, '0') + ' 00000 n \n';
+    }
+
+    // Trailer
+    xref +=
+        'trailer\n<< /Size ' +
+        nextNum +
+        ' /Root ' +
+        newCatalogNum +
+        ' 0 R >>\n' +
+        'startxref\n' +
+        xrefStart +
+        '\n%%EOF\n';
+
+    parts.push(latin1Encode(xref));
+
+    return concat(parts);
+}

--- a/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.html
+++ b/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.html
@@ -89,6 +89,51 @@
                 </template>
             </div>
 
+            <!-- Approve an existing drawing (exp/document-markup, M1) -->
+            <template if:true={hasRecordPdfs}>
+                <div class="slds-box slds-var-m-bottom_medium" style="border-radius: 6px">
+                    <div class="slds-grid slds-grid_vertical-align-center slds-var-m-bottom_x-small">
+                        <lightning-icon
+                            icon-name="utility:file"
+                            size="x-small"
+                            class="slds-var-m-right_x-small"
+                        ></lightning-icon>
+                        <h3 class="slds-text-title_bold">Approve an Existing Drawing (optional)</h3>
+                    </div>
+                    <p class="slds-text-body_small slds-text-color_weak slds-var-m-bottom_x-small">
+                        Pick a PDF already on this record (e.g. an A3 technical drawing). It is combined with the single
+                        approval template selected above and sent as one document for the client to approve or reject.
+                    </p>
+                    <lightning-combobox
+                        name="selectDrawing"
+                        label="Drawing on this record"
+                        value={selectedDrawingCvId}
+                        placeholder="None — send the template only"
+                        options={recordPdfOptions}
+                        onchange={handleDrawingChange}
+                    ></lightning-combobox>
+                    <template if:true={isMergedApprovalMode}>
+                        <div class="slds-var-m-top_small">
+                            <lightning-radio-group
+                                name="drawingOrder"
+                                label="Document order"
+                                type="button"
+                                options={drawingOrderOptions}
+                                value={drawingOrderValue}
+                                onchange={handleDrawingOrderChange}
+                            ></lightning-radio-group>
+                            <lightning-button
+                                label="Clear drawing"
+                                variant="base"
+                                icon-name="utility:close"
+                                onclick={handleClearDrawing}
+                                class="slds-var-m-top_x-small"
+                            ></lightning-button>
+                        </div>
+                    </template>
+                </div>
+            </template>
+
             <!-- Detected Placements Summary -->
             <template if:true={hasDetectedPlacements}>
                 <div class="slds-box slds-theme_shade slds-var-m-bottom_medium" style="border-radius: 6px">

--- a/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.js
+++ b/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.js
@@ -9,6 +9,11 @@ import getPendingSignatureRequests from '@salesforce/apex/DocGenSignatureSenderC
 import getDocGenTemplates from '@salesforce/apex/DocGenSignatureSenderController.getDocGenTemplatesForRecord';
 import getTemplateSignaturePlacements from '@salesforce/apex/DocGenSignatureSenderController.getTemplateSignaturePlacements';
 import getDocumentPreviewPdfBase64 from '@salesforce/apex/DocGenSignatureSenderController.getDocumentPreviewPdfBase64';
+import prepareApprovalForMerge from '@salesforce/apex/DocGenSignatureSenderController.prepareApprovalForMerge';
+import attachMergedSourceAndSend from '@salesforce/apex/DocGenSignatureSenderController.attachMergedSourceAndSend';
+import getRecordPdfs from '@salesforce/apex/DocGenController.getRecordPdfs';
+import getContentVersionBase64 from '@salesforce/apex/DocGenController.getContentVersionBase64';
+import { mergePdfs } from './docGenPdfMerger';
 
 let signerIdCounter = 0;
 let templateIdCounter = 0;
@@ -51,6 +56,15 @@ export default class DocGenSignatureSender extends LightningElement {
     @track previousRequests = [];
     @track showPreviousRequests = false;
 
+    // --- Approve an existing drawing (exp/document-markup, M1) ---
+    // Optional: prepend a PDF already on the record (e.g. an A3 technical drawing) to the
+    // selected approval template, merge them client-side, and send the combined document
+    // for signing. The appended template carries the sign-spots; the drawing is the content
+    // being approved/rejected.
+    @track recordPdfOptions = [];
+    @track selectedDrawingCvId = '';
+    @track drawingFirst = true; // drawing pages first, approval/signature page last
+
     @wire(getSignerRolePicklistValues)
     wiredRoles({ error, data }) {
         if (data) {
@@ -88,11 +102,44 @@ export default class DocGenSignatureSender extends LightningElement {
         }
     }
 
+    connectedCallback() {
+        this._loadRecordPdfs();
+    }
+
     disconnectedCallback() {
         this._revokePreviewUrls();
     }
 
+    async _loadRecordPdfs() {
+        try {
+            const pdfs = await getRecordPdfs({ recordId: this.recordId });
+            this.recordPdfOptions = pdfs || [];
+        } catch (_err) {
+            this.recordPdfOptions = [];
+        }
+    }
+
     // --- Computed Properties ---
+
+    get hasRecordPdfs() {
+        return this.recordPdfOptions.length > 0;
+    }
+
+    // True once the sender has chosen an existing record PDF to send for approval.
+    get isMergedApprovalMode() {
+        return !!this.selectedDrawingCvId;
+    }
+
+    get drawingOrderOptions() {
+        return [
+            { label: 'Drawing first, signature page last', value: 'first' },
+            { label: 'Signature page first, drawing after', value: 'last' }
+        ];
+    }
+
+    get drawingOrderValue() {
+        return this.drawingFirst ? 'first' : 'last';
+    }
 
     get hasSelectedTemplates() {
         return this.selectedTemplates.length > 0;
@@ -104,6 +151,8 @@ export default class DocGenSignatureSender extends LightningElement {
 
     get isGenerateDisabled() {
         if (this.selectedTemplates.length === 0 || this.signers.length === 0) return true;
+        // Merged-approval supports a single approval template only (no packets).
+        if (this.isMergedApprovalMode && this.selectedTemplates.length !== 1) return true;
         return this.signers.some((s) => !s.signerName || !s.signerEmail || !s.roleName);
     }
 
@@ -178,7 +227,22 @@ export default class DocGenSignatureSender extends LightningElement {
     }
 
     get generateButtonLabel() {
+        if (this.isMergedApprovalMode) return 'Send Drawing for Approval';
         return this.isPacketMode ? 'Generate Packet Signature Links' : 'Generate Signature Links';
+    }
+
+    // --- Approve-an-existing-drawing handlers ---
+
+    handleDrawingChange(event) {
+        this.selectedDrawingCvId = event.detail.value || '';
+    }
+
+    handleDrawingOrderChange(event) {
+        this.drawingFirst = event.detail.value === 'first';
+    }
+
+    handleClearDrawing() {
+        this.selectedDrawingCvId = '';
     }
 
     get signingOrderOptions() {
@@ -544,7 +608,11 @@ export default class DocGenSignatureSender extends LightningElement {
             const signersJson = JSON.stringify(signersPayload);
 
             const titleFormat = (this.documentTitleFormat || '').trim() || null;
-            if (this.selectedTemplates.length === 1) {
+            if (this.isMergedApprovalMode) {
+                // Approve an existing drawing: merge the record PDF with the approval
+                // template client-side, then send the combined document for signing.
+                this.signerResults = await this._runMergedApproval(signersJson, titleFormat);
+            } else if (this.selectedTemplates.length === 1) {
                 const single = this.selectedTemplates[0];
                 // Consolidated signing (#170): single-template signing always uses the
                 // guided PDF path — draw/type on the real PDF, walk field-to-field, with a
@@ -582,6 +650,59 @@ export default class DocGenSignatureSender extends LightningElement {
         } finally {
             this.isLoading = false;
         }
+    }
+
+    /**
+     * Merged-approval flow (exp/document-markup, M1). Two server calls bracket a
+     * client-side PDF merge:
+     *   1. prepareApprovalForMerge → Draft request + the tagged approval-template PDF.
+     *   2. fetch the existing drawing PDF, merge [drawing, approval] (or reversed) with
+     *      docGenPdfMerger, then attachMergedSourceAndSend → stores the merged signing
+     *      source and sends invitations.
+     * Merge stays client-side (large A3 scans would blow the Apex heap — same reason
+     * docGenPdfMerger exists for the runner).
+     */
+    async _runMergedApproval(signersJson, titleFormat) {
+        const single = this.selectedTemplates[0];
+        const prep = await prepareApprovalForMerge({
+            templateId: single.templateId,
+            relatedRecordId: this.recordId,
+            signersJson,
+            signingOrder: this.signingOrder,
+            documentTitleFormat: titleFormat
+        });
+
+        const drawingBase64 = await getContentVersionBase64({ contentVersionId: this.selectedDrawingCvId });
+        const drawingBytes = this._base64ToBytes(drawingBase64);
+        const approvalBytes = this._base64ToBytes(prep.viewingPdfBase64);
+        const ordered = this.drawingFirst ? [drawingBytes, approvalBytes] : [approvalBytes, drawingBytes];
+
+        const mergedBytes = mergePdfs(ordered);
+        const mergedBase64 = this._bytesToBase64(mergedBytes);
+
+        return attachMergedSourceAndSend({
+            requestId: prep.requestId,
+            mergedPdfBase64: mergedBase64
+        });
+    }
+
+    _base64ToBytes(base64) {
+        const binary = atob(base64);
+        const len = binary.length;
+        const bytes = new Uint8Array(len);
+        for (let i = 0; i < len; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        return bytes;
+    }
+
+    _bytesToBase64(bytes) {
+        let binary = '';
+        const chunk = 0x8000;
+        for (let i = 0; i < bytes.length; i += chunk) {
+            binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+        }
+        return btoa(binary);
     }
 
     // --- Previous Requests ---

--- a/force-app/main/default/objects/DocGen_Settings__c/fields/Markup_Vector_Flatten__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Settings__c/fields/Markup_Vector_Flatten__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Markup_Vector_Flatten__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description
+    >When enabled, PDF markup is flattened using vector drawing instead of the default rasterized PNG overlay. Vector flattening is not yet implemented; the markup page falls back to raster regardless until it ships, so this switch is a no-op today.</description>
+    <externalId>false</externalId>
+    <inlineHelpText
+    >Switches markup flattening from raster (default) to vector once vector flattening is implemented. Leave off until vector support ships.</inlineHelpText>
+    <label>Markup Vector Flatten</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Template__c/fields/Allow_Markup__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Template__c/fields/Allow_Markup__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Allow_Markup__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description
+    >When enabled, signers using this template can draw, add text, shapes and highlights (markup) on the document during signing. The marked-up PDF is saved back to the related record.</description>
+    <inlineHelpText
+    >Let signers mark up the PDF (pen, text, shapes, highlighter) while signing. The marked-up document is saved to the related record on approve or reject.</inlineHelpText>
+    <label>Allow Markup</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/pages/DocGenSignaturePdf.page
+++ b/force-app/main/default/pages/DocGenSignaturePdf.page
@@ -425,6 +425,75 @@
                     inset: 0;
                 }
 
+                /* ===== MARKUP OVERLAY (M2) ===== */
+                /* One transparent canvas per page, stacked above the sign-spot chips (z5)
+                   only while marking; otherwise pointer-events are off so chips stay live. */
+                .dg-markup-canvas {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    width: 100%;
+                    height: 100%;
+                    z-index: 6;
+                    cursor: crosshair;
+                    touch-action: none;
+                }
+                .dg-markup-canvas.dg-markup-off {
+                    pointer-events: none;
+                    cursor: default;
+                }
+                .markup-toolbar {
+                    display: none;
+                    flex-wrap: wrap;
+                    align-items: center;
+                    gap: 6px;
+                    padding: 8px 12px;
+                    background: #1c2b3a;
+                    border-bottom: 1px solid #0d1722;
+                }
+                .markup-toolbar .mk-label {
+                    color: #9fb3c8;
+                    font-size: 12px;
+                    font-weight: 600;
+                    margin-right: 4px;
+                }
+                .markup-toolbar .mk-tool,
+                .markup-toolbar .mk-btn {
+                    background: #2b3f54;
+                    color: #e8eef5;
+                    border: 1px solid #3c5a76;
+                    border-radius: 4px;
+                    padding: 5px 10px;
+                    font-size: 12px;
+                    cursor: pointer;
+                }
+                .markup-toolbar .mk-tool.active {
+                    background: #2563eb;
+                    border-color: #2563eb;
+                }
+                .markup-toolbar .mk-btn.mk-done {
+                    background: #16a34a;
+                    border-color: #16a34a;
+                    margin-left: auto;
+                }
+                .markup-toolbar .mk-colors {
+                    display: inline-flex;
+                    gap: 4px;
+                    margin: 0 4px;
+                }
+                .markup-toolbar .mk-swatch {
+                    width: 18px;
+                    height: 18px;
+                    border-radius: 50%;
+                    border: 2px solid #fff;
+                    cursor: pointer;
+                    padding: 0;
+                }
+                .markup-toolbar .mk-swatch.active {
+                    outline: 2px solid #2563eb;
+                    outline-offset: 1px;
+                }
+
                 /* ===== SIGN-SPOT OVERLAY CHIPS ===== */
                 .spot-chip {
                     position: absolute;
@@ -699,6 +768,21 @@
                             <span id="pdf-role-badge" class="role-badge" style="display: none"></span>
                         </div>
 
+                        <!-- Markup toolbar (M2) — shown only while in Mark Up mode. -->
+                        <div id="markup-toolbar" class="markup-toolbar">
+                            <span class="mk-label">Markup:</span>
+                            <button type="button" class="mk-tool active" data-tool="pen">Pen</button>
+                            <button type="button" class="mk-tool" data-tool="text">Text</button>
+                            <button type="button" class="mk-tool" data-tool="rect">Box</button>
+                            <button type="button" class="mk-tool" data-tool="arrow">Arrow</button>
+                            <button type="button" class="mk-tool" data-tool="line">Line</button>
+                            <button type="button" class="mk-tool" data-tool="highlight">Highlight</button>
+                            <span id="markup-colors" class="mk-colors"></span>
+                            <button type="button" id="mk-undo" class="mk-btn">Undo</button>
+                            <button type="button" id="mk-clear" class="mk-btn">Clear</button>
+                            <button type="button" id="mk-done" class="mk-btn mk-done">Done</button>
+                        </div>
+
                         <!-- DocGenPdfViewer.render() renders into this container. -->
                         <div class="pdf-viewer" id="pdf-viewer-container">
                             <div class="spinner-container"><div class="spinner"></div></div>
@@ -709,6 +793,7 @@
                                 Signing as: <strong id="pdf-signer-name"></strong>
                                 <span id="pdf-progress-info" style="display: none"></span>
                             </div>
+                            <button id="btn-markup" class="btn" type="button" style="display: none">Mark Up</button>
                             <button id="btn-decline" class="btn btn-destructive" type="button">Decline</button>
                             <button id="btn-open-sign" class="btn btn-brand btn-lg" type="button">Sign Document</button>
                         </div>
@@ -758,6 +843,11 @@
                                 placeholder="Let the sender know why you're declining..."
                             ></textarea>
                         </div>
+                        <div
+                            id="decline-status"
+                            class="slds-text-color_weak"
+                            style="display: none; margin-bottom: 12px"
+                        ></div>
                         <div class="btn-row">
                             <button id="btn-decline-cancel" class="btn" type="button">Go Back</button>
                             <button id="btn-decline-confirm" class="btn btn-destructive" type="button">
@@ -1105,6 +1195,27 @@
                             return ready;
                         },
 
+                        // Markup (M2): lightweight geometry per rendered page so the markup
+                        // overlay can attach a transparent canvas and convert its pixels to
+                        // PDF points at flatten time. Same scale + Y-flip basis as hitToPdfRect.
+                        getPages: function () {
+                            var out = [];
+                            for (var i = 0; i < pages.length; i++) {
+                                var vp = pages[i].viewport;
+                                out.push({
+                                    pageIndex: i,
+                                    pageNum: pages[i].pageNum,
+                                    wrapEl: pages[i].wrapEl,
+                                    cssW: vp.width,
+                                    cssH: vp.height,
+                                    scale: vp.scale,
+                                    widthPts: vp.width / vp.scale,
+                                    heightPts: vp.height / vp.scale
+                                });
+                            }
+                            return out;
+                        },
+
                         // Find EVERY occurrence of each needle across all pages, tolerating
                         // a match split across text runs. Occurrences are returned in
                         // document order so callers can map duplicate needles to records.
@@ -1305,6 +1416,10 @@
                         function (result, event) {
                             if (event.status && result && result.isValid) {
                                 signerData = result;
+                                markupAllowed = !!result.allowMarkup;
+                                // Org-setting seam (Chunk D): vector flatten is still a stub in
+                                // flattenMarkupInto, so this safely no-ops to raster today.
+                                markupFlattenMode = result.markupVectorFlatten ? 'vector' : 'raster';
                                 if (result.requiresPin) {
                                     initVerifyScreen(result);
                                 } else {
@@ -1460,6 +1575,7 @@
 
                         // Wire the action bar.
                         document.getElementById('btn-open-sign').addEventListener('click', openSignModal);
+                        document.getElementById('btn-markup').addEventListener('click', enterMarkup);
                         document.getElementById('btn-decline').addEventListener('click', function () {
                             showState('decline');
                         });
@@ -1492,6 +1608,7 @@
                                     DocGenPdfViewer.render(result.base64, containerEl)
                                         .then(function () {
                                             initGuidedOverlay();
+                                            initMarkupLayer();
                                         })
                                         .catch(function () {
                                             /* render error already shown by the viewer */
@@ -2016,6 +2133,377 @@
                         );
                     }
 
+                    // ===== MARKUP LAYER (M2) =====
+                    // A transparent canvas over each rendered page captures freehand ink,
+                    // text notes, boxes, arrows/lines, and highlights as STRUCTURED marks
+                    // (device px relative to the page canvas). Marks are re-rendered for
+                    // display and, at finalize, flattened into the PDF (raster v1; the
+                    // structured model leaves room for a vector flatten later). Pointer
+                    // events are off unless Mark Up mode is active, so sign-spot chips stay
+                    // live the rest of the time.
+                    var MarkupLayer = (function () {
+                        var layers = []; // [{ pageIndex, canvas, ctx, marks: [] }]
+                        var active = false;
+                        var tool = 'pen';
+                        var color = '#e11d48';
+                        var PALETTE = ['#e11d48', '#2563eb', '#16a34a', '#f59e0b', '#111827'];
+                        var drawing = false;
+                        var cur = null;
+                        var curLayer = null;
+                        var seq = 0;
+
+                        function evtPos(e, canvas) {
+                            var r = canvas.getBoundingClientRect();
+                            var src = e.touches && e.touches.length ? e.touches[0] : e;
+                            return {
+                                x: (src.clientX - r.left) * (canvas.width / r.width),
+                                y: (src.clientY - r.top) * (canvas.height / r.height)
+                            };
+                        }
+
+                        function widthFor(t) {
+                            return t === 'highlight' ? 14 : t === 'pen' ? 2.5 : 2;
+                        }
+
+                        function arrowHead(ctx, x0, y0, x1, y1) {
+                            var a = Math.atan2(y1 - y0, x1 - x0);
+                            var len = 12;
+                            ctx.beginPath();
+                            ctx.moveTo(x1, y1);
+                            ctx.lineTo(x1 - len * Math.cos(a - Math.PI / 6), y1 - len * Math.sin(a - Math.PI / 6));
+                            ctx.lineTo(x1 - len * Math.cos(a + Math.PI / 6), y1 - len * Math.sin(a + Math.PI / 6));
+                            ctx.closePath();
+                            ctx.fill();
+                        }
+
+                        function drawMark(ctx, m) {
+                            ctx.save();
+                            ctx.lineCap = 'round';
+                            ctx.lineJoin = 'round';
+                            ctx.strokeStyle = m.color;
+                            ctx.fillStyle = m.color;
+                            ctx.lineWidth = m.width;
+                            ctx.globalAlpha = m.opacity != null ? m.opacity : 1;
+                            if (m.type === 'pen' || m.type === 'highlight') {
+                                if (m.points.length) {
+                                    ctx.beginPath();
+                                    ctx.moveTo(m.points[0].x, m.points[0].y);
+                                    for (var i = 1; i < m.points.length; i++) ctx.lineTo(m.points[i].x, m.points[i].y);
+                                    ctx.stroke();
+                                }
+                            } else if (m.type === 'rect') {
+                                ctx.strokeRect(m.x0, m.y0, m.x1 - m.x0, m.y1 - m.y0);
+                            } else if (m.type === 'line' || m.type === 'arrow') {
+                                ctx.beginPath();
+                                ctx.moveTo(m.x0, m.y0);
+                                ctx.lineTo(m.x1, m.y1);
+                                ctx.stroke();
+                                if (m.type === 'arrow') arrowHead(ctx, m.x0, m.y0, m.x1, m.y1);
+                            } else if (m.type === 'text') {
+                                ctx.globalAlpha = 1;
+                                ctx.font = m.fontSize + 'px Helvetica, Arial, sans-serif';
+                                ctx.textBaseline = 'top';
+                                ctx.fillText(m.text, m.x0, m.y0);
+                            }
+                            ctx.restore();
+                        }
+
+                        function repaint(layer) {
+                            layer.ctx.clearRect(0, 0, layer.canvas.width, layer.canvas.height);
+                            for (var i = 0; i < layer.marks.length; i++) drawMark(layer.ctx, layer.marks[i]);
+                            if (cur && curLayer === layer) drawMark(layer.ctx, cur);
+                        }
+
+                        function onDown(e, layer) {
+                            if (!active) return;
+                            if (e.cancelable) e.preventDefault();
+                            var p = evtPos(e, layer.canvas);
+                            if (tool === 'text') {
+                                var txt = window.prompt('Note text:');
+                                if (txt) {
+                                    layer.marks.push({
+                                        type: 'text',
+                                        text: txt,
+                                        x0: p.x,
+                                        y0: p.y,
+                                        color: color,
+                                        fontSize: 16,
+                                        width: 1,
+                                        opacity: 1,
+                                        seq: ++seq
+                                    });
+                                    repaint(layer);
+                                }
+                                return;
+                            }
+                            drawing = true;
+                            curLayer = layer;
+                            if (tool === 'pen' || tool === 'highlight') {
+                                cur = {
+                                    type: tool,
+                                    points: [p],
+                                    color: color,
+                                    width: widthFor(tool),
+                                    opacity: tool === 'highlight' ? 0.35 : 1
+                                };
+                            } else {
+                                cur = {
+                                    type: tool,
+                                    x0: p.x,
+                                    y0: p.y,
+                                    x1: p.x,
+                                    y1: p.y,
+                                    color: color,
+                                    width: widthFor(tool),
+                                    opacity: 1
+                                };
+                            }
+                        }
+
+                        function onMove(e, layer) {
+                            if (!active || !drawing || curLayer !== layer) return;
+                            if (e.cancelable) e.preventDefault();
+                            var p = evtPos(e, layer.canvas);
+                            if (cur.type === 'pen' || cur.type === 'highlight') cur.points.push(p);
+                            else {
+                                cur.x1 = p.x;
+                                cur.y1 = p.y;
+                            }
+                            repaint(layer);
+                        }
+
+                        function onUp() {
+                            if (!drawing) return;
+                            drawing = false;
+                            if (cur && curLayer) {
+                                var keep = true;
+                                if ((cur.type === 'pen' || cur.type === 'highlight') && cur.points.length < 2)
+                                    keep = false;
+                                if (
+                                    (cur.type === 'rect' || cur.type === 'line' || cur.type === 'arrow') &&
+                                    Math.abs(cur.x1 - cur.x0) < 3 &&
+                                    Math.abs(cur.y1 - cur.y0) < 3
+                                )
+                                    keep = false;
+                                if (keep) {
+                                    cur.seq = ++seq;
+                                    curLayer.marks.push(cur);
+                                }
+                                repaint(curLayer);
+                            }
+                            cur = null;
+                            curLayer = null;
+                        }
+
+                        return {
+                            init: function (viewerPages) {
+                                layers = [];
+                                for (var i = 0; i < viewerPages.length; i++) {
+                                    (function (vp) {
+                                        var c = document.createElement('canvas');
+                                        c.className = 'dg-markup-canvas dg-markup-off';
+                                        c.width = vp.cssW;
+                                        c.height = vp.cssH;
+                                        vp.wrapEl.appendChild(c);
+                                        var layer = {
+                                            pageIndex: vp.pageIndex,
+                                            canvas: c,
+                                            ctx: c.getContext('2d'),
+                                            marks: []
+                                        };
+                                        c.addEventListener('mousedown', function (e) {
+                                            onDown(e, layer);
+                                        });
+                                        c.addEventListener('mousemove', function (e) {
+                                            onMove(e, layer);
+                                        });
+                                        c.addEventListener('touchstart', function (e) {
+                                            onDown(e, layer);
+                                        });
+                                        c.addEventListener('touchmove', function (e) {
+                                            onMove(e, layer);
+                                        });
+                                        c.addEventListener('touchend', onUp);
+                                        layers.push(layer);
+                                    })(viewerPages[i]);
+                                }
+                                window.addEventListener('mouseup', onUp);
+                            },
+                            setActive: function (on) {
+                                active = !!on;
+                                for (var i = 0; i < layers.length; i++) {
+                                    layers[i].canvas.classList.toggle('dg-markup-off', !active);
+                                }
+                            },
+                            setTool: function (t) {
+                                tool = t;
+                            },
+                            setColor: function (c) {
+                                color = c;
+                            },
+                            palette: function () {
+                                return PALETTE;
+                            },
+                            undo: function () {
+                                var best = null,
+                                    bestLayer = null;
+                                for (var i = 0; i < layers.length; i++) {
+                                    var ms = layers[i].marks;
+                                    if (ms.length && (!best || ms[ms.length - 1].seq > best.seq)) {
+                                        best = ms[ms.length - 1];
+                                        bestLayer = layers[i];
+                                    }
+                                }
+                                if (bestLayer) {
+                                    bestLayer.marks.pop();
+                                    repaint(bestLayer);
+                                }
+                            },
+                            clear: function () {
+                                for (var i = 0; i < layers.length; i++) {
+                                    layers[i].marks = [];
+                                    repaint(layers[i]);
+                                }
+                            },
+                            hasMarks: function () {
+                                for (var i = 0; i < layers.length; i++) if (layers[i].marks.length) return true;
+                                return false;
+                            },
+                            // Raster flatten source: transparent PNG of one page's marks, or
+                            // null if that page has none. (M2-2 consumes this.)
+                            pageImage: function (pageIndex) {
+                                for (var i = 0; i < layers.length; i++) {
+                                    if (layers[i].pageIndex === pageIndex && layers[i].marks.length) {
+                                        return layers[i].canvas.toDataURL('image/png');
+                                    }
+                                }
+                                return null;
+                            }
+                        };
+                    })();
+
+                    var markupMode = false;
+                    var markupAllowed = false; // set from validateToken (template Allow_Markup__c)
+                    // Flatten strategy for the markup overlay at composite/finalize time.
+                    // 'raster' (v1): rasterize each page's marks to a transparent full-page
+                    // PNG and draw it onto the matching pdf-lib page. 'vector' (future):
+                    // re-emit the captured strokes as native pdf-lib vector ops; not yet
+                    // implemented (see flattenMarkupInto + TODO(vector)). Chunk D flips this
+                    // from a DocGen_Settings__c-backed flag on the validateToken response.
+                    var markupFlattenMode = 'raster';
+
+                    function setMarkupTool(t, btn) {
+                        MarkupLayer.setTool(t);
+                        var tb = document.getElementById('markup-toolbar');
+                        if (tb) {
+                            var bs = tb.querySelectorAll('.mk-tool');
+                            for (var i = 0; i < bs.length; i++) bs[i].classList.remove('active');
+                        }
+                        if (btn) btn.classList.add('active');
+                    }
+
+                    function enterMarkup() {
+                        markupMode = true;
+                        MarkupLayer.setActive(true);
+                        document.getElementById('markup-toolbar').style.display = 'flex';
+                        var mb = document.getElementById('btn-markup');
+                        if (mb) mb.style.display = 'none';
+                    }
+
+                    function exitMarkup() {
+                        markupMode = false;
+                        MarkupLayer.setActive(false);
+                        document.getElementById('markup-toolbar').style.display = 'none';
+                        var mb = document.getElementById('btn-markup');
+                        if (mb && markupAllowed) mb.style.display = '';
+                    }
+
+                    function wireMarkupToolbar() {
+                        var tb = document.getElementById('markup-toolbar');
+                        if (!tb || tb.getAttribute('data-wired')) return;
+                        tb.setAttribute('data-wired', '1');
+                        var tools = tb.querySelectorAll('[data-tool]');
+                        for (var i = 0; i < tools.length; i++) {
+                            (function (b) {
+                                b.addEventListener('click', function () {
+                                    setMarkupTool(b.getAttribute('data-tool'), b);
+                                });
+                            })(tools[i]);
+                        }
+                        var sw = document.getElementById('markup-colors');
+                        var pal = MarkupLayer.palette();
+                        for (var c = 0; c < pal.length; c++) {
+                            (function (col, first) {
+                                var s = document.createElement('button');
+                                s.type = 'button';
+                                s.className = 'mk-swatch' + (first ? ' active' : '');
+                                s.style.background = col;
+                                s.addEventListener('click', function () {
+                                    MarkupLayer.setColor(col);
+                                    var all = sw.querySelectorAll('.mk-swatch');
+                                    for (var k = 0; k < all.length; k++) all[k].classList.remove('active');
+                                    s.classList.add('active');
+                                });
+                                sw.appendChild(s);
+                            })(pal[c], c === 0);
+                        }
+                        document.getElementById('mk-undo').addEventListener('click', function () {
+                            MarkupLayer.undo();
+                        });
+                        document.getElementById('mk-clear').addEventListener('click', function () {
+                            if (window.confirm('Clear all markup?')) MarkupLayer.clear();
+                        });
+                        document.getElementById('mk-done').addEventListener('click', exitMarkup);
+                    }
+
+                    // Called after the viewer paints. No-op unless the template allows markup.
+                    function initMarkupLayer() {
+                        if (!markupAllowed) return;
+                        MarkupLayer.init(DocGenPdfViewer.getPages());
+                        wireMarkupToolbar();
+                        var mb = document.getElementById('btn-markup');
+                        if (mb) mb.style.display = '';
+                    }
+
+                    // ===== Markup flatten (M2) — shared seam for approve + reject paths =====
+                    // Burn the on-screen markup overlay into the pdf-lib document so the saved
+                    // PDF carries the reviewer's marks. Returns a Promise that resolves once
+                    // every marked page has been drawn. Callers MUST chain this BEFORE drawing
+                    // signature stamps so the marks sit underneath the signatures.
+                    //   doc          : PDFLib.PDFDocument (source already loaded)
+                    //   pdfLibPages  : doc.getPages() — index-aligned with DocGenPdfViewer pages
+                    function flattenMarkupInto(doc, pdfLibPages) {
+                        // 'vector' is a planned alternative that would re-emit captured strokes
+                        // as native pdf-lib path ops (crisper, smaller, selectable). Not built
+                        // yet — warn and fall through to raster so the document is never lost.
+                        // TODO(vector): implement vector stroke re-emission and remove this
+                        // fall-through; gate is markupFlattenMode === 'vector'.
+                        if (markupFlattenMode === 'vector') {
+                            console.warn('vector markup flatten not implemented; using raster');
+                        }
+                        // Raster: one transparent, full-page PNG per marked page, drawn full-bleed
+                        // at the page's PDF-point size so it overlays the source content exactly.
+                        var viewerPages = DocGenPdfViewer.getPages();
+                        var chain = Promise.resolve();
+                        viewerPages.forEach(function (entry) {
+                            chain = chain.then(function () {
+                                var pngData = MarkupLayer.pageImage(entry.pageIndex);
+                                if (!pngData) return; // no marks on this page
+                                var target = pdfLibPages[entry.pageIndex];
+                                if (!target) return; // viewer/pdf-lib page count mismatch guard
+                                return doc.embedPng(dataUrlToBytes(pngData)).then(function (png) {
+                                    target.drawImage(png, {
+                                        x: 0,
+                                        y: 0,
+                                        width: entry.widthPts,
+                                        height: entry.heightPts
+                                    });
+                                });
+                            });
+                        });
+                        return chain;
+                    }
+
                     // Composite ALL captured fields (drawn images + typed text + dates) onto
                     // the source PDF with pdf-lib, add signature attribution captions, and —
                     // when this signer completes the request — a Certificate of Completion
@@ -2218,7 +2706,14 @@
                                             });
                                             return cardW;
                                         }
-                                        var chain = Promise.resolve();
+                                        // Markup (M2): burn the reviewer's overlay into the
+                                        // document FIRST so signature stamps draw on top of it.
+                                        // No-markup path is untouched — chain stays a bare
+                                        // resolved promise exactly as before.
+                                        var chain =
+                                            markupAllowed && MarkupLayer.hasMarks()
+                                                ? flattenMarkupInto(doc, pages)
+                                                : Promise.resolve();
                                         guided.spots.forEach(function (spot) {
                                             chain = chain.then(function () {
                                                 var rect = DocGenPdfViewer.hitToPdfRect(spot.hit);
@@ -3105,34 +3600,118 @@
                     }
 
                     // ===== DECLINE =====
+                    // Small non-fatal status line inside the decline card (used to surface a
+                    // markup-save warning without blocking the decline itself).
+                    function setDeclineStatus(msg) {
+                        var el = document.getElementById('decline-status');
+                        if (!el) return;
+                        if (!msg) {
+                            el.style.display = 'none';
+                            el.textContent = '';
+                            return;
+                        }
+                        el.textContent = msg;
+                        el.style.display = '';
+                    }
+
+                    // If the reviewer drew markup before declining, flatten + save the marked-up
+                    // PDF to the record FIRST (mirrors the approve path's pdf-lib flatten), then
+                    // record the decline. Returns a Promise that ALWAYS resolves — a markup-save
+                    // failure must never block the decline (see saveMarkupBeforeDecline comment).
+                    function saveMarkupBeforeDecline(ua) {
+                        if (!(markupAllowed && MarkupLayer.hasMarks() && sourcePdfBase64)) {
+                            return Promise.resolve(); // no marks / not allowed → byte-identical to old path
+                        }
+                        if (typeof PDFLib === 'undefined') {
+                            console.warn('Markup save skipped before decline: PDFLib not loaded');
+                            return Promise.resolve();
+                        }
+                        // Load the served source PDF into pdf-lib, flatten the overlay onto it, and
+                        // save the marked-up document via saveMarkupDocument. Same pattern as
+                        // compositeAndFinalize (b64ToBytes -> PDFLib.PDFDocument.load -> flatten ->
+                        // doc.save() -> bytesToB64).
+                        return PDFLib.PDFDocument.load(b64ToBytes(sourcePdfBase64))
+                            .then(function (doc) {
+                                return flattenMarkupInto(doc, doc.getPages()).then(function () {
+                                    return doc.save();
+                                });
+                            })
+                            .then(function (outBytes) {
+                                var b64 = bytesToB64(outBytes);
+                                // $RemoteAction callbacks are NOT promises, so wrap the invoke so we
+                                // can sequence it before declineSignature.
+                                return new Promise(function (resolve) {
+                                    Visualforce.remoting.Manager.invokeAction(
+                                        '{!$RemoteAction.DocGenSignatureController.saveMarkupDocument}',
+                                        token,
+                                        b64,
+                                        capturedIp,
+                                        ua,
+                                        function (result, event) {
+                                            if (!event.status || !result || result.success === false) {
+                                                // Non-fatal: warn but resolve so the decline still
+                                                // proceeds. The reject must never be blocked by a
+                                                // markup-save failure.
+                                                var m = (result && result.message) || event.message || 'Unknown error';
+                                                console.warn('Markup save before decline failed: ' + m);
+                                                setDeclineStatus(
+                                                    'Your markup could not be saved, but your decline will still be recorded.'
+                                                );
+                                            }
+                                            resolve();
+                                        },
+                                        { escape: false, buffer: false, timeout: 120000 }
+                                    );
+                                });
+                            })
+                            .catch(function (e) {
+                                // Same non-fatal stance for client-side flatten/load errors: warn
+                                // and resolve so the decline below is never blocked.
+                                console.warn('Markup flatten before decline failed: ' + (e && e.message));
+                                setDeclineStatus(
+                                    'Your markup could not be saved, but your decline will still be recorded.'
+                                );
+                                return Promise.resolve();
+                            });
+                    }
+
                     function handleDecline() {
                         var reason = document.getElementById('decline-reason').value.trim();
                         var btn = document.getElementById('btn-decline-confirm');
                         btn.disabled = true;
                         btn.textContent = 'Declining...';
+                        setDeclineStatus('');
 
                         var ua = navigator.userAgent || 'Unknown';
-                        Visualforce.remoting.Manager.invokeAction(
-                            '{!$RemoteAction.DocGenSignatureController.declineSignature}',
-                            token,
-                            reason,
-                            capturedIp,
-                            ua,
-                            function (result, event) {
-                                btn.disabled = false;
-                                btn.textContent = 'Confirm Decline';
-                                if (event.status && result && result.success) {
-                                    document.getElementById('error-message').textContent =
-                                        'You have declined this signature request.';
-                                    document.querySelector('.error-card h2').textContent = 'Request Declined';
-                                    document.querySelector('.error-icon').textContent = '✖';
-                                    showState('error');
-                                } else {
-                                    alert(result ? result.message : 'Failed to decline. Please try again.');
-                                }
-                            },
-                            { escape: false }
-                        );
+
+                        // The existing decline RemoteAction — unchanged from before, just hoisted
+                        // into an inner fn so it can run AFTER the optional markup save completes.
+                        function doDecline() {
+                            Visualforce.remoting.Manager.invokeAction(
+                                '{!$RemoteAction.DocGenSignatureController.declineSignature}',
+                                token,
+                                reason,
+                                capturedIp,
+                                ua,
+                                function (result, event) {
+                                    btn.disabled = false;
+                                    btn.textContent = 'Confirm Decline';
+                                    if (event.status && result && result.success) {
+                                        document.getElementById('error-message').textContent =
+                                            'You have declined this signature request.';
+                                        document.querySelector('.error-card h2').textContent = 'Request Declined';
+                                        document.querySelector('.error-icon').textContent = '✖';
+                                        showState('error');
+                                    } else {
+                                        alert(result ? result.message : 'Failed to decline. Please try again.');
+                                    }
+                                },
+                                { escape: false }
+                            );
+                        }
+
+                        // Sequence: markup save (best-effort, always resolves) → decline.
+                        saveMarkupBeforeDecline(ua).then(doDecline);
                     }
                 })();
             </script>

--- a/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
@@ -229,6 +229,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>DocGen_Settings__c.Markup_Vector_Flatten__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>DocGen_Settings__c.Signature_Email_Brand_Color__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -376,6 +381,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>DocGen_Template__c.Footer_Html__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Template__c.Allow_Markup__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
@@ -39,6 +39,11 @@
     <description
     >Grants Site Guest User permission to execute the DocGen Signature Visualforce page and related Apex controllers.</description>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Settings__c.Markup_Vector_Flatten__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>DocGen_Signature_Audit__c.Contact__c</field>
         <readable>true</readable>
@@ -247,6 +252,11 @@
     <!-- Signer form-field config: validateToken/captureFormFieldData read
          Template__r.Form_Fields_Config__c under SYSTEM_MODE + guestAssertAccessible.
          Read-only for guest (editable=false). -->
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Template__c.Allow_Markup__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
         <field>DocGen_Template__c.Form_Fields_Config__c</field>

--- a/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
@@ -221,6 +221,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>DocGen_Settings__c.Markup_Vector_Flatten__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>DocGen_Settings__c.Signature_Email_Brand_Color__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -368,6 +373,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>DocGen_Template__c.Footer_Html__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Template__c.Allow_Markup__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>


### PR DESCRIPTION
> ⚠️ **Experimental / RFC — not proposed for merge as-is.** Branch `exp/document-markup`. Opening this to share the use case and get an early look at the approach + code. Dave — feel free to push directly onto the branch.

## The use case
We send clients a **pre-existing PDF** (an A3 technical drawing, often multi-page) for **approve / reject**, and we want the client to be able to **mark up the drawing** (redline it) and have the marked-up PDF land back on the originating record for our design team.

## What's here — two milestones

**M1 — approve/reject a pre-existing record PDF.** From a record you pick an existing PDF (the drawing) **plus** an approval template; DocGen merges them **client-side** (`docGenPdfMerger.mergePdfs`) into one signing document and routes it through the **existing guided PDF path**. The appended approval template carries the `{@Signature_*}` sign-spots, so this stays inside the mainline "the document has tags" model — it deliberately does **not** revive the bare-flat-PDF signing that was removed in v3.18. Merge is client-side because large A3 scans would blow the Apex heap (same reason `docGenPdfMerger` exists for the runner).

**M2 — markup.** While signing, the signer can draw on the PDF — **pen, text notes, boxes, arrows/lines, highlighter** — and on **approve or reject** the markup is flattened into the PDF and saved back to the record (approve rides the existing composite + writeback; reject saves via a new `saveMarkupDocument` then declines).

## ⚠️ Known incomplete / experimental — please read
- **Markup flattens as a RASTER layer only.** A **vector flatten path is NOT built yet** — only the org-level switch/seam exists (`DocGen_Settings__c.Markup_Vector_Flatten__c` + a JS stub that warns and falls back to raster). Vector is the intended fidelity + file-size upgrade; both the **selection/UX and the implementation are still TODO**.
- **Raster size ceiling:** the client composite runs in a synchronous RemoteAction (~6 MB heap), so very dense markup on a large multi-page A3 can hit the size cap (`saveMarkupDocument` rejects oversized payloads cleanly). Fine for typical drawings; the vector path is the real fix.
- Marks are undo/clear only — no editing/moving a mark after placement. Desktop-first.
- Verified on a `--no-namespace` scratch org only; **not** validated in a namespaced/subscriber build. Site/guest enablement is org-UI config and is not in this diff.
- `docs/markup-m2-agent-plan.md` documents the design and exactly what's intentionally deferred.

## Per-template / per-org controls
- `DocGen_Template__c.Allow_Markup__c` — opt markup in **per template** (enforced server-side, not just a UI hint).
- `DocGen_Settings__c.Markup_Vector_Flatten__c` — the (currently stubbed) raster↔vector switch.

## Security
New guest endpoint `saveMarkupDocument` mirrors `saveCompositedSignedPdf`: 64-hex token, **server-resolved** related-record id (IDOR-safe — never from the client), expiry + terminal-state + **PIN-verification** gates, **server-side `Allow_Markup__c` enforcement**, a size cap, and per-field FLS guards. An adversarial review was run; 2 High + 1 Medium were found and remediated before this PR.

## Tests / gates (no-namespace scratch)
- `DocGenSignaturePdfTests` **40/40** (8 new markup cases incl. IDOR / PIN-not-verified / markup-not-enabled / declined).
- `RunLocalTests` **1663 / 100% / 77%** org-wide coverage.
- prettier clean.

## Demo
_(video of the markup → approve → saved-back-to-record flow to be added)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
