### PR TITLE
v3.47.0 — PowerPoint table loops, GUID preservation, split-run merge tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## v3.47.0 — PowerPoint table loops, GUID preservation, split-run merge tags
+
+Three PowerPoint-only defects, all found while diagnosing a single "the table is not
+expanding" report on an Opportunity Products deck. All three predate any recent
+release — they went unnoticed because PowerPoint templates have no installed base yet.
+No Word, HTML, Excel, or PDF behavior changes.
+
+### Fixed
+
+- **`{#Loop}` now clones a slide table row.** The container auto-expansion in
+  `processXml` had candidates for Word `<w:tr>`, numbered `<w:p>`, HTML `<tr>`/`<li>`,
+  and Excel `<row>` — but none for PowerPoint's DrawingML `<a:tr>`. A loop spanning
+  cells fell through to repeating the raw span between the tags, which includes the
+  intervening `</a:tc><a:tc>` markup: N records produced **one** row holding 4N
+  `<a:tc>` against 4 `<a:gridCol>`, so PowerPoint rendered only the first record.
+  Adds an `<a:tr>` candidate mirroring the Excel `<row>` block (same sibling guard),
+  plus `stripDrawingMlRowIds` so cloned rows don't repeat the authored `<a16:rowId>`
+  change-tracking extension. That extension is optional — unlike Excel's `r` indices,
+  which are core spec and need `renumberExcelRows()`.
+- **OOXML GUIDs are no longer eaten as merge tags.** `<a:ext uri="{0D108BD9-…}">`,
+  `<a:tableStyleId>{5C22544A-…}</a:tableStyleId>`, and `<a16:creationId id="{…}">`
+  are brace-delimited and textually indistinguishable from a merge tag, so they
+  resolved to empty. Every generated PPTX shipped with blanked `uri=""` on its column
+  ids, row ids, and creation ids, and an authored custom table style was silently
+  swapped for the hardcoded default by `normalizePowerPointSlideXml`'s
+  empty-`tableStyleId` repair. `isOoxmlGuidToken` now emits canonical 8-4-4-4-12 hex
+  tokens verbatim. Measured on a real template: 46 GUID uris preserved, 0 blanked.
+- **Merge tags split across runs now de-fragment for PowerPoint.**
+  `mergeRunsInTagsCore` already matched both `<w:t>` and `<a:t>`, but its call site
+  was gated to `templateType == 'Word'`. PowerPoint takes that branch on every render
+  — `tryMergeFromPreDecomposed`, which does call it, is gated to Word→PDF. PowerPoint
+  splits a run at any character-formatting boundary (a spell-check squiggle alone
+  yields `err="1"` on the middle run), so `{UnitPrice:currency}` authored as three
+  `<a:r>` elements reached `processXml` as an unresolvable tag spanning markup and
+  rendered blank. Excel stays excluded by design: its text lives in `<t>`, which
+  `mergeRunsInTagsCore` does not match.
+
+### Docs
+
+- **UserGuide §4 — do not use select-all when assigning `DocGen_User`.** The permission
+  set carries read-only View All on DocGen Template (v3.29+). Chatter Free, Identity,
+  and Community licenses cannot hold View All Records on a custom object, so a
+  blanket assignment blocks the org's **next package upgrade** — Salesforce
+  re-validates every existing assignment against its user license when the permission
+  set changes. Documents the exact install error, a diagnostic SOQL query, and the
+  remediation. Same caveat noted for `DocGen_Admin`, which carries View All on more
+  objects.
+
+### Validation
+
+Real customer template rendered end-to-end against an Opportunity with 3 line items —
+4 rows, 16 cells, correct values, valid `.pptx` that opens and renders in LibreOffice.
+9 new tests. RunLocalTests 1786 / 100% / 78% org-wide, e2e-07-syntax1..4 PASS FAIL 0,
+`sf code-analyzer` 0 violations, prettier clean.
+
 ## v3.46.0 — AI template authoring (Agentforce) + Flying Saucer validator
 
 Requires a short one-time setup (`docs/AGENTFORCE_SETUP.md`). **Without it nothing

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -187,6 +187,23 @@ Three permission sets ship with the package. Assign what each user needs.
 3. Click **Manage Assignments → Add Assignments**
 4. Check the box next to each user → **Next** → **Assign**
 
+> **Assign deliberately — do not use the select-all checkbox.** `DocGen_User` includes read-only _View All_ on DocGen Template (v3.29+, see §5.4). Some Salesforce user licenses — **Chatter Free**, **Identity**, and **Customer/Partner Community** among them — do not permit View All Records on a custom object. Assigning `DocGen_User` to those users is not just unnecessary (they cannot generate documents anyway); it will **block your next package upgrade**, because Salesforce re-validates every existing assignment against its user license when the permission set changes. The install fails with:
+>
+> ```
+> PermissionSet(DocGen_User) The user license doesn't allow the
+> permission: View All portwoodglobal__DocGen_Template__c
+> ```
+>
+> This most often bites orgs that ran "select all" on the assignment screen during first-time setup, then upgraded from a pre-v3.29 version. To find offending assignments before you upgrade:
+>
+> ```sql
+> SELECT Assignee.Name, Assignee.Profile.UserLicense.Name
+> FROM PermissionSetAssignment
+> WHERE PermissionSet.Name = 'DocGen_User'
+> ```
+>
+> Remove `DocGen_User` from any user whose license is not a full Salesforce license, then upgrade. The same applies to `DocGen_Admin`, which carries View All on more objects — keep it on genuine administrators only.
+
 ### Assigning DocGen_Guest_Signature to a Site guest user
 
 Salesforce hides guest users behind several clicks. Full path:

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -10352,4 +10352,254 @@ private class DocGenMiscTests {
             'Footer keeps its authored position: ' + result
         );
     }
+
+    /**
+     * Builds a DrawingML slide table with a header row and one loop row whose
+     * {#Lines}…{/Lines} span crosses cell boundaries — the shape Portwood's
+     * Opportunity Products slide uses.
+     */
+    private static String pptTableXml(String loopRowCells) {
+        return '<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" ' +
+            'xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">' +
+            '<p:cSld><p:spTree><p:graphicFrame><a:graphic>' +
+            '<a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table"><a:tbl>' +
+            '<a:tblGrid><a:gridCol w="2032000"/><a:gridCol w="2032000"/></a:tblGrid>' +
+            '<a:tr h="370840">' +
+            '<a:tc><a:txBody><a:p><a:r><a:t>Product</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>' +
+            '<a:tc><a:txBody><a:p><a:r><a:t>Qty</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>' +
+            '<a:extLst><a:ext uri="{0D108BD9-81ED-4DB2-BD59-A6C34878D82A}">' +
+            '<a16:rowId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" val="1496546544"/>' +
+            '</a:ext></a:extLst>' +
+            '</a:tr>' +
+            '<a:tr h="370840">' +
+            loopRowCells +
+            '<a:extLst><a:ext uri="{0D108BD9-81ED-4DB2-BD59-A6C34878D82A}">' +
+            '<a16:rowId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" val="2064594304"/>' +
+            '</a:ext></a:extLst>' +
+            '</a:tr>' +
+            '</a:tbl></a:graphicData></a:graphic></p:graphicFrame></p:spTree></p:cSld></p:sld>';
+    }
+
+    private static Map<String, Object> pptLoopData(List<Map<String, Object>> lines) {
+        return new Map<String, Object>{
+            'Name' => 'Acme Corp',
+            'Lines' => new Map<String, Object>{ 'records' => lines, 'totalSize' => lines.size() }
+        };
+    }
+
+    @IsTest
+    static void testPowerPointTableRowLoopClonesRow() {
+        // A child loop spanning cells in one DrawingML row ({#Lines}{Name} in cell 1,
+        // {Quantity}{/Lines} in cell 2) must clone the whole <a:tr> per record.
+        // Before the <a:tr> container candidate existed, the fallback repeated the raw
+        // span between the tags — including the intervening </a:tc><a:tc> markup — so
+        // N records produced ONE row holding 2N <a:tc> against 2 <a:gridCol>, and
+        // PowerPoint rendered only the first record.
+        String xml = pptTableXml(
+            '<a:tc><a:txBody><a:p><a:r><a:t>{#Lines}{Name}</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>' +
+            '<a:tc><a:txBody><a:p><a:r><a:t>{Quantity}{/Lines}</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>'
+        );
+        Map<String, Object> data = pptLoopData(
+            new List<Map<String, Object>>{
+                new Map<String, Object>{ 'Name' => 'Widget', 'Quantity' => '2' },
+                new Map<String, Object>{ 'Name' => 'Gadget', 'Quantity' => '5' },
+                new Map<String, Object>{ 'Name' => 'Gizmo', 'Quantity' => '9' }
+            }
+        );
+
+        String result = DocGenService.processXmlForTest(xml, data, 'PowerPoint');
+
+        System.assertEquals(4, result.countMatches('<a:tr '), 'Header row + one row per line item: ' + result);
+        System.assertEquals(
+            8,
+            result.countMatches('<a:tc>'),
+            'Two cells per row — cells must not accumulate inside one row: ' + result
+        );
+        System.assert(result.contains('<a:t>Widget</a:t>'), 'First record rendered: ' + result);
+        System.assert(result.contains('<a:t>Gizmo</a:t>'), 'Last record rendered: ' + result);
+        System.assert(!result.contains('{#') && !result.contains('{/'), 'No leaked loop tags: ' + result);
+    }
+
+    @IsTest
+    static void testPowerPointTableRowLoopStripsDuplicateRowIds() {
+        // Cloned rows must not repeat the authored <a16:rowId> change-tracking id.
+        String xml = pptTableXml(
+            '<a:tc><a:txBody><a:p><a:r><a:t>{#Lines}{Name}</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>' +
+            '<a:tc><a:txBody><a:p><a:r><a:t>{Quantity}{/Lines}</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>'
+        );
+        Map<String, Object> data = pptLoopData(
+            new List<Map<String, Object>>{
+                new Map<String, Object>{ 'Name' => 'Widget', 'Quantity' => '2' },
+                new Map<String, Object>{ 'Name' => 'Gadget', 'Quantity' => '5' }
+            }
+        );
+
+        String result = DocGenService.processXmlForTest(xml, data, 'PowerPoint');
+
+        System.assertEquals(
+            0,
+            result.countMatches('val="2064594304"'),
+            'Loop row rowId dropped from every clone: ' + result
+        );
+        System.assertEquals(
+            1,
+            result.countMatches('val="1496546544"'),
+            'Untouched header row keeps its authored rowId: ' + result
+        );
+    }
+
+    @IsTest
+    static void testPowerPointTableRowLoopEmptyListDropsRow() {
+        String xml = pptTableXml(
+            '<a:tc><a:txBody><a:p><a:r><a:t>{#Lines}{Name}</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>' +
+            '<a:tc><a:txBody><a:p><a:r><a:t>{Quantity}{/Lines}</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>'
+        );
+        Map<String, Object> data = pptLoopData(new List<Map<String, Object>>());
+
+        String result = DocGenService.processXmlForTest(xml, data, 'PowerPoint');
+
+        System.assertEquals(1, result.countMatches('<a:tr '), 'Only the header row survives: ' + result);
+        System.assert(result.contains('<a:t>Product</a:t>'), 'Header row preserved: ' + result);
+        System.assert(!result.contains('{#') && !result.contains('{/'), 'No leaked loop tags: ' + result);
+    }
+
+    @IsTest
+    static void testPowerPointTableRowLoopSiblingGuard() {
+        // Two sibling sections in one row: neither may grab the whole <a:tr>, or the
+        // first would swallow the second's content (the <w:tr> sibling-guard lesson).
+        String xml = pptTableXml(
+            '<a:tc><a:txBody><a:p><a:r><a:t>{#Lines}{Name}{/Lines}</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>' +
+            '<a:tc><a:txBody><a:p><a:r><a:t>{#Lines}{Quantity}{/Lines}</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>'
+        );
+        Map<String, Object> data = pptLoopData(
+            new List<Map<String, Object>>{
+                new Map<String, Object>{ 'Name' => 'Widget', 'Quantity' => '2' },
+                new Map<String, Object>{ 'Name' => 'Gadget', 'Quantity' => '5' }
+            }
+        );
+
+        String result = DocGenService.processXmlForTest(xml, data, 'PowerPoint');
+
+        System.assertEquals(2, result.countMatches('<a:tr '), 'No row cloning when siblings share the row: ' + result);
+        System.assert(result.contains('WidgetGadget'), 'First section repeated in place: ' + result);
+        System.assert(result.contains('25'), 'Second section survived and repeated in place: ' + result);
+    }
+
+    @IsTest
+    static void testPowerPointLoopOutsideTableRepeatsBody() {
+        // Loops in a plain text shape have no row container — the body-repeat
+        // fallback must still work (and must not be disturbed by the <a:tr> candidate).
+        String xml =
+            '<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" ' +
+            'xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">' +
+            '<p:sp><p:txBody><a:p><a:r><a:t>{#Lines}{Name} </a:t></a:r></a:p>' +
+            '<a:p><a:r><a:t>{Quantity}{/Lines}</a:t></a:r></a:p></p:txBody></p:sp></p:sld>';
+        Map<String, Object> data = pptLoopData(
+            new List<Map<String, Object>>{
+                new Map<String, Object>{ 'Name' => 'Widget', 'Quantity' => '2' },
+                new Map<String, Object>{ 'Name' => 'Gadget', 'Quantity' => '5' }
+            }
+        );
+
+        String result = DocGenService.processXmlForTest(xml, data, 'PowerPoint');
+
+        System.assert(result.contains('Widget'), 'First record rendered: ' + result);
+        System.assert(result.contains('Gadget'), 'Second record rendered: ' + result);
+        System.assert(!result.contains('{#') && !result.contains('{/'), 'No leaked loop tags: ' + result);
+    }
+
+    @IsTest
+    static void testPowerPointRowIdStripLeavesUnrelatedExtLstAlone() {
+        // An extLst without a rowId (e.g. a cell-level extension) must survive.
+        String rowXml =
+            '<a:tr><a:tc><a:extLst><a:ext uri="{ABC}"><a16:other val="1"/></a:ext></a:extLst></a:tc>' +
+            '<a:extLst><a:ext uri="{DEF}"><a16:rowId val="99"/></a:ext></a:extLst></a:tr>';
+
+        String result = DocGenService.stripDrawingMlRowIds(rowXml);
+
+        System.assert(!result.contains('a16:rowId'), 'rowId extension removed: ' + result);
+        System.assert(result.contains('a16:other'), 'Unrelated extLst preserved: ' + result);
+    }
+
+    @IsTest
+    static void testOoxmlGuidTokensSurviveMerge() {
+        // OOXML GUIDs are brace-delimited and were being consumed as merge tags,
+        // blanking <a:ext uri="">, column/row ids, and creation ids on every render.
+        String xml =
+            '<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">' +
+            '<a:ext uri="{0D108BD9-81ED-4DB2-BD59-A6C34878D82A}"/>' +
+            '<a:tableStyleId>{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}</a:tableStyleId>' +
+            '<a16:colId val="332169544"/><a:t>{Name}</a:t></p:sld>';
+        Map<String, Object> data = new Map<String, Object>{ 'Name' => 'Acme Corp' };
+
+        String result = DocGenService.processXmlForTest(xml, data, 'PowerPoint');
+
+        System.assert(
+            result.contains('uri="{0D108BD9-81ED-4DB2-BD59-A6C34878D82A}"'),
+            'Extension uri GUID preserved verbatim: ' + result
+        );
+        System.assert(
+            result.contains('<a:tableStyleId>{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}</a:tableStyleId>'),
+            'Authored table style GUID preserved — not swapped for the default: ' + result
+        );
+        System.assertEquals(0, result.countMatches('uri=""'), 'No blanked uri attributes: ' + result);
+        System.assert(result.contains('<a:t>Acme Corp</a:t>'), 'Real merge tags still resolve: ' + result);
+    }
+
+    @IsTest
+    static void testGuidGuardDoesNotShadowRealTags() {
+        // The guard is shape-based; it must not swallow anything a template
+        // legitimately uses, including hyphenated or GUID-length field values.
+        System.assert(
+            DocGenService.isOoxmlGuidToken('0D108BD9-81ED-4DB2-BD59-A6C34878D82A'),
+            'Canonical GUID recognised'
+        );
+        System.assert(
+            DocGenService.isOoxmlGuidToken('5c22544a-7ee6-4342-b048-85bdc9fd1c3a'),
+            'Lowercase GUID recognised'
+        );
+        System.assert(!DocGenService.isOoxmlGuidToken('Name'), 'Plain field is not a GUID');
+        System.assert(!DocGenService.isOoxmlGuidToken('Account.Owner.Email'), 'Relationship path is not a GUID');
+        System.assert(!DocGenService.isOoxmlGuidToken('#Contacts'), 'Section opener is not a GUID');
+        System.assert(!DocGenService.isOoxmlGuidToken('CloseDate:MM/dd/yyyy'), 'Format suffix is not a GUID');
+        System.assert(
+            !DocGenService.isOoxmlGuidToken('0D108BD9-81ED-4DB2-BD59-A6C34878D82AZ'),
+            'Over-length token rejected'
+        );
+        System.assert(
+            !DocGenService.isOoxmlGuidToken('ZZZZZZZZ-81ED-4DB2-BD59-A6C34878D82A'),
+            'Non-hex token rejected'
+        );
+        System.assert(!DocGenService.isOoxmlGuidToken(null), 'Null rejected');
+
+        // End-to-end: a 36-char non-GUID tag must still resolve normally.
+        String result = DocGenService.processXmlForTest(
+            '<a:t>{Name}</a:t>',
+            new Map<String, Object>{ 'Name' => 'Acme' },
+            'PowerPoint'
+        );
+        System.assert(result.contains('Acme'), 'Ordinary tag unaffected: ' + result);
+    }
+
+    @IsTest
+    static void testPowerPointSplitRunTagDefragments() {
+        // PowerPoint splits a run at any character-formatting boundary — a spell-check
+        // squiggle alone puts err="1" on the middle run — so {UnitPrice:currency} is
+        // commonly authored as three <a:r> elements. Without run-defragmentation the
+        // tag reaches processXml spanning markup and renders blank.
+        String xml =
+            '<a:p><a:r><a:rPr lang="en-US" dirty="0"/><a:t>{</a:t></a:r>' +
+            '<a:r><a:rPr lang="en-US" dirty="0" err="1"/><a:t>UnitPrice:currency</a:t></a:r>' +
+            '<a:r><a:rPr lang="en-US" dirty="0"/><a:t>}</a:t></a:r></a:p>';
+
+        String merged = DocGenService.mergeRunsInTagsForTest(xml);
+        System.assert(merged.contains('{UnitPrice:currency}'), 'Split tag rejoined into one run: ' + merged);
+
+        String result = DocGenService.processXmlForTest(
+            merged,
+            new Map<String, Object>{ 'UnitPrice' => 100 },
+            'PowerPoint'
+        );
+        System.assert(result.contains('$100.00'), 'Rejoined tag resolves with its format suffix: ' + result);
+    }
 }

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -751,7 +751,17 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                     continue;
                 }
 
-                if (templateType == 'Word') {
+                // De-fragment merge tags split across runs. mergeRunsInTagsCore already
+                // matches both <w:t> and <a:t>, but this gate was Word-only, so PowerPoint
+                // never got the pass: PowerPoint splits a run on any character-formatting
+                // boundary (a spell-check squiggle alone yields err="1" on the middle run),
+                // so {UnitPrice:currency} authored as {|UnitPrice:currency|} across three
+                // <a:r> elements reached processXml as an unresolvable tag spanning markup
+                // and rendered blank. PowerPoint takes this branch for every render —
+                // tryMergeFromPreDecomposed (which does call mergeRunsInTags) is gated to
+                // Word→PDF. Excel is excluded by design: its text lives in <t>, which
+                // mergeRunsInTagsCore does not match, and shared strings are inlined later.
+                if (templateType == 'Word' || templateType == 'PowerPoint') {
                     xml = mergeRunsInTags(xml);
                 }
                 xml = processXml(xml, recordDataMap);
@@ -3702,6 +3712,21 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             // so error enrichment can report the tag's location (issue #115).
             Integer tagStartPos = nextTag;
 
+            // OOXML writes GUIDs in brace syntax that is textually indistinguishable
+            // from a merge tag: <a:ext uri="{0D108BD9-…}">, <a:tableStyleId>{5C22544A-…}
+            // </a:tableStyleId>, <a16:creationId id="{…}">, <w15:docId val="{…}"/>.
+            // Resolving them as tags emitted '' and silently corrupted the markup —
+            // every generated PPTX shipped with blanked <a:ext uri=""> on its column
+            // ids, row ids, and creation ids, and an authored custom table style was
+            // swapped for the hardcoded default by normalizePowerPointSlideXml's
+            // empty-tableStyleId repair. Emit verbatim: no Salesforce field name or
+            // supported tag syntax has this shape, so nothing legitimate is shadowed.
+            if (isOoxmlGuidToken(tagContent)) {
+                output += xml.substring(cursor, tagClose + 1);
+                cursor = tagClose + 1;
+                continue;
+            }
+
             try {
                 // {@Signature_*} signing tags. During a signature send/finalize
                 // (preserveSignatureTags) keep them verbatim so the signature service
@@ -3959,10 +3984,56 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                             }
                         }
 
+                        // PowerPoint DrawingML <a:tr> container: mirror the DOCX <w:tr>
+                        // auto-expand for slide tables so a loop spanning cells in one row
+                        // ({#OpportunityLineItems}{Name} in cell 1, {TotalPrice}{/…} in cell 4)
+                        // clones the whole row per record. Gated on PowerPoint — <a:tr> only
+                        // exists in DrawingML tables. Without this the fallback repeats the raw
+                        // span between the tags, which includes the intervening </a:tc><a:tc>
+                        // markup: N records produce one row with 4N <a:tc> against 4
+                        // <a:gridCol>, so PowerPoint shows only the first record.
+                        if (currentTemplateType == 'PowerPoint' && !skipContainerExpand) {
+                            Integer pptRowStart = lastIndexOfTagStart(xml, 'a:tr', cursor);
+                            if (pptRowStart != -1) {
+                                Integer pptRowEnd = xml.indexOf('</a:tr>', pptRowStart);
+                                Boolean pptRowClosedBeforeCursor = xml.substring(pptRowStart, cursor)
+                                    .contains('</a:tr>');
+                                if (!pptRowClosedBeforeCursor && pptRowEnd != -1 && pptRowEnd > closeTagEnd) {
+                                    Integer pptRowFullEnd = pptRowEnd + 7; // </a:tr>
+                                    // Same sibling guard as <w:tr>: only expand when this section
+                                    // is the row's sole tagged region.
+                                    String pptBefore = xml.substring(pptRowStart, cursor);
+                                    String pptAfter = xml.substring(closeTagEnd + 1, pptRowFullEnd);
+                                    Boolean pptHasSibling =
+                                        pptBefore.contains('{#') ||
+                                        pptBefore.contains('{^') ||
+                                        pptBefore.contains('{/') ||
+                                        pptAfter.contains('{#') ||
+                                        pptAfter.contains('{^') ||
+                                        pptAfter.contains('{/');
+                                    if (!pptHasSibling) {
+                                        if (chosenContainerStart == -1 || pptRowStart > chosenContainerStart) {
+                                            chosenContainerStart = pptRowStart;
+                                            chosenContainerEnd = pptRowFullEnd;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
                         if (chosenContainerStart != -1 && chosenContainerEnd != -1) {
                             contentStart = chosenContainerStart;
                             contentEnd = chosenContainerEnd;
                             innerXml = xml.substring(contentStart, contentEnd);
+
+                            // Cloned DrawingML rows would repeat the row's <a16:rowId>
+                            // change-tracking extension. It is an optional Microsoft
+                            // extension (unlike Excel's r indices, which are core spec and
+                            // need renumberExcelRows()), so dropping it from every clone is
+                            // both sufficient and safe.
+                            if (currentTemplateType == 'PowerPoint') {
+                                innerXml = stripDrawingMlRowIds(innerXml);
+                            }
 
                             String startTagFull = '{' + rawTag + '}';
                             innerXml = innerXml.replace(startTagFull, '');
@@ -4961,6 +5032,56 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         }
 
         return false;
+    }
+
+    /**
+     * True when a brace token is an OOXML GUID rather than a merge tag —
+     * canonical 8-4-4-4-12 hex with hyphens, e.g. {0D108BD9-81ED-4DB2-BD59-A6C34878D82A}.
+     * Salesforce field names, relationship paths, and every supported tag prefix
+     * ({#, {/, {^, {%, {@, {:) are excluded by shape, so this never shadows a real tag.
+     */
+    @TestVisible
+    private static Boolean isOoxmlGuidToken(String tagContent) {
+        if (String.isBlank(tagContent) || tagContent.length() != 36) {
+            return false;
+        }
+        return Pattern.matches(
+            '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}',
+            tagContent
+        );
+    }
+
+    /**
+     * Removes every <a:extLst> block that carries an <a16:rowId> change-tracking
+     * extension. Used when a {#Loop} clones a DrawingML table row: the authored
+     * row's rowId would otherwise be duplicated across every clone. The extension
+     * is optional (Microsoft drawing/2014), so dropping it is safe — unlike Excel's
+     * <row r="…"> indices, which are core spec and must be renumbered instead.
+     *
+     * Scans for the enclosing extLst rather than regex-matching so a cell-level
+     * extLst without a rowId is left untouched.
+     */
+    @TestVisible
+    private static String stripDrawingMlRowIds(String rowXml) {
+        if (String.isBlank(rowXml) || !rowXml.contains('a16:rowId')) {
+            return rowXml;
+        }
+        String result = rowXml;
+        while (true) {
+            Integer rowIdAt = result.indexOf('a16:rowId');
+            if (rowIdAt == -1) {
+                break;
+            }
+            Integer blockStart = result.lastIndexOf('<a:extLst>', rowIdAt);
+            Integer blockEnd = result.indexOf('</a:extLst>', rowIdAt);
+            if (blockStart == -1 || blockEnd == -1) {
+                // Malformed or unexpected shape — leave the markup alone rather
+                // than risk cutting valid XML out of the row.
+                break;
+            }
+            result = result.substring(0, blockStart) + result.substring(blockEnd + 11); // </a:extLst>
+        }
+        return result;
     }
 
     private static Integer lastIndexOfTagStart(String xml, String tagName, Integer fromIndex) {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,15 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.46.0 — AI template authoring (Agentforce) + Flying Saucer validator",
-      "versionNumber": "3.46.0.NEXT",
+      "versionName": "v3.47.0 — PowerPoint table loops, GUID preservation, split-run merge tags",
+      "versionNumber": "3.47.0.NEXT",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "postInstallScript": "DocGenEmailTemplateInstall",
       "package": "Portwood DocGen Managed",
-      "versionDescription": "Portwood DocGen generates polished PDFs, Word documents, and Excel workbooks from any Salesforce record, with built-in e-signatures. v3.46 lets you build a template by describing it. Tell DocGen what you want — \"a one-page invoice with a branded header, a line-item table and a totals row\" — and it writes the template for you, right inside Salesforce. Already have a template? Ask for a change in plain English and it revises what is on the canvas instead of starting over. Everything it produces is checked against the PDF engine first, and you are told exactly what was adjusted and why, so a template never looks right on screen and wrong in the finished document. Requires Einstein/Prompt Builder in your org plus a short one-time setup; without it, everything else works exactly as before. 100% native Salesforce — no external services or callouts. Free for all users.",
-      "ancestorVersion": "3.45.0"
+      "ancestorVersion": "3.46.0"
     },
     {
       "versionName": "v1.0.0 — Agentforce template authoring",


### PR DESCRIPTION
Three PowerPoint-only defects, all surfaced while diagnosing a single "the table is not expanding" report on an Opportunity Products deck. All three predate any recent release — they went unnoticed because PowerPoint templates have no installed base yet.

**No Word, HTML, Excel, or PDF behavior changes.**

## Fixes

**1. `{#Loop}` never cloned a slide table row.** Container auto-expansion in `processXml` had candidates for Word `<w:tr>`, numbered `<w:p>`, HTML `<tr>`/`<li>`, and Excel `<row>` — but none for PowerPoint's `<a:tr>`. A loop spanning cells fell through to repeating the raw span between the tags, which includes the intervening `</a:tc><a:tc>` markup: N records produced **one** row holding 4N `<a:tc>` against 4 `<a:gridCol>`, so PowerPoint rendered only the first record. Adds an `<a:tr>` candidate mirroring the Excel `<row>` block (same sibling guard), plus `stripDrawingMlRowIds` so clones don't repeat the authored `<a16:rowId>`.

**2. OOXML GUIDs were consumed as merge tags.** `<a:ext uri="{0D108BD9-…}">` and friends are brace-delimited and indistinguishable from a merge tag, so they resolved to empty — every generated PPTX shipped with blanked `uri=""` on column ids, row ids, and creation ids, and an authored custom table style was silently swapped for the hardcoded default. `isOoxmlGuidToken` now emits canonical GUIDs verbatim. Measured on the real template: 46 preserved, 0 blanked.

**3. Split-run merge tags never de-fragmented for PowerPoint.** `mergeRunsInTagsCore` already matches `<a:t>`, but its call site was gated to `templateType == 'Word'` — and PowerPoint takes that branch on every render, since `tryMergeFromPreDecomposed` is gated to Word→PDF. PowerPoint splits a run at any formatting boundary (a spell-check squiggle yields `err="1"` on the middle run), so `{UnitPrice:currency}` in three `<a:r>` elements reached `processXml` as an unresolvable tag spanning markup and rendered blank. This is backlog #130.

## Docs

UserGuide §4 — warns against select-all when assigning `DocGen_User`. The permset carries View All on DocGen Template (v3.29+); Chatter Free / Identity / Community licenses can't hold that, so a blanket assignment blocks the org's **next upgrade**. Includes the exact install error, a diagnostic query, and remediation.

## Validation

- Real customer template rendered end-to-end against an Opportunity with 3 line items — 4 rows, 16 cells, correct values, valid `.pptx` confirmed opening and rendering in LibreOffice
- 9 new tests
- RunLocalTests **1786 / 100% / 78%** org-wide
- e2e-07-syntax1..4 **PASS, FAIL 0**
- `sf code-analyzer` **0 violations**
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)