### PR TITLE
v3.48.0 — Bulk generation: conditionals, charts, sorting, Designer access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,200 @@
 # Changelog
 
+## v3.48.0 — Bulk generation: conditionals, charts, sorting, permissions
+
+A bulk-generation release. Most of what follows is silent-wrong-output — bulk jobs that
+reported success while producing documents that were subtly or completely wrong.
+
+### Fixed — bulk merge-tag resolution
+
+The bulk retriever `getRecordDataV3Bulk` is a hand-written twin of `getRecordDataV3`.
+Four things it did differently, none of which raised an error:
+
+- **Aliased loops resolved to nothing.** The bulk node parser never read `alias`.
+  `TreeNode.dataMapKey()` is `alias ?? relationshipName` and is the key the child block
+  is stitched under, so a template using a Tag name (`{#OpenCases}` over a Cases node)
+  filed its collection under `Cases` and the loop tag resolved null — `{#…}` rendered
+  nothing, `{^…}` fired its inverse branch, `{#IF …}` was false. **V3 query configs
+  only**; V1 falls through to the identical single-record path, which is why it looked
+  intermittent. Also adds the sibling duplicate-key guard the single path already had.
+- **Per-record `LIMIT` was applied per job.** The bulk child query spans every record in
+  the batch, so a bare `LIMIT 10` returned 10 rows for the whole job — the first parents
+  consumed them and every other record got an empty collection. No flat SOQL LIMIT can
+  express "n per parent" (scaling by parent count still starves a skewed set: one parent
+  with more than n children eats the surplus), so the clause is dropped from the query
+  and re-applied per parent after grouping. Fetches no more rows than a child node with
+  no limit clause already fetched on this path.
+- **`{Field:label}` threw in bulk only.** `resolvePicklistLabels` cast to
+  `Map<String,String>`, but `DocGenBatch` serializes the data map to JSON for its cache
+  and rehydrates with `JSON.deserializeUntyped`, which yields `Map<String,Object>`.
+  Read as `Map<String,Object>`, which accepts both shapes.
+- **`{#Approvals}` was never populated.** `generateDocumentData` injects it;
+  `generateDocumentDataFromCache` did not. Still opt-in, cached per template.
+
+### Added — charts in bulk
+
+`{Chart:…}` image charts rendered as `[Chart: rel.field]` text placeholders in bulk,
+because building a `chartCvMap` meant rasterizing SVG in a browser `<canvas>`.
+`DocGenChartRasterizer` — a pure-Apex PNG renderer — and
+`prepareChartImagesServerSide` were both built for DOM-less callers and documented for
+"batch jobs and bulk runners", but nothing ever called them.
+
+`DocGenBatch` now rasterizes per record (buckets differ per record, so it cannot be
+hoisted), seeds the chart context, and reaps the transient CVs in a `finally`. A
+`hasChartTags` probe resolves once per job so templates without charts — the
+overwhelming majority — never pay a per-record SOQL to prove a negative.
+
+`DocGenChartCvReaper` is the backstop: the previous docblock claimed an orphan reaper
+existed, and it did not. Chart CVs are caller-owned, and a caller that dies mid-flow
+left them behind. Tolerable when the only producer was a human clicking Generate;
+not once bulk creates them per record. Reaps `docgen_chart_*` older than 60 minutes,
+capped at 500 per run. Schedule with
+`System.schedule('DocGen Chart CV Reaper', '0 0 * * * ?', new DocGenChartCvReaper());`
+
+**Unaffected either way:** `{#ChartBucket:…}` loops and HTML CSS-bar charts resolve
+server-side inside `processXml` and have always worked in bulk.
+
+### Fixed — bulk output format
+
+- **PowerPoint and Excel in Combined PDF produced blank pages.**
+  `generateHtmlForRecord` branched on fillable-PDF and HTML, then let everything else
+  fall into the Word DOCX→HTML branch. A PPTX/XLSX template has no `word/document.xml`,
+  so it yielded empty HTML and a merged PDF of blank pages, reporting success.
+  `generateDocument` catches this via `validateOutputFormatOverride`, but the merge path
+  calls `mergeTemplate` with a hardcoded `'PDF'` and never passes through it. Now
+  rejected in `analyzeJob`, `submitJobInternal`, and `generateHtmlForRecord`.
+  **Individual Files remains fully supported** for both — `assembleZip` builds the OOXML
+  package in Apex, no browser required.
+
+### Fixed — bulk screen refused to start jobs
+
+The Run button was gated on `analyzeJob().canProceed`, which the server enforces
+nowhere — the Flow action ran the identical job the UI was refusing. The estimates are
+also systematically pessimistic about the async job they describe: measured in a 6MB
+synchronous Aura request but judged against the 12MB async ceiling, multiplying
+`DocGenBatch`'s once-per-`execute()` fixed costs by batch size, and ignoring both the
+shared data cache and `DocGenBulkGiantFallbackJob`, which already retries heap-failed
+records one at a time. At `batchSize=1` a heavy template emitted "reduce batch size to
+1" — an unactionable dead end.
+
+`canProceed` is now reserved for hard blockers (unsupported template/mode, >50,000
+records). Over-limit estimates stay visible as errors but no longer disable the button.
+
+### Fixed — Template Designer blank for non-admins (two separate causes)
+
+**Cause 2: the canvas was empty for anyone who didn't own the template's files.**
+
+`getHtmlTemplateBody` and `listHtmlTemplateImages` found their ContentVersions with a
+bare `WHERE Title LIKE 'docgen_html_body_<templateId>%'`. **File access is not governed
+by Apex sharing keywords or `WITH SYSTEM_MODE`.** Measured on a Standard User holding
+`DocGen_Admin`:
+
+```
+template=1  cdl=1  cvUserMode=0  cvSystemMode=0  cvViaWithoutSharingLoader=0
+                   cvScopedByContentDocumentId=1
+```
+
+The user could read the template record and its `ContentDocumentLink`, but a title-only
+`ContentVersion` query returned **zero rows in user mode, in `SYSTEM_MODE`, and from a
+`without sharing` class alike**. Resolving `ContentDocumentId`s from the link first
+returns the row.
+
+A System Administrator has View All Data and never hit it — so the Designer populated
+for whoever built the template and came up blank for everyone else, **silently**: no
+toast, no console error, just the "Start typing your document here" empty state. Because
+it looked like a permissions problem, the natural response was to grant more permission
+sets, which changed nothing.
+
+Both methods now go through the CDL-scoped loader
+(`loadInternalContentVersionsForVersionByTitlePrefix` /
+`loadInternalContentVersionMetaForEntityByTitlePrefix`, the latter metadata-only so
+listing images doesn't pull every blob into heap). Covered by two `System.runAs` tests
+against a real Standard User — the only way to reproduce this, since an admin never sees
+it.
+
+**Cause 1: missing Apex class access.**
+
+`docGenAdmin` imports `DocGenChartImageController` and `DocGenAiTemplateController`,
+neither of which had a `classAccesses` entry. An LWC's Apex imports resolve at module
+load, so one missing class blanks the entire component — and the `try/catch` around
+`isAiAvailable()` cannot help, because the failure is at import time, not call time.
+System Administrators have implicit access to every class and never saw it.
+
+Six entries added to both `DocGen_Admin` and `DocGen_User`:
+`DocGenAiTemplateController`, `DocGenAiHtmlValidator`, `DocGenChartImageController`,
+`DocGenFlsGuard`, `DocGenFieldWritebackService`, `DocGenSignaturePdfFlowAction`.
+
+### Fixed — template cloning dropped HTML files
+
+Clone is `exportTemplate` → `importTemplate`, so every export gap is a clone gap.
+
+- **Cloned HTML templates opened with a blank Designer canvas.** The body CV was titled
+  after the template name, but `getHtmlTemplateBody` finds it by the
+  `docgen_html_body_<templateId>_` prefix. The clone rendered correctly and was
+  uneditable — and the first Save wrote the blank canvas back over the real body.
+- **Designer images went to the wrong template.** Copied assets kept the source
+  template Id in their titles, and `listHtmlTemplateImages` matches on that prefix with
+  no parent scoping — so the clone's picker was empty and the **source** template's
+  picker gained duplicates.
+- Export now sweeps every `docgen_html_img_*` linked to the template, not only images
+  the current body references via a shepherd URL.
+- Export CV reads moved to the FLS-guard + `SYSTEM_MODE` hybrid. Under `USER_MODE` these
+  `Visibility=InternalUsers` links read empty (the #114 quirk), so a clone could be
+  created with no body at all, silently.
+- The imported version now carries `Output_Format__c`, `Header_Html__c`,
+  `Footer_Html__c`, and `Document_Title_Format__c` — using the shepherd-rewritten
+  header/footer, not the raw bundle values that still point at the source org's CVs.
+  This matters twice: the renderer prefers version values over template values, and
+  `activateVersion` pushes version fields back onto the template, so re-activating an
+  imported version blanked all four.
+
+### Added — multi-column sorting
+
+`ORDER BY` was already a free-text clause and the sanitizer already split on commas, so
+`Amount DESC, Name ASC` was expressible but had no editor and two broken consumers:
+
+- The child-relationship "Sort by" text box is now a repeatable field + direction picker
+  with reorder and remove. Storage stays a single clause string — no schema change.
+- `scoutChildCounts`' V3 branch dropped `orderBy`/`where`/`limit` entirely (the V1
+  branch emitted all three), and `docGenRunner` reads `serverChildNode.orderBy` to drive
+  the client-side giant DOCX cursor — so V3-config templates rendered child rows
+  unsorted while an identical V1 config sorted correctly.
+- `getSortedChildIds`' validator lacked the standard-relationship fallback that
+  `DocGenDataRetriever.sanitizeClause` has, so `Product2.Name` (resolved via
+  `Product2Id`) passed everywhere except the client giant path.
+
+### Added — bulk Flow action Template API Name (#256)
+
+"Generate Bulk Documents" accepts `Template API Name`, matching the single-record
+action. `Template ID` is no longer required. Resolution happens inside the existing try
+block so a bad API name lands on `Error Message` rather than faulting the interview.
+
+### Fixed — bulk sample record
+
+Switching templates left the previous template's sample record in place, keeping the
+Preview button enabled against a record of the wrong sObject type. The record picker
+also survived the switch and kept searching the old object, because it sits inside an
+`if:true` that stays true — it is now keyed on the base object so it rebuilds.
+
+### Internal
+
+- `e2e-01-permissions.apex` bulkified. It ran `SELECT Name FROM ApexClass` inside a loop,
+  one query per granted class; the six new permission-set entries pushed it past the
+  100-SOQL limit, which prints no summary line at all. It would have broken on the next
+  permission-set addition regardless.
+- `config/permission-test-scratch-def.json` + `scripts/setup-permission-test-org.sh`
+  spin up a namespaced scratch org with two non-admin users (Standard User +
+  `DocGen_Admin`, Standard Platform User + `DocGen_User`), passwords, and sample data in
+  one command. A System Administrator cannot reproduce permission-set gaps.
+- `docGenAdmin` cell-wrap emptiness check moved off `innerHTML` to a `childNodes`
+  predicate — same semantics (`textContent` is not equivalent: a cell holding only an
+  `<img>` has empty text but is not empty), and clears the last `sf code-analyzer` High.
+
+### Validation
+
+RunLocalTests, e2e-01..08 + 07-syntax1..4, `sf code-analyzer` 0 violations, prettier
+clean.
+
 ## v3.47.0 — PowerPoint table loops, GUID preservation, split-run merge tags
 
 `04tVx000000zMTRIA2` (build 3.47.0-1, promoted 2026-07-28, ancestor 3.46.0.5).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,21 @@ toast, no console error, just the "Start typing your document here" empty state.
 it looked like a permissions problem, the natural response was to grant more permission
 sets, which changed nothing.
 
-Both methods now go through the CDL-scoped loader
+**A blank canvas can no longer destroy a body.** The Designer seeds a placeholder
+scaffold ("Start typing your document here…") whenever the stored body reads back
+blank — correct for a new template, catastrophic when a _read failure_ made an existing
+body look blank, because one Save wrote the placeholder over the author's work.
+`saveHtmlTemplateBody` now refuses to replace a substantive stored body with an empty
+document or that seed placeholder, and says so. Deliberately server-side, so it holds
+for every caller: no future read bug, permission gap, or race can turn "I couldn't load
+it" into "I deleted it". Legitimate edits and brand-new templates are unaffected.
+
+`scripts/audit-blanked-template-bodies.apex` (read-only) finds any body already
+overwritten this way and names the exact prior ContentVersion to restore from — nothing
+was ever deleted, the old versions are still there. Run against Portwood Dev (69
+bodies), Production (11), and Demo (0): **all clean, no data was lost.**
+
+Both read methods now go through the CDL-scoped loader
 (`loadInternalContentVersionsForVersionByTitlePrefix` /
 `loadInternalContentVersionMetaForEntityByTitlePrefix`, the latter metadata-only so
 listing images doesn't pull every blob into heap). Covered by two `System.runAs` tests

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -2526,7 +2526,7 @@ Mass-generate documents for many records in one batch.
 5. Adjust batch size if needed (1–200; default 1 — one record per batch execution is the safest for heap-heavy templates; raise it for small, simple templates).
 6. Submit.
 
-**Preview one record first.** Before launching a big job, use **Generate Sample** — pick a sample record and the bulk runner produces one real PDF from it so you can sanity-check the output.
+**Preview one record first.** Before launching a big job, pick a record under **Preview Sample Record** and hit **Preview Sample PDF** — the bulk runner produces one real PDF from it so you can sanity-check the output. The sample record clears when you switch templates, since it belongs to the previous template's object.
 
 ### 9.2 Saved queries
 
@@ -2544,19 +2544,56 @@ Command Hub → **Job History** tab. Every bulk job shows:
 - Start + end time
 - Error messages (for failed jobs)
 
-### 9.4 Governor-limit analysis
+### 9.4 What bulk supports, by template type
 
-Before a big bulk job submits, the runner calls `analyzeJob()` which estimates:
+Bulk runs two different pipelines depending on the output mode, and that decides what works:
+
+- **Individual Files** → the full generation pipeline, including server-side OOXML packaging. No browser involved.
+- **Combined PDF** → each record is rendered to HTML, then all of them are merged into one PDF.
+
+| Template type          | Individual Files       | Combined PDF                                 |
+| ---------------------- | ---------------------- | -------------------------------------------- |
+| **HTML**               | Yes — PDF              | Yes                                          |
+| **Word → PDF**         | Yes                    | Yes                                          |
+| **Word → Native DOCX** | Yes                    | n/a — a combined bundle is always a PDF      |
+| **PowerPoint**         | Yes — one `.pptx` each | **No** — blocked with an explanatory message |
+| **Excel**              | Yes — one `.xlsx` each | **No** — blocked with an explanatory message |
+| **PDF (fillable)**     | Yes                    | **No** — blocked with an explanatory message |
+
+PowerPoint and Excel have no HTML conversion, so there is nothing for the merge step to combine. Run those as **Individual Files** and you get one native file per record. (Before v3.48 the combined job ran anyway and produced a PDF of blank pages while reporting success.)
+
+**Charts in bulk (v3.48+).** All chart types now render in bulk jobs:
+
+- `{#ChartBucket:…}` loops and HTML CSS-bar charts resolve server-side and have always worked.
+- `{Chart:…}` image charts are rasterized in Apex per record — no browser needed. Supported for Word, HTML, and PowerPoint templates; Excel does not embed chart images.
+
+Two things to know about chart-heavy bulk jobs:
+
+- Rasterizing is CPU-intensive. Keep **batch size at 1** (the default) for templates with charts. A handful of charts per record is comfortable; a dozen may exceed the per-batch CPU limit.
+- In **HTML → PDF** output, use the CSS-bar chart styles (`bar`, `pivot`, `clustered`, `stacked`). `column`, `pie`, and `donut` require `htmlRender=svg`, and the PDF engine drops inline SVG — those render in a browser preview but come out blank in the PDF. This applies to all HTML → PDF output, not just bulk.
+
+Schedule the chart cleanup job once per org so transient chart files from interrupted jobs don't accumulate:
+
+```apex
+System.schedule('DocGen Chart CV Reaper', '0 0 * * * ?', new DocGenChartCvReaper());
+```
+
+### 9.5 Governor-limit analysis
+
+Before a job submits, the runner calls `analyzeJob()`, which reports:
 
 - SOQL query count
 - DML operation count
-- Peak heap usage
+- Peak heap usage (per batch, and for the combined-PDF merge)
 
-If any projection exceeds governor limits, the runner **blocks submission** and suggests mitigations (reduce batch size, split the filter into multiple jobs, switch to async).
+**These are estimates, and they are advisory.** They are measured in a synchronous request but describe an asynchronous batch that gets a larger heap ceiling, a shared data cache, and an automatic retry path for records that do run out of memory — so they tend to overstate the real cost. An item shown in red is a risk worth reading, not a veto: the Run button stays enabled and the job may well succeed.
 
-### 9.5 Heap estimation for merge mode
+Submission is blocked only for conditions no setting can work around:
 
-Combined-PDF mode is memory-heavy. `estimateHeapUsage()` flags risky jobs ahead of time and suggests individual-files mode for large datasets.
+- An unsupported template type + output mode combination (see 9.4)
+- More than 50,000 records — the platform's batch query-locator ceiling
+
+If a job does fail on heap, reduce the batch size and re-run; records that individually exceed the limit are automatically retried one at a time through the giant-query path.
 
 ### 9.6 Oversized records — automatic giant-query recovery
 

--- a/config/permission-test-scratch-def.json
+++ b/config/permission-test-scratch-def.json
@@ -1,0 +1,30 @@
+{
+    "orgName": "DocGen Permission Test",
+    "edition": "developer",
+    "description": "Scratch org for testing DocGen permission sets against real non-admin users. Created WITH the portwoodglobal namespace on purpose: the Designer bugs that only appear under Lightning Web Security's per-namespace sandbox are invisible in a no-namespace org. Note the trade-off — the scripts/e2e-*.apex files use bare (unprefixed) class and field references and will NOT compile here; run those against a --no-namespace org instead.",
+    "features": ["EnableSetPasswordInApi", "Sites"],
+    "settings": {
+        "languageSettings": {
+            "enableTranslationWorkbench": true,
+            "enableEndUserLanguages": true,
+            "enablePlatformLanguages": true
+        },
+        "lightningExperienceSettings": {
+            "enableS1DesktopEnabled": true
+        },
+        "securitySettings": {
+            "sessionSettings": {
+                "forceRelogin": false,
+                "enableCacheAndAutocomplete": false
+            },
+            "passwordPolicies": {
+                "complexity": "NoRestriction",
+                "expiration": "Never",
+                "minimumPasswordLength": 8
+            }
+        },
+        "userManagementSettings": {
+            "enableScrambleUserData": false
+        }
+    }
+}

--- a/designer-snapshot.md
+++ b/designer-snapshot.md
@@ -1,0 +1,209 @@
+- generic [active]:
+    - generic [ref=f22e2]:
+        - generic [ref=f22e3]:
+            - link "Skip to Navigation" [ref=f22e4] [cursor=pointer]:
+                - /url: javascript:void(0);
+            - link "Skip to Main Content" [ref=f22e5] [cursor=pointer]:
+                - /url: javascript:void(0);
+            - generic [ref=f22e155]:
+                - generic [ref=f22e162]: Logged in as DocGen AdminTester (dgadmin.docgenperm@example.com)
+                - link "Log out as DocGen AdminTester" [ref=f22e163] [cursor=pointer]:
+                    - /url: /secur/logout.jsp
+            - generic [ref=f22e6]:
+                - button "Search" [ref=f22e12]: Search...
+                - navigation "Global Header" [ref=f22e17]:
+                    - list [ref=f22e165]:
+                        - listitem [ref=f22e166]:
+                            - group [ref=f22e167]:
+                                - button "Add favorite" [ref=f22e169] [cursor=pointer]:
+                                    - generic [ref=f22e170]:
+                                        - tooltip "Add favorite"
+                                - button [ref=f22e178] [cursor=pointer]:
+                                    - generic [ref=f22e179]:
+                                        - tooltip "Favorites list"
+                        - listitem [ref=f22e186]:
+                            - button [ref=f22e280] [cursor=pointer]:
+                                - generic [ref=f22e281]:
+                                    - tooltip "Global Actions"
+                        - listitem [ref=f22e288]:
+                            - button [ref=f22e290] [cursor=pointer]:
+                                - generic [ref=f22e291]:
+                                    - tooltip "Guidance Center"
+                        - listitem [ref=f22e195]:
+                            - button [ref=f22e198] [cursor=pointer]:
+                                - generic [ref=f22e199]:
+                                    - tooltip "Salesforce Help"
+                        - listitem [ref=f22e206]:
+                            - button [ref=f22e212] [cursor=pointer]:
+                                - generic [ref=f22e213]:
+                                    - tooltip "Setup"
+                        - listitem [ref=f22e220]:
+                            - button [ref=f22e223] [cursor=pointer]:
+                                - generic [ref=f22e224]:
+                                    - tooltip "Notifications"
+                        - listitem [ref=f22e233]:
+                            - button "View profile" [ref=f22e236] [cursor=pointer]:
+                                - generic [ref=f22e237]:
+                                    - tooltip "View profile"
+        - generic [ref=f22e23]:
+            - generic [ref=f22e26]:
+                - generic [ref=f22e28]:
+                    - navigation "App" [ref=f22e29]:
+                        - button "App Launcher" [ref=f22e31] [cursor=pointer]
+                    - heading "DocGen" [level=1] [ref=f22e43]
+                - navigation "Global" [ref=f22e47]:
+                    - list [ref=f22e48]:
+                        - listitem [ref=f22e49]:
+                            - link "DocGen" [ref=f22e50] [cursor=pointer]:
+                                - /url: /lightning/n/portwoodglobal\_\_DocGen_Command_Hub
+                        - listitem [ref=f22e52]:
+                            - link "DocGen Templates" [ref=f22e53] [cursor=pointer]:
+                                - /url: /lightning/o/portwoodglobal**DocGen_Template**c/home
+                            - button "DocGen Templates List" [ref=f22e58] [cursor=pointer]
+                        - listitem [ref=f22e66]:
+                            - link "DocGen Jobs" [ref=f22e67] [cursor=pointer]:
+                                - /url: /lightning/o/portwoodglobal**DocGen_Job**c/home
+                            - button "DocGen Jobs List" [ref=f22e72] [cursor=pointer]
+                        - listitem [ref=f22e80]:
+                            - link "DocGen Signature Requests" [ref=f22e81] [cursor=pointer]:
+                                - /url: /lightning/o/portwoodglobal**DocGen_Signature_Request**c/home
+                            - button "DocGen Signature Requests List" [ref=f22e86] [cursor=pointer]
+                        - listitem [ref=f22e94]:
+                            - link "DocGen Signers" [ref=f22e95] [cursor=pointer]:
+                                - /url: /lightning/o/portwoodglobal**DocGen_Signer**c/home
+                            - button "DocGen Signers List" [ref=f22e100] [cursor=pointer]
+                        - listitem [ref=f22e241] [cursor=pointer]:
+                            - link "\* DocGen Template Manager" [ref=f22e242]:
+                                - /url: /lightning/n/portwoodglobal\_\_DocGen_Template_Manager
+                                - generic "Not added to nav bar" [ref=f22e243]: "\*"
+                                - generic [ref=f22e244]: DocGen Template Manager
+                            - button "DocGen Template Manager List" [ref=f22e248]
+                            - button "Close tab" [ref=f22e256]
+                        - listitem [ref=f22e264]:
+                            - button "Show more navigation items" [ref=f22e266] [cursor=pointer]:
+                                - generic [ref=f22e267]: More
+                        - listitem [ref=f22e136]:
+                            - button "Edit nav items" [ref=f22e138] [cursor=pointer]
+            - main [ref=f22e145]:
+                - generic [ref=f22e302]:
+                    - tablist "Tabs" [ref=f22e304]:
+                        - tab "Create New" [selected] [ref=f22e305] [cursor=pointer]
+                        - tab "Your Templates" [ref=f22e306] [cursor=pointer]
+                        - tab "Designer (Beta)" [ref=f22e307] [cursor=pointer]
+                    - tabpanel "Create New" [ref=f22e309]:
+                        - generic [ref=f22e311]:
+                            - generic [ref=f22e314]:
+                                - list [ref=f22e315]:
+                                    - generic [ref=f22e316]:
+                                        - listitem [ref=f22e317]:
+                                            - generic [ref=f22e318]: Name Your Template - Current Stage
+                                        - listitem [ref=f22e320]:
+                                            - generic [ref=f22e321]: Pick Your Data - Stage Not Started
+                                        - listitem [ref=f22e323]:
+                                            - generic [ref=f22e324]: Review & Create - Stage Not Started
+                                - progressbar "Progress Bar" [ref=f22e326]:
+                                    - generic: Progress 0%
+                            - generic [ref=f22e328]:
+                                - radiogroup "How do you want to build this template?" [ref=f22e329]:
+                                    - radio "Start from a Design Recommended Pick a professional starter layout — your fields are dropped in automatically and the template renders on the first click. Creates an HTML template, the most reliable path to pixel-perfect PDFs." [ref=f22e330] [cursor=pointer]:
+                                        - generic [ref=f22e331]:
+                                            - generic [ref=f22e338]: Start from a Design
+                                            - generic [ref=f22e339]: Recommended
+                                        - paragraph [ref=f22e340]: Pick a professional starter layout — your fields are dropped in automatically and the template renders on the first click. Creates an HTML template, the most reliable path to pixel-perfect PDFs.
+                                    - radio "Generate with AI We assemble a ready-to-paste prompt with your fields and DocGen's tag syntax. Paste it into Claude, ChatGPT, or Copilot, then paste the HTML it returns straight into the template editor." [ref=f22e341] [cursor=pointer]:
+                                        - generic [ref=f22e342]: Generate with AI
+                                        - paragraph [ref=f22e352]: We assemble a ready-to-paste prompt with your fields and DocGen's tag syntax. Paste it into Claude, ChatGPT, or Copilot, then paste the HTML it returns straight into the template editor.
+                                    - 'radio "Start From Scratch A blank page in the visual designer. Click anywhere and type, drag in blocks and merge tags, or hit ` for the insert menu — build the document your way." [ref=f22e353] [cursor=pointer]':
+                                        - generic [ref=f22e354]: Start From Scratch
+                                        - paragraph [ref=f22e362]: "A blank page in the visual designer. Click anywhere and type, drag in blocks and merge tags, or hit ` for the insert menu — build the document your way."
+                                    - radio "I Have an Existing File Upload a Word, PowerPoint, Excel, fillable PDF, or HTML file you already maintain. Word documents are converted to HTML for PDF output — complex layouts may not convert exactly." [checked] [ref=f22e363] [cursor=pointer]:
+                                        - generic [ref=f22e364]: I Have an Existing File
+                                        - paragraph [ref=f22e372]: Upload a Word, PowerPoint, Excel, fillable PDF, or HTML file you already maintain. Word documents are converted to HTML for PDF output — complex layouts may not convert exactly.
+                                - generic [ref=f22e373]:
+                                    - generic [ref=f22e374]:
+                                        - generic [ref=f22e377]:
+                                            - generic [ref=f22e378]: "\*Template Name"
+                                            - textbox "Template Name" [ref=f22e380]
+                                        - generic [ref=f22e383]:
+                                            - generic [ref=f22e384]: API Name
+                                            - button "API Name Help Info" [ref=f22e388] [cursor=pointer]
+                                            - textbox "API Name" [ref=f22e395]
+                                        - generic [ref=f22e398]:
+                                            - generic [ref=f22e399]: Category
+                                            - textbox "Category" [ref=f22e401]
+                                        - radiogroup "\*Data Source" [ref=f22e403]:
+                                            - generic [ref=f22e405]:
+                                                - generic [ref=f22e406]:
+                                                    - radio "Salesforce Record (SOQL)" [checked] [ref=f22e407]
+                                                    - generic [ref=f22e408] [cursor=pointer]: Salesforce Record (SOQL)
+                                                - generic [ref=f22e410]:
+                                                    - radio "Apex Class (Data Provider)" [ref=f22e411]
+                                                    - generic [ref=f22e412] [cursor=pointer]: Apex Class (Data Provider)
+                                                - generic [ref=f22e414]:
+                                                    - radio "JSON Data (from Flow)" [ref=f22e415]
+                                                    - generic [ref=f22e416] [cursor=pointer]: JSON Data (from Flow)
+                                            - status
+                                        - generic [ref=f22e421]:
+                                            - generic [ref=f22e422]: "\*Base Object"
+                                            - textbox "Base Object" [ref=f22e424]:
+                                                - /placeholder: Account, Opportunity, Contact...
+                                                - text: Account
+                                    - generic [ref=f22e425]:
+                                        - generic [ref=f22e427]:
+                                            - generic [ref=f22e428]: "\*Type"
+                                            - button "Type Help Info" [ref=f22e433] [cursor=pointer]
+                                            - combobox "Type" [ref=f22e443] [cursor=pointer]:
+                                                - generic [ref=f22e444]: Word
+                                            - status
+                                        - note [ref=f22e451]:
+                                            - paragraph [ref=f22e452]:
+                                                - text: Word templates are converted to HTML for PDF output — complex layouts (text boxes, floating images, unusual tables) may not convert exactly. Keep Output Format
+                                                - strong [ref=f22e459]: Native (.docx)
+                                                - text: for full fidelity, upload an
+                                                - strong [ref=f22e460]: HTML
+                                                - text: file for a pixel-perfect PDF, or use
+                                                - strong [ref=f22e461]: Start from a Design
+                                                - text: /
+                                                - strong [ref=f22e462]: Generate with AI
+                                                - text: /
+                                                - strong [ref=f22e463]: Start From Scratch
+                                                - text: .
+                                                - strong [ref=f22e464]: Excel
+                                                - text: and
+                                                - strong [ref=f22e465]: PowerPoint
+                                                - text: templates always generate in their native format — no conversion involved.
+                                        - generic [ref=f22e467]:
+                                            - generic [ref=f22e468]: "\*Output Format"
+                                            - combobox "Output Format" [ref=f22e474] [cursor=pointer]:
+                                                - generic [ref=f22e475]: PDF
+                                            - status
+                                        - generic [ref=f22e483]:
+                                            - generic [ref=f22e484]: Page Orientation
+                                            - button "Page Orientation Help Info" [ref=f22e489] [cursor=pointer]
+                                            - combobox "Page Orientation" [ref=f22e499] [cursor=pointer]:
+                                                - generic [ref=f22e500]: Portrait
+                                            - status
+                                        - generic [ref=f22e508]:
+                                            - generic [ref=f22e509]: Page Size
+                                            - button "Page Size Help Info" [ref=f22e514] [cursor=pointer]
+                                            - combobox "Page Size" [ref=f22e524] [cursor=pointer]:
+                                                - generic [ref=f22e525]: Letter (8.5 x 11 in)
+                                            - status
+                                        - generic [ref=f22e533]:
+                                            - generic [ref=f22e534]: Page Margins
+                                            - button "Page Margins Help Info" [ref=f22e539] [cursor=pointer]
+                                            - combobox "Page Margins" [ref=f22e549] [cursor=pointer]:
+                                                - generic [ref=f22e550]: Default for size
+                                            - status
+                                        - generic [ref=f22e557]:
+                                            - generic [ref=f22e561]:
+                                                - generic [ref=f22e562]: Sample Record (optional)
+                                                - combobox "Sample Record (optional)" [ref=f22e570]
+                                                - status
+                                            - paragraph [ref=f22e577]: See real data from this record while building your query.
+                            - generic [ref=f22e579]:
+                                - generic:
+                                    - button "Back" [disabled]
+                                - button "Next" [ref=f22e581] [cursor=pointer]
+    - generic:
+        - status

--- a/force-app/main/default/classes/DocGenBatch.cls
+++ b/force-app/main/default/classes/DocGenBatch.cls
@@ -38,6 +38,23 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
     // Merge mode: sequence counter for HTML snippet ordering
     public Integer htmlSequence = 0;
 
+    // Chart rasterization (Stateful — resolved once, reused across execute() chunks).
+    //
+    // {Chart:...} image charts need a chartCvMap, which the interactive runner builds
+    // by rasterizing SVG in a browser <canvas>. A batch has no DOM, so bulk rendered
+    // those tags as "[Chart: rel.field]" text placeholders. DocGenChartRasterizer is a
+    // pure-Apex PNG renderer built for exactly this; prepareChartImagesServerSide wraps
+    // it and returns the same map shape the merge pipeline already consumes.
+    //
+    // The has-charts probe is cached because prepareChartImagesServerSide loads the
+    // active template body to look for chart tags — a per-record SOQL that would be
+    // pure waste on the overwhelming majority of templates, which have no charts.
+    //
+    // {#ChartBucket:...} loops and HTML CSS-bar charts are NOT affected by any of this:
+    // they resolve server-side inside processXml and have always worked in bulk.
+    @TestVisible
+    private Boolean templateHasChartTags = null;
+
     /**
      * Constructs a batch job in default (non-merge) mode.
      * @param jobId The DocGen_Job__c record ID
@@ -372,11 +389,36 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
             }
         }
 
+        // Resolve once per job, not per record — see templateHasChartTags.
+        if (templateHasChartTags == null) {
+            try {
+                templateHasChartTags = DocGenChartImageController.hasChartTags(templateId);
+            } catch (Exception e) {
+                // A failed probe must not sink the job; charts simply fall back to the
+                // text placeholder they produced before this path existed.
+                templateHasChartTags = false;
+            }
+        }
+
         for (SObject rec : scope) {
+            List<Id> chartCvIds = null;
             try {
                 Map<String, Object> recordData = null;
                 if (dataCache != null) {
                     recordData = (Map<String, Object>) dataCache.get(String.valueOf(rec.Id));
+                }
+
+                // Charts are per-record: each record's buckets differ, so the PNGs have
+                // to be rasterized inside this record's iteration, not once per job.
+                if (templateHasChartTags == true) {
+                    Map<String, String> chartCvMap = DocGenChartImageController.prepareChartImagesServerSide(
+                        templateId,
+                        rec.Id
+                    );
+                    if (!chartCvMap.isEmpty()) {
+                        chartCvIds = DocGenChartImageController.chartCvIdsFrom(chartCvMap);
+                        DocGenService.beginChartContext(chartCvMap);
+                    }
                 }
 
                 if (mergeOnly) {
@@ -392,6 +434,25 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
             } catch (Exception e) {
                 failCount++;
                 recordFailure(rec.Id, e);
+            } finally {
+                // The chart CVs are transient render inputs and this batch owns them —
+                // deleteChartImages is caller-owned and there is no reaper watching a
+                // batch. Reap per record so a long job never accumulates: N records x
+                // M charts of orphaned ContentVersions is a storage complaint waiting
+                // to happen. In the finally so a failed record cleans up too.
+                DocGenService.endChartContext();
+                if (chartCvIds != null && !chartCvIds.isEmpty()) {
+                    try {
+                        DocGenChartImageController.deleteChartImages(chartCvIds);
+                    } catch (Exception cleanupEx) {
+                        // Cleanup is best-effort — DocGenChartCvReaper is the backstop.
+                        // Deliberately swallowed: never let a reap failure convert a
+                        // successful render into a failed record. (No control-flow
+                        // statement here — a continue/return inside finally would
+                        // discard the in-flight exception from the try block.)
+                        chartCvIds = null;
+                    }
+                }
             }
         }
 

--- a/force-app/main/default/classes/DocGenBulkController.cls
+++ b/force-app/main/default/classes/DocGenBulkController.cls
@@ -235,6 +235,20 @@ public with sharing class DocGenBulkController {
      */
     @AuraEnabled
     public static JobAnalysis analyzeJob(Id templateId, Integer recordCount, Integer batchSize, Boolean mergePdf) {
+        // canProceed gates the Run button and is reserved for HARD blockers only —
+        // conditions no batch size or record set can work around (unsupported
+        // template/mode combination, or the platform's own QueryLocator ceiling).
+        //
+        // The SOQL / DML / heap items below are ESTIMATES computed in this
+        // synchronous Aura request and are systematically pessimistic about the
+        // async job they describe: they measure a 6MB-ceiling transaction against
+        // the 12MB async ceiling, multiply DocGenBatch's once-per-execute() fixed
+        // costs by batch size, and ignore both the shared dataCache (which drops
+        // per-record SOQL to ~0) and DocGenBulkGiantFallbackJob (which already
+        // re-runs heap-failed records one per Queueable). They stay visible as
+        // 'error' items so the panel keeps its diagnostic value, but they must not
+        // disable the button — the server enforces none of them, so the Flow
+        // action happily runs the exact same job the UI was refusing.
         JobAnalysis analysis = new JobAnalysis();
         analysis.recordCount = recordCount;
         analysis.items = new List<AnalysisItem>();
@@ -275,6 +289,20 @@ public with sharing class DocGenBulkController {
                 analysis.canProceed = false;
             }
 
+            // PowerPoint / Excel have no DOCX→HTML conversion, so there is nothing to
+            // merge into a combined PDF. A genuine hard blocker, not an estimate.
+            if (isMerge && (temp.Type__c == 'PowerPoint' || temp.Type__c == 'Excel')) {
+                AnalysisItem mergeItem = new AnalysisItem();
+                mergeItem.label = 'Template Format';
+                mergeItem.status = 'error';
+                mergeItem.message =
+                    temp.Type__c +
+                    ' templates cannot be combined into a single PDF. ' +
+                    'Switch to Individual Files to get one file per record.';
+                analysis.items.add(mergeItem);
+                analysis.canProceed = false;
+            }
+
             // --- 1. SOQL Queries per batch execution ---
             Integer queriesPerRecord = countQueriesPerRecord(temp.Query_Config__c);
             // Overhead: template load (~3 queries first batch, cached after), job update (1)
@@ -286,16 +314,17 @@ public with sharing class DocGenBulkController {
             soqlItem.label = 'SOQL Queries';
             soqlItem.estimated = soqlPerBatch;
             soqlItem.limitVal = soqlLimit;
-            if (soqlPerBatch >= soqlLimit) {
+            if (soqlPerBatch > soqlLimit) {
                 soqlItem.status = 'error';
                 soqlItem.message =
                     soqlPerBatch +
                     ' / ' +
                     soqlLimit +
-                    ' per batch — will exceed limit. Reduce batch size to ' +
+                    ' per batch — worst case exceeds the limit. This estimate assumes every record ' +
+                    're-runs the full query tree; the batch job caches shared data and usually issues ' +
+                    'far fewer. Reduce batch size to ' +
                     Math.max(1, Math.floor((soqlLimit - overhead) / queriesPerRecord)) +
-                    ' or lower.';
-                analysis.canProceed = false;
+                    ' or lower if the job fails.';
             } else if (soqlPerBatch >= 80) {
                 soqlItem.status = 'warning';
                 soqlItem.message =
@@ -319,10 +348,9 @@ public with sharing class DocGenBulkController {
             dmlItem.label = 'DML Statements';
             dmlItem.estimated = dmlPerBatch;
             dmlItem.limitVal = dmlLimit;
-            if (dmlPerBatch >= dmlLimit) {
+            if (dmlPerBatch > dmlLimit) {
                 dmlItem.status = 'error';
-                dmlItem.message = dmlPerBatch + ' / ' + dmlLimit + ' per batch — will exceed limit. Reduce batch size.';
-                analysis.canProceed = false;
+                dmlItem.message = dmlPerBatch + ' / ' + dmlLimit + ' per batch — exceeds the limit. Reduce batch size.';
             } else if (dmlPerBatch >= 120) {
                 dmlItem.status = 'warning';
                 dmlItem.message = dmlPerBatch + ' / ' + dmlLimit + ' per batch — approaching limit.';
@@ -382,8 +410,9 @@ public with sharing class DocGenBulkController {
                             heapItem.status = 'error';
                             heapItem.message =
                                 totalMb.setScale(1) +
-                                'MB / 12MB — high risk of heap failure. Reduce record count or switch to Individual Files.';
-                            analysis.canProceed = false;
+                                'MB / 12MB — high risk of heap failure. Records that run out of heap are ' +
+                                'automatically retried one at a time, so the job can still finish. To lower the ' +
+                                'risk, reduce record count or switch to Individual Files.';
                         } else if (totalMb >= 7.0) {
                             heapItem.status = 'warning';
                             heapItem.message = totalMb.setScale(1) + 'MB / 12MB — moderate usage, monitor job.';
@@ -403,12 +432,21 @@ public with sharing class DocGenBulkController {
 
                     if (batchMb >= 10.0) {
                         batchHeapItem.status = 'error';
+                        // Suggesting a batch size the user is already at is a dead end —
+                        // it reads as "do something" while offering nothing to do. When a
+                        // single record alone trips the estimate, say so instead.
+                        Integer suggestedBatch = Math.max(
+                            1,
+                            Integer.valueOf(Math.floor(9.0 / (batchMb / safeBatchSize)))
+                        );
                         batchHeapItem.message =
                             batchMb.setScale(1) +
-                            'MB / 12MB per batch — reduce batch size to ' +
-                            Math.max(1, Math.floor(9.0 / (batchMb / safeBatchSize))) +
-                            ' or lower.';
-                        analysis.canProceed = false;
+                            'MB / 12MB per batch — ' +
+                            (suggestedBatch < safeBatchSize
+                                ? 'reduce batch size to ' + suggestedBatch + ' or lower.'
+                                : 'one record alone approaches the async heap ceiling. This figure is measured ' +
+                                  'in a 6MB synchronous request and overstates the batch job, which gets a fresh ' +
+                                  '12MB per execution; records that do run out of heap are retried individually.');
                     } else if (batchMb >= 7.0) {
                         batchHeapItem.status = 'warning';
                         batchHeapItem.message =
@@ -443,8 +481,15 @@ public with sharing class DocGenBulkController {
                     warnings++;
                 }
             }
-            if (errors > 0) {
-                analysis.summary = 'Cannot proceed — ' + errors + ' limit(s) will be exceeded.';
+            // "Cannot proceed" is now driven by canProceed (hard blockers only), not by
+            // the error count — an over-limit ESTIMATE is a risk to flag, not a veto.
+            if (!analysis.canProceed) {
+                analysis.summary = 'Cannot proceed — see the blocking item(s) below.';
+            } else if (errors > 0) {
+                analysis.summary =
+                    'You can run this, but ' +
+                    errors +
+                    ' estimate(s) exceed a limit — the job may need a smaller batch size to finish cleanly.';
             } else if (warnings > 0) {
                 analysis.summary = 'Should work, but ' + warnings + ' item(s) need attention.';
             } else {
@@ -610,6 +655,17 @@ public with sharing class DocGenBulkController {
                     'Turn off Merged PDF and Merge Only for this template.'
                 );
             }
+            // Fail up front rather than per-record. generateHtmlForRecord throws for
+            // these too, but only once the batch is already running — which surfaces
+            // as N failed records on a job that should never have started.
+            String unmergeable = isMergeMode ? unmergeableTemplateType(templateId) : null;
+            if (unmergeable != null) {
+                throw new DocGenException(
+                    unmergeable +
+                        ' templates cannot be combined into a single PDF. ' +
+                        'Turn off Merged PDF and Merge Only to get one file per record.'
+                );
+            }
 
             // 1. Create Job Record
             DocGen_Job__c job = new DocGen_Job__c(
@@ -661,6 +717,36 @@ public with sharing class DocGenBulkController {
             LIMIT 1
         ];
         return !templates.isEmpty() && templates[0].Type__c == 'PDF';
+    }
+
+    /**
+     * Template types that cannot be combined into a single PDF, because they have no
+     * DOCX→HTML conversion and the merge path is HTML-based. Returns the type name so
+     * callers can name it in the error, or null when the template is mergeable.
+     *
+     * Without this, a PPTX/XLSX combined-PDF job produced a PDF of blank pages and
+     * reported success — the merge path never ran the output-format validation that
+     * the individual-file path does.
+     */
+    @TestVisible
+    private static String unmergeableTemplateType(Id templateId) {
+        if (templateId == null) {
+            return null;
+        }
+        DocGenFlsGuard.assertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Type__c' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Template__c> templates = [
+            SELECT Type__c
+            FROM DocGen_Template__c
+            WHERE Id = :templateId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (templates.isEmpty()) {
+            return null;
+        }
+        String t = templates[0].Type__c;
+        return (t == 'PowerPoint' || t == 'Excel') ? t : null;
     }
 
     /**

--- a/force-app/main/default/classes/DocGenBulkControllerTest.cls
+++ b/force-app/main/default/classes/DocGenBulkControllerTest.cls
@@ -171,7 +171,17 @@ public with sharing class DocGenBulkControllerTest {
             }
         }
         System.assertEquals(true, hasSoqlError, 'High batch size should trigger SOQL error');
-        System.assertEquals(false, analysis.canProceed, 'Should not be able to proceed with limit exceeded');
+        // canProceed is reserved for HARD blockers (unsupported template/mode, >50k
+        // records). An over-limit SOQL ESTIMATE is surfaced as an error item but must
+        // NOT disable the Run button: the estimate assumes every record re-runs the
+        // full query tree, while DocGenBatch caches shared data, and the server-side
+        // submitJob path enforces none of it — so the Flow action would run the exact
+        // same job the UI was refusing.
+        System.assertEquals(
+            true,
+            analysis.canProceed,
+            'An over-limit estimate should warn, not block — only hard blockers set canProceed=false'
+        );
     }
 
     @IsTest

--- a/force-app/main/default/classes/DocGenBulkFlowAction.cls
+++ b/force-app/main/default/classes/DocGenBulkFlowAction.cls
@@ -5,8 +5,17 @@
  */
 global with sharing class DocGenBulkFlowAction { // NOPMD AvoidGlobalModifier — global required for @InvocableMethod visibility in subscriber orgs
     global class Request {
-        @InvocableVariable(label='Template ID' required=true description='The DocGen Template record ID')
+        @InvocableVariable(
+            label='Template ID'
+            description='The DocGen Template record ID. Provide this OR Template API Name.'
+        )
         global Id templateId;
+
+        @InvocableVariable(
+            label='Template API Name'
+            description='The template\'s API Name field — a stable key that survives sandbox-to-production deploys, unlike a record Id. Provide this OR Template ID.'
+        )
+        global String templateApiName;
 
         @InvocableVariable(
             label='WHERE Condition'
@@ -65,6 +74,17 @@ global with sharing class DocGenBulkFlowAction { // NOPMD AvoidGlobalModifier �
             Response res = new Response();
             String effectiveCondition;
             try {
+                // Allow addressing the template by its stable API Name, matching
+                // DocGenFlowAction. Resolution happens inside the try so a bad API
+                // name surfaces on the Error Message output instead of faulting
+                // the interview.
+                if (req.templateId == null) {
+                    req.templateId = DocGenService.templateIdByApiName(req.templateApiName);
+                }
+                if (req.templateId == null) {
+                    throw new DocGenException('Provide Template ID or Template API Name.');
+                }
+
                 // Default: combined PDF only (most efficient)
                 Boolean mergeOnly = (req.combinedPdfOnly != false && req.keepIndividualFiles != true);
                 Boolean mergePdf = mergeOnly || (req.keepIndividualFiles == true);

--- a/force-app/main/default/classes/DocGenBulkFlowActionTest.cls
+++ b/force-app/main/default/classes/DocGenBulkFlowActionTest.cls
@@ -69,6 +69,58 @@ private class DocGenBulkFlowActionTest {
         }
     }
 
+    // ─── Template API Name addressing ────────────────────────────────────
+    // Mirrors DocGenFlowAction so a Flow can reference a bulk template by its
+    // stable API Name instead of an environment-specific record Id.
+
+    @IsTest
+    static void testGenerateBulk_byTemplateApiName() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c temp = [SELECT Id FROM DocGen_Template__c LIMIT 1];
+            temp.API_Name__c = 'Bulk_Template_Api_Key';
+            Database.update(temp, AccessLevel.SYSTEM_MODE);
+
+            DocGenBulkFlowAction.Request req = new DocGenBulkFlowAction.Request();
+            req.templateApiName = 'Bulk_Template_Api_Key';
+            req.queryCondition = 'Name = \'Test Account 1\'';
+
+            Test.startTest();
+            List<DocGenBulkFlowAction.Response> responses = DocGenBulkFlowAction.generateBulkDocuments(
+                new List<DocGenBulkFlowAction.Request>{ req }
+            );
+            Test.stopTest();
+
+            System.assertEquals(true, responses[0].success, 'API Name should resolve: ' + responses[0].errorMessage);
+            System.assertNotEquals(null, responses[0].jobId, 'Should have a jobId when addressed by API Name');
+
+            DocGen_Job__c job = [SELECT Template__c FROM DocGen_Job__c WHERE Id = :responses[0].jobId];
+            System.assertEquals(temp.Id, job.Template__c, 'Job should target the template matched by API Name');
+        }
+    }
+
+    @IsTest
+    static void testGenerateBulk_unknownTemplateApiNameReturnsError() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGenBulkFlowAction.Request req = new DocGenBulkFlowAction.Request();
+            req.templateApiName = 'No_Such_Template_Api_Name';
+
+            Test.startTest();
+            List<DocGenBulkFlowAction.Response> responses = DocGenBulkFlowAction.generateBulkDocuments(
+                new List<DocGenBulkFlowAction.Request>{ req }
+            );
+            Test.stopTest();
+
+            System.assertEquals(false, responses[0].success, 'Unknown API Name should fail the request');
+            System.assertEquals(null, responses[0].jobId, 'No job should be created for an unknown API Name');
+            System.assert(
+                responses[0].errorMessage.contains('No_Such_Template_Api_Name'),
+                'Error should name the API Name that failed to resolve: ' + responses[0].errorMessage
+            );
+        }
+    }
+
     // ─── Record-IDs collection input ─────────────────────────────────────
     // Lets a Flow that has already filtered records (e.g. via decision logic
     // or a Get Records collection) hand them directly to bulk generation

--- a/force-app/main/default/classes/DocGenBulkTests.cls
+++ b/force-app/main/default/classes/DocGenBulkTests.cls
@@ -5,6 +5,345 @@ private class DocGenBulkTests {
         TestDataFactory.createStandardTestData();
     }
 
+    // ─── Combined-PDF format guard ───────────────────────────────────────
+    // PowerPoint and Excel have no DOCX→HTML conversion, so there is nothing for the
+    // merge path to combine. Before the guard they fell through to the Word branch,
+    // produced empty HTML, and shipped a PDF of blank pages reporting success.
+
+    private static DocGen_Template__c makeTypedTemplate(String type) {
+        DocGen_Template__c t = new DocGen_Template__c(
+            Name = 'Bulk ' + type + ' Template',
+            Base_Object_API__c = 'Account',
+            Type__c = type,
+            Query_Config__c = 'Name'
+        );
+        Database.insert(t, AccessLevel.SYSTEM_MODE);
+        return t;
+    }
+
+    @IsTest
+    static void combinedPdfIsRejectedForPowerPointAndExcel() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            for (String type : new List<String>{ 'PowerPoint', 'Excel' }) {
+                DocGen_Template__c t = makeTypedTemplate(type);
+                String message = null;
+                try {
+                    DocGenBulkController.submitJobInternal(t.Id, null, 'Merge ' + type, true, 1, true);
+                } catch (Exception e) {
+                    message = e.getMessage();
+                }
+                System.assertNotEquals(null, message, type + ' must not be accepted for a combined-PDF job');
+                System.assertEquals(
+                    true,
+                    message.contains(type),
+                    'Error should name the offending template type: ' + message
+                );
+            }
+        }
+    }
+
+    @IsTest
+    static void individualFilesIsStillAllowedForPowerPointAndExcel() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c t = makeTypedTemplate('PowerPoint');
+
+            Test.startTest();
+            // mergePdf=false, mergeOnly=false — native one-file-per-record, which IS
+            // supported: DocGenService.assembleZip builds the OOXML package in Apex.
+            // The guard must not over-reach and block the mode that works.
+            Id jobId = DocGenBulkController.submitJobInternal(t.Id, null, 'Individual PPTX', false, 1, false);
+            Test.stopTest();
+
+            System.assertNotEquals(null, jobId, 'Individual-file bulk must remain available for PowerPoint');
+        }
+    }
+
+    @IsTest
+    static void analyzeJobFlagsUnmergeableTypesAsHardBlockers() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c t = makeTypedTemplate('Excel');
+
+            Test.startTest();
+            DocGenBulkController.JobAnalysis merged = DocGenBulkController.analyzeJob(t.Id, 10, 1, true);
+            DocGenBulkController.JobAnalysis individual = DocGenBulkController.analyzeJob(t.Id, 10, 1, false);
+            Test.stopTest();
+
+            System.assertEquals(false, merged.canProceed, 'Excel + combined PDF is a genuine hard blocker');
+            System.assertEquals(
+                true,
+                individual.canProceed,
+                'Excel as individual files must stay runnable — the guard is merge-only'
+            );
+        }
+    }
+
+    // ─── Server-side chart rasterization in bulk ─────────────────────────
+
+    /**
+     * Minimum surface prepareChartImagesServerSide reads: a Word template, an active
+     * version, and a pre-decomposed word__document.xml CV whose body carries a
+     * {Chart:...} tag. Mirrors the fixture in DocGenChartImageControllerTest.
+     */
+    private static DocGen_Template__c makeWordChartTemplate() {
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'Bulk Chart Word Tpl',
+            Base_Object_API__c = 'Account',
+            Type__c = 'Word',
+            Query_Config__c = 'Name'
+        );
+        Database.insert(tpl, AccessLevel.SYSTEM_MODE);
+        DocGen_Template_Version__c ver = new DocGen_Template_Version__c(Template__c = tpl.Id, Is_Active__c = true);
+        Database.insert(ver, AccessLevel.SYSTEM_MODE);
+        ContentVersion xmlCv = new ContentVersion(
+            Title = 'docgen_tmpl_xml_' + ver.Id + '_word__document.xml',
+            PathOnClient = 'document.xml',
+            VersionData = Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8"?>' +
+                    '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>' +
+                    '<w:p><w:r><w:t>{Chart:Contacts:LastName:bar:title=Demo}</w:t></w:r></w:p>' +
+                    '</w:body></w:document>'
+            )
+        );
+        Database.insert(xmlCv, AccessLevel.SYSTEM_MODE);
+        return tpl;
+    }
+
+    @IsTest
+    static void hasChartTagsDetectsAWordTemplateWithCharts() {
+        DocGen_Template__c tpl = makeWordChartTemplate();
+
+        Test.startTest();
+        Boolean result = DocGenChartImageController.hasChartTags(tpl.Id);
+        Test.stopTest();
+
+        // This probe is the gate DocGenBatch checks once per job. If it returns false
+        // for a template that DOES have charts, bulk silently keeps emitting the old
+        // "[Chart: rel.field]" text placeholders and the feature looks unshipped.
+        System.assertEquals(true, result, 'A Word template containing {Chart:} must be detected');
+    }
+
+    @IsTest
+    static void bulkBatchRendersChartTemplateWithoutLeakingChartCvs() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c tpl = makeWordChartTemplate();
+            DocGen_Job__c job = new DocGen_Job__c(
+                Template__c = tpl.Id,
+                Status__c = 'Queued',
+                Query_Condition__c = 'Name = \'DocGen Test Account\''
+            );
+            Database.insert(job, AccessLevel.SYSTEM_MODE);
+
+            Integer chartCvsBefore = [SELECT COUNT() FROM ContentVersion WHERE Title LIKE 'docgen_chart_%'];
+
+            Test.startTest();
+            Database.executeBatch(new DocGenBatch(job.Id), 1);
+            Test.stopTest();
+
+            // The batch owns the transient chart CVs it creates — deleteChartImages is
+            // caller-owned and no reaper watches a running batch. If the finally-block
+            // cleanup regresses, a long job accumulates N records x M charts of orphans.
+            System.assertEquals(
+                chartCvsBefore,
+                [SELECT COUNT() FROM ContentVersion WHERE Title LIKE 'docgen_chart_%'],
+                'Batch must reap every transient chart CV it created'
+            );
+        }
+    }
+
+    @IsTest
+    static void hasChartTagsIsFalseForTemplatesWithoutCharts() {
+        DocGen_Template__c t = TestDataFactory.getTestTemplate();
+
+        Test.startTest();
+        Boolean result = DocGenChartImageController.hasChartTags(t.Id);
+        Test.stopTest();
+
+        // The probe is what keeps DocGenBatch from spending a per-record SOQL proving
+        // a negative on the overwhelming majority of templates, which have no charts.
+        System.assertEquals(false, result, 'A template with no {Chart:} tags must report false');
+    }
+
+    @IsTest
+    static void chartCvIdsFromParsesTheCvIdOutOfTheDimensionSuffix() {
+        Id cvA = '068000000000001AAA';
+        Id cvB = '068000000000002AAA';
+
+        // chartCvMap values are `cvId|WxH` — the dimensions belong to the image markup,
+        // not the ContentVersion, and must not end up in a delete list.
+        List<Id> ids = DocGenChartImageController.chartCvIdsFrom(
+            new Map<String, String>{ 'sigA' => cvA + '|500x280', 'sigB' => String.valueOf(cvB) }
+        );
+
+        System.assertEquals(2, ids.size(), 'Both entries should yield a CV Id');
+        System.assertEquals(true, ids.contains(cvA), 'Should parse the Id ahead of the | separator');
+        System.assertEquals(true, ids.contains(cvB), 'Should accept a bare Id with no dimensions');
+    }
+
+    @IsTest
+    static void chartCvIdsFromToleratesMalformedEntries() {
+        // A malformed entry must not abort cleanup of the well-formed ones alongside it —
+        // otherwise one bad value leaks every chart CV in the record.
+        List<Id> ids = DocGenChartImageController.chartCvIdsFrom(
+            new Map<String, String>{ 'bad' => 'not-an-id', 'blank' => '', 'good' => '068000000000003AAA|100x100' }
+        );
+
+        System.assertEquals(1, ids.size(), 'Only the well-formed entry should be returned');
+        System.assertEquals(0, DocGenChartImageController.chartCvIdsFrom(null).size(), 'Null map returns empty');
+    }
+
+    // ─── Bulk vs single-record data-map parity ───────────────────────────
+    // The bulk retriever is a hand-written twin of getRecordDataV3, so anything
+    // the single path reads off a node has to be read here too. Divergences show
+    // up as conditionals that silently render nothing in bulk while working fine
+    // for one record — no error, just wrong output.
+
+    private static Map<String, Object> aliasedContactsConfig(String aliasValue, String limitValue) {
+        Map<String, Object> rootNode = new Map<String, Object>{
+            'id' => 'n0',
+            'object' => 'Account',
+            'parentNode' => null,
+            'fields' => new List<Object>{ 'Id', 'Name' },
+            'parentFields' => new List<Object>()
+        };
+        Map<String, Object> childNode = new Map<String, Object>{
+            'id' => 'n1',
+            'object' => 'Contact',
+            'parentNode' => 'n0',
+            'relationshipName' => 'Contacts',
+            'lookupField' => 'AccountId',
+            'fields' => new List<Object>{ 'Id', 'LastName' },
+            'parentFields' => new List<Object>()
+        };
+        if (aliasValue != null) {
+            childNode.put('alias', aliasValue);
+        }
+        if (limitValue != null) {
+            childNode.put('limit', limitValue);
+        }
+        return new Map<String, Object>{
+            'v' => 3,
+            'root' => 'Account',
+            'nodes' => new List<Object>{ rootNode, childNode }
+        };
+    }
+
+    /**
+     * Runs the bulk retriever and hands back one record's data map.
+     *
+     * The nested-generic return type lives here rather than in the test methods on
+     * purpose: the Apex compiler rejects a `Map<Id, Map<String, Object>>` LOCAL
+     * declaration in any method that also contains a brace collection initializer
+     * (`new Set<Id>{ ... }`) — it parses the `Map` as a variable and reports
+     * "Unexpected token 'Map'". Keeping the type in a signature sidesteps it.
+     */
+    private static Map<String, Object> bulkDataFor(Set<Id> recordIds, Map<String, Object> config, Id target) {
+        return DocGenDataRetriever.getRecordDataV3Bulk(recordIds, config).get(target);
+    }
+
+    @IsTest
+    static void testBulkRetrieverHonorsNodeAlias() {
+        Account acc = [SELECT Id FROM Account WHERE Name = 'DocGen Test Account' LIMIT 1];
+        Set<Id> ids = new Set<Id>{ acc.Id };
+
+        Test.startTest();
+        Map<String, Object> data = bulkDataFor(ids, aliasedContactsConfig('AllContacts', null), acc.Id);
+        Test.stopTest();
+
+        System.assertNotEquals(null, data, 'Bulk retriever should return data for the account');
+        // The alias is what {#AllContacts}…{/AllContacts} resolves against. Dropping it
+        // filed the collection under 'Contacts', so the loop tag resolved null and
+        // rendered nothing — and {^AllContacts} fired its inverse branch — in bulk only.
+        System.assertEquals(
+            true,
+            data.containsKey('AllContacts'),
+            'Child collection must be keyed by the node alias, matching getRecordDataV3'
+        );
+        System.assertEquals(
+            false,
+            data.containsKey('Contacts'),
+            'Aliased node must NOT also be filed under the raw relationship name'
+        );
+        Map<String, Object> block = (Map<String, Object>) data.get('AllContacts');
+        System.assertEquals(3, (Integer) block.get('totalSize'), 'All three contacts should be present');
+    }
+
+    @IsTest
+    static void testBulkRetrieverAppliesLimitPerRecordNotPerJob() {
+        Account first = [SELECT Id FROM Account WHERE Name = 'DocGen Test Account' LIMIT 1];
+        Account second = new Account(Name = 'DocGen Test Account 2');
+        insert second;
+        List<Contact> extra = new List<Contact>();
+        for (Integer i = 1; i <= 3; i++) {
+            extra.add(new Contact(FirstName = 'Second', LastName = 'Contact ' + i, AccountId = second.Id));
+        }
+        insert extra;
+
+        Set<Id> ids = new Set<Id>{ first.Id, second.Id };
+        Map<String, Object> config = aliasedContactsConfig('AllContacts', '2');
+
+        Test.startTest();
+        Map<String, Object> firstData = bulkDataFor(ids, config, first.Id);
+        Map<String, Object> secondData = bulkDataFor(ids, config, second.Id);
+        Test.stopTest();
+
+        // The authored LIMIT is per record. A bare `LIMIT 2` on the batch-wide query
+        // returned 2 rows for the WHOLE job, so the first account consumed them and the
+        // second got an empty collection — {#AllContacts} rendered nothing there and
+        // {^AllContacts} fired its inverse branch. Both records must now see their own 2.
+        Map<String, Object> firstBlock = (Map<String, Object>) firstData.get('AllContacts');
+        Map<String, Object> secondBlock = (Map<String, Object>) secondData.get('AllContacts');
+        System.assertEquals(
+            2,
+            (Integer) firstBlock.get('totalSize'),
+            'First record should get its own LIMIT 2, not share one across the job'
+        );
+        System.assertEquals(
+            2,
+            (Integer) secondBlock.get('totalSize'),
+            'Second record must not be starved by the first consuming the whole LIMIT'
+        );
+    }
+
+    @IsTest
+    static void testBulkRetrieverRejectsDuplicateSiblingKeys() {
+        Account acc = [SELECT Id FROM Account WHERE Name = 'DocGen Test Account' LIMIT 1];
+        Map<String, Object> config = aliasedContactsConfig(null, null);
+        // A second, differently-filtered node over the same relationship with no alias —
+        // both would write to the 'Contacts' key and the second would silently win.
+        List<Object> nodes = (List<Object>) config.get('nodes');
+        nodes.add(
+            new Map<String, Object>{
+                'id' => 'n2',
+                'object' => 'Contact',
+                'parentNode' => 'n0',
+                'relationshipName' => 'Contacts',
+                'lookupField' => 'AccountId',
+                'fields' => new List<Object>{ 'Id' },
+                'parentFields' => new List<Object>()
+            }
+        );
+
+        Test.startTest();
+        String message = null;
+        try {
+            DocGenDataRetriever.getRecordDataV3Bulk(new Set<Id>{ acc.Id }, config);
+        } catch (DocGenException e) {
+            message = e.getMessage();
+        }
+        Test.stopTest();
+
+        System.assertNotEquals(null, message, 'Bulk should raise the same duplicate-key guard as single-record');
+        System.assertEquals(
+            true,
+            message.contains('Duplicate loop key'),
+            'Guard message should match getRecordDataV3: ' + message
+        );
+    }
+
     @IsTest
     static void testGetBulkTemplates() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];

--- a/force-app/main/default/classes/DocGenChartCvReaper.cls
+++ b/force-app/main/default/classes/DocGenChartCvReaper.cls
@@ -1,0 +1,84 @@
+/**
+ * Deletes orphaned transient chart ContentVersions.
+ *
+ * Chart rasterization uploads one `docgen_chart_*` ContentVersion per chart as a
+ * render input, and the CALLER owns cleanup. The interactive runner reaps its own
+ * in a finally; so does DocGenBatch. But a caller that dies mid-flow — an uncaught
+ * limit exception, a killed batch, a browser tab closed between upload and
+ * generate — leaves its CVs behind with nothing watching them.
+ *
+ * That was tolerable while the only producer was a human clicking Generate. Once
+ * bulk generation rasterizes per record, the failure mode scales with the job:
+ * N records x M charts of orphaned files. This is the backstop.
+ *
+ * Only reaps CVs older than the age threshold, so it can never delete one that a
+ * render is actively using — a chart CV's useful life is a single transaction.
+ *
+ * Schedule hourly:
+ *   System.schedule('DocGen Chart CV Reaper', '0 0 * * * ?', new DocGenChartCvReaper());
+ */
+global with sharing class DocGenChartCvReaper implements Schedulable { // NOPMD AvoidGlobalModifier — global so subscribers can schedule it in a managed package
+    private static final String CV_TITLE_PREFIX = 'docgen_chart_';
+
+    // Chart CVs live for one transaction. An hour is far beyond any legitimate
+    // render, including a batch chunk running at the async CPU ceiling, while
+    // still keeping orphans short-lived.
+    @TestVisible
+    private static final Integer ORPHAN_AGE_MINUTES = 60;
+
+    // Batch-friendly cap. A single scheduled run reaps at most this many; the next
+    // run picks up the rest rather than risking the DML row limit in one pass.
+    @TestVisible
+    private static final Integer MAX_PER_RUN = 500;
+
+    global void execute(SchedulableContext ctx) {
+        reap();
+    }
+
+    /**
+     * Deletes orphaned chart CVs. Returns the number of ContentDocuments removed.
+     * Separated from execute() so tests and ad-hoc admin runs can call it directly.
+     */
+    global static Integer reap() {
+        DateTime cutoff = System.now().addMinutes(-ORPHAN_AGE_MINUTES);
+        String titlePattern = CV_TITLE_PREFIX + '%';
+
+        // SYSTEM_MODE: these are package-internal render artifacts whose
+        // ContentDocumentLinks default to Visibility=InternalUsers, which USER_MODE
+        // reads silently drop (the #114 quirk) — a USER_MODE query here would report
+        // "nothing to clean up" while orphans piled up.
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title', 'ContentDocumentId' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<ContentVersion> orphans = [
+            SELECT ContentDocumentId
+            FROM ContentVersion
+            WHERE Title LIKE :titlePattern AND CreatedDate < :cutoff AND IsLatest = TRUE
+            WITH SYSTEM_MODE
+            LIMIT :MAX_PER_RUN
+        ];
+        if (orphans.isEmpty()) {
+            return 0;
+        }
+
+        // Delete the ContentDocument, not the ContentVersion — deleting the version
+        // of a single-version document is not permitted.
+        Set<Id> docIds = new Set<Id>();
+        for (ContentVersion cv : orphans) {
+            if (cv.ContentDocumentId != null) {
+                docIds.add(cv.ContentDocumentId);
+            }
+        }
+        if (docIds.isEmpty()) {
+            return 0;
+        }
+
+        List<ContentDocument> docs = [SELECT Id FROM ContentDocument WHERE Id IN :docIds WITH SYSTEM_MODE];
+        if (docs.isEmpty()) {
+            return 0;
+        }
+        // Partial-success delete: one undeletable document (locked by another
+        // transaction, already reaped concurrently) must not block the rest.
+        Database.delete(docs, false, AccessLevel.SYSTEM_MODE); // NOPMD ApexCRUDViolation — package-internal transient render artifacts
+        return docs.size();
+    }
+}

--- a/force-app/main/default/classes/DocGenChartCvReaper.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenChartCvReaper.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenChartCvReaperTest.cls
+++ b/force-app/main/default/classes/DocGenChartCvReaperTest.cls
@@ -1,0 +1,73 @@
+// CxSAST: Test class — SOQL/DML findings are test data operations, not production code paths
+@IsTest
+private class DocGenChartCvReaperTest {
+    @TestSetup
+    static void setup() {
+        TestDataFactory.assignAdminPermissionSet();
+    }
+
+    private static ContentVersion makeChartCv(String suffix) {
+        ContentVersion cv = new ContentVersion(
+            Title = 'docgen_chart_' + suffix,
+            PathOnClient = 'chart.png',
+            VersionData = Blob.valueOf('fake-png-bytes')
+        );
+        Database.insert(cv, AccessLevel.SYSTEM_MODE);
+        return cv;
+    }
+
+    @IsTest
+    static void freshChartCvsAreLeftAlone() {
+        makeChartCv('fresh1');
+        makeChartCv('fresh2');
+
+        Test.startTest();
+        Integer reaped = DocGenChartCvReaper.reap();
+        Test.stopTest();
+
+        // A CV created seconds ago may still be an in-flight render input. Reaping it
+        // would blank the chart in a document that is mid-generation.
+        System.assertEquals(0, reaped, 'Chart CVs younger than the age threshold must not be reaped');
+        System.assertEquals(
+            2,
+            [SELECT COUNT() FROM ContentVersion WHERE Title LIKE 'docgen_chart_%'],
+            'Both fresh chart CVs should survive'
+        );
+    }
+
+    @IsTest
+    static void nonChartFilesAreNeverTouched() {
+        ContentVersion keep = new ContentVersion(
+            Title = 'CustomerContract',
+            PathOnClient = 'contract.pdf',
+            VersionData = Blob.valueOf('not-a-chart')
+        );
+        Database.insert(keep, AccessLevel.SYSTEM_MODE);
+
+        Test.startTest();
+        DocGenChartCvReaper.reap();
+        Test.stopTest();
+
+        // The reaper deletes ContentDocuments. Scoping it to the docgen_chart_ prefix
+        // is the only thing standing between it and a customer's real files.
+        System.assertEquals(
+            1,
+            [SELECT COUNT() FROM ContentVersion WHERE Title = 'CustomerContract'],
+            'A file without the docgen_chart_ prefix must never be reaped'
+        );
+    }
+
+    @IsTest
+    static void schedulableEntryPointRuns() {
+        Test.startTest();
+        String cron = System.schedule('DocGen Chart CV Reaper Test', '0 0 0 1 1 ? 2099', new DocGenChartCvReaper());
+        Test.stopTest();
+
+        System.assertNotEquals(null, cron, 'Reaper should be schedulable');
+        System.assertEquals(
+            1,
+            [SELECT COUNT() FROM CronTrigger WHERE Id = :cron],
+            'A CronTrigger should exist for the scheduled reaper'
+        );
+    }
+}

--- a/force-app/main/default/classes/DocGenChartCvReaperTest.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenChartCvReaperTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenChartImageController.cls
+++ b/force-app/main/default/classes/DocGenChartImageController.cls
@@ -139,6 +139,66 @@ public with sharing class DocGenChartImageController {
      * `prepareChartImages`.
      */
     @AuraEnabled
+    /**
+     * Cheap "is it even worth calling prepareChartImagesServerSide?" probe.
+     *
+     * Exists for batch callers. prepareChartImagesServerSide has to load the active
+     * template body to find chart tags, and in a bulk job that is a per-record SOQL
+     * spent proving a negative on the overwhelming majority of templates, which have
+     * no charts at all. A batch resolves this ONCE and skips the whole path when false.
+     *
+     * Same template-type and tag-presence rules as the real call, so a true here means
+     * the real call will actually do work.
+     */
+    public static Boolean hasChartTags(Id templateId) {
+        if (templateId == null) {
+            return false;
+        }
+        DocGenFlsGuard.assertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Type__c' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Template__c> templates = [
+            SELECT Id, Type__c
+            FROM DocGen_Template__c
+            WHERE Id = :templateId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (templates.isEmpty()) {
+            return false;
+        }
+        String t = templates[0].Type__c;
+        if (t != 'Word' && t != 'HTML' && t != 'PowerPoint') {
+            return false;
+        }
+        String body = loadActiveBody(t, templateId);
+        return String.isNotBlank(body) && body.contains(CHART_OPEN_PREFIX);
+    }
+
+    /**
+     * Extracts the ContentVersion Ids from a chartCvMap so a caller can reap them.
+     * Values are `cvId|WxH`; the dimensions are for the image markup, not the CV.
+     */
+    public static List<Id> chartCvIdsFrom(Map<String, String> chartCvMap) {
+        List<Id> ids = new List<Id>();
+        if (chartCvMap == null) {
+            return ids;
+        }
+        for (String v : chartCvMap.values()) {
+            if (String.isBlank(v)) {
+                continue;
+            }
+            String rawId = v.contains('|') ? v.substringBefore('|') : v;
+            try {
+                ids.add(Id.valueOf(rawId));
+            } catch (Exception ignored) {
+                // Malformed entry — nothing to reap, and a bad Id must not abort cleanup
+                // of the well-formed ones alongside it.
+                continue;
+            }
+        }
+        return ids;
+    }
+
     public static Map<String, String> prepareChartImagesServerSide(Id templateId, Id recordId) {
         if (templateId == null || recordId == null) {
             throw DocGenService.ahe('Template and record IDs are required.');

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -3267,6 +3267,44 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
      * Returns the same shape lightning-file-upload produces so the rest of
      * the LWC save flow (Save as New Version → saveTemplate) is unchanged.
      */
+    /**
+     * Does this HTML carry anything an author would be sorry to lose?
+     *
+     * Used only to decide whether a save is a legitimate edit or an accidental wipe,
+     * so it errs toward "yes" — anything structural (an image, a table, a merge tag)
+     * counts even with no visible text, and only a genuinely blank document or the
+     * Designer's own seed placeholder returns false. A false positive here costs
+     * nothing; a false negative would let a body get overwritten.
+     */
+    @TestVisible
+    private static Boolean hasSubstantiveHtml(String html) {
+        if (String.isBlank(html)) {
+            return false;
+        }
+        // Drop head/style/script FIRST. A CSS rule body (`p{color:red}`) is textually
+        // indistinguishable from a merge tag, so checking for tags before stripping
+        // made every styled-but-empty document look like it had content.
+        String cleaned = html.replaceAll('(?is)<(head|style|script)\\b[^>]*>.*?</\\1\\s*>', ' ');
+
+        // Structural content counts regardless of text.
+        String lower = cleaned.toLowerCase();
+        if (lower.contains('<img') || lower.contains('<table') || lower.contains('<svg')) {
+            return true;
+        }
+        // A merge tag is authored content even if the document is otherwise bare.
+        if (Pattern.compile('\\{[#^/%@]?[A-Za-z_][^}]*\\}').matcher(cleaned).find()) {
+            return true;
+        }
+        String text = cleaned.replaceAll('(?s)<[^>]*>', ' ');
+        text = text.replaceAll('&nbsp;|&#160;', ' ').replaceAll('\\s+', ' ').trim();
+        if (String.isBlank(text)) {
+            return false;
+        }
+        // The Designer's seed copy for a blank canvas is not authored content — if it
+        // is all that is being saved, the editor never loaded a real body.
+        return !text.startsWithIgnoreCase('Start typing your document here');
+    }
+
     @AuraEnabled
     public static Map<String, Object> saveHtmlTemplateBody(Id templateId, String fileName, String htmlContent) {
         if (templateId == null) {
@@ -3299,6 +3337,33 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         }
         if (tpls[0].Type__c != 'HTML') {
             throw new DocGenException('saveHtmlTemplateBody is for HTML-type templates only.');
+        }
+
+        // Refuse to overwrite a real body with an empty one.
+        //
+        // The Designer seeds a placeholder scaffold ("Start typing your document
+        // here…") whenever the stored body reads back blank. That is correct for a
+        // genuinely new template — but when a READ failure made an existing body look
+        // blank, hitting Save wrote the placeholder straight over the author's work.
+        // That is exactly what the non-admin file-access bug did: the canvas came up
+        // empty for everyone without View All Data, and one Save destroyed the body.
+        //
+        // The read is fixed, but this is the guard that makes the failure mode
+        // non-destructive for good: no future read bug, permission gap, or race can
+        // turn "I couldn't load it" into "I deleted it". Deliberately server-side so
+        // it holds for every caller, not just the Designer.
+        if (!hasSubstantiveHtml(htmlContent)) {
+            List<ContentVersion> existing = DocGenService.loadInternalContentVersionsForVersionByTitlePrefix(
+                templateId,
+                'docgen_html_body_'
+            );
+            if (!existing.isEmpty() && hasSubstantiveHtml(existing[0].VersionData.toString())) {
+                throw new DocGenException(
+                    'This would replace the saved template body with an empty document, so it was not saved. ' +
+                        'If the editor opened blank, close it and reopen the template — the body is still stored. ' +
+                        'To intentionally start over, add some content first, then save.'
+                );
+            }
         }
 
         String pathBase = String.isBlank(fileName) ? 'body' : fileName.substringBeforeLast('.');

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -1,6 +1,10 @@
 public with sharing class DocGenController { // NOPMD ExcessivePublicCount — controller requires public methods for AuraEnabled endpoints
     private static Id cachedTemplateId;
     private static Map<String, Object> cachedTemplateEnvelope;
+    // Whether the cached template opts into Classic Approval history. Cached
+    // alongside the envelope so the per-record injection below doesn't re-read
+    // Query_Config__c for every record in a bulk batch.
+    private static Boolean cachedNeedsApprovals = false;
 
     // v1.97 — Render-time snapshot lookup. The active version snapshots the
     // render-affecting fields at save time (Output_Format, Header_Html,
@@ -291,11 +295,25 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                     ? snap.Custom_Margins__c
                     : template.Custom_Margins__c
             };
+            cachedNeedsApprovals = DocGenApprovalHistory.queryConfigMentionsApprovals(template.Query_Config__c);
             cachedTemplateId = templateId;
         }
 
         // Clone envelope and inject this record's data
         Map<String, Object> result = cachedTemplateEnvelope.clone();
+
+        // Issue #66 parity — generateDocumentData injects Approvals, this cached
+        // twin did not, so {#Approvals}…{/Approvals} resolved null and rendered
+        // empty in bulk only (and {^Approvals} fired its inverse branch). The
+        // approval history is per-record and can't come from the batch data cache,
+        // so it is loaded here; still opt-in, so templates that don't ask for it
+        // pay nothing.
+        if (cachedNeedsApprovals == true && cachedRecordData != null) {
+            Object recId = cachedRecordData.get('Id');
+            if (recId != null) {
+                cachedRecordData.put('Approvals', DocGenApprovalHistory.load((Id) String.valueOf(recId)));
+            }
+        }
         result.put('data', cachedRecordData);
         return result;
     }
@@ -1533,7 +1551,17 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                                 'object' => n.get('object'),
                                 'lookupField' => n.get('lookupField'),
                                 'fields' => n.get('fields'),
-                                'parentFields' => n.get('parentFields')
+                                'parentFields' => n.get('parentFields'),
+                                // The V1 branch below emits where/orderBy/limit; this one did
+                                // not, and docGenRunner reads `serverChildNode.orderBy` to drive
+                                // the client-side giant DOCX cursor. Omitting it silently fell
+                                // back to unsorted, so a V3-config template rendered its child
+                                // rows in arbitrary order while the identical V1 config sorted
+                                // correctly. Also the reason a multi-column ORDER BY appeared
+                                // to be ignored on that path.
+                                'where' => n.get('where'),
+                                'orderBy' => n.get('orderBy'),
+                                'limit' => n.get('limit')
                             }
                         );
                     }
@@ -1733,20 +1761,32 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 throw new DocGenException('Invalid ORDER BY clause: disallowed keyword.');
             }
         }
-        // Parse ORDER BY fields and validate each against Schema field describe
+        // Parse ORDER BY fields and validate each against Schema field describe.
+        // Splitting on ',' means a multi-column clause ("Amount DESC, Name ASC") is
+        // validated column by column. Kept deliberately in step with
+        // DocGenDataRetriever.sanitizeClause — the two ran different rules, and this
+        // one lacked the standard-relationship fallback, so a clause mixing a standard
+        // lookup ("Product2.Name, Name") passed in the sync path and threw only here,
+        // on the client-side giant DOCX path.
         for (String part : orderByClause.split(',')) {
             String fieldName = part.trim().split('\\s+')[0].toLowerCase();
             // Handle relationship fields like Product2.Name — validate the relationship prefix
             String baseField = fieldName.contains('.') ? fieldName.split('\\.')[0] : fieldName;
-            if (!fieldMap.containsKey(baseField)) {
-                // Try with __r → __c conversion for custom relationship fields
-                String asLookup = baseField.endsWith('__r')
-                    ? baseField.substring(0, baseField.length() - 3) + '__c'
-                    : baseField;
-                if (!fieldMap.containsKey(asLookup)) {
-                    throw new DocGenException('Invalid field in ORDER BY: ' + fieldName);
-                }
+            if (fieldMap.containsKey(baseField)) {
+                continue;
             }
+            // Custom relationship: My_Lookup__r → My_Lookup__c
+            String asCustomLookup = baseField.endsWith('__r')
+                ? baseField.substring(0, baseField.length() - 3) + '__c'
+                : null;
+            if (asCustomLookup != null && fieldMap.containsKey(asCustomLookup)) {
+                continue;
+            }
+            // Standard relationship: Account → AccountId, Product2 → Product2Id, Owner → OwnerId
+            if (fieldMap.containsKey(baseField + 'id')) {
+                continue;
+            }
+            throw new DocGenException('Invalid field in ORDER BY: ' + fieldName);
         }
 
         // Sanitize WHERE clause if provided
@@ -3194,20 +3234,15 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             throw DocGenService.ahe('Template not found or access denied.');
         }
 
-        String titlePrefix = 'docgen_html_img_' + templateId + '%';
-        DocGenFlsGuard.assertAccessible(
-            ContentVersion.sObjectType,
-            new Set<String>{ 'Title', 'PathOnClient', 'IsLatest' }
+        // CDL-scoped for the same reason as getHtmlTemplateBody — a title-only query
+        // returns nothing for any user who doesn't own the files, so this rendered an
+        // empty image picker for everyone except a System Administrator. Metadata-only
+        // variant: pulling VersionData would load every image blob into heap just to
+        // render a list.
+        List<ContentVersion> cvs = DocGenService.loadInternalContentVersionMetaForEntityByTitlePrefix(
+            templateId,
+            'docgen_html_img_'
         );
-        /* code-analyzer-suppress ApexFlsViolation */
-        List<ContentVersion> cvs = [
-            SELECT Id, PathOnClient
-            FROM ContentVersion
-            WHERE Title LIKE :titlePrefix AND IsLatest = TRUE
-            WITH SYSTEM_MODE
-            ORDER BY CreatedDate DESC
-            LIMIT 50
-        ];
         List<Map<String, Object>> results = new List<Map<String, Object>>();
         for (ContentVersion cv : cvs) {
             results.add(
@@ -3333,16 +3368,23 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             throw new DocGenException('getHtmlTemplateBody is for HTML-type templates only.');
         }
 
-        String titlePrefix = 'docgen_html_body_' + templateId + '%';
-        /* code-analyzer-suppress ApexFlsViolation */
-        List<ContentVersion> cvs = [
-            SELECT VersionData
-            FROM ContentVersion
-            WHERE Title LIKE :titlePrefix AND IsLatest = TRUE
-            WITH SYSTEM_MODE
-            ORDER BY CreatedDate DESC, Id DESC
-            LIMIT 1
-        ];
+        // Scope the read by the template's linked documents, NOT by a bare Title LIKE.
+        //
+        // File access is not governed by Apex sharing keywords or WITH SYSTEM_MODE.
+        // Measured on a Standard User holding DocGen_Admin: they could read the
+        // template (1 row) and its ContentDocumentLink (1 row), but a title-only
+        // ContentVersion query returned ZERO in user mode, in SYSTEM_MODE, and from a
+        // `without sharing` class alike. Resolving ContentDocumentIds from the link
+        // first returns the row.
+        //
+        // A System Administrator has View All Data and never hit this, so the Designer
+        // canvas always populated for whoever built the template and came up BLANK for
+        // every other user — silently, with no toast and no console error, regardless
+        // of which permission set they held.
+        List<ContentVersion> cvs = DocGenService.loadInternalContentVersionsForVersionByTitlePrefix(
+            templateId,
+            'docgen_html_body_'
+        );
         if (cvs.isEmpty()) {
             return null;
         }
@@ -7077,11 +7119,22 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             if (!tmpl.Versions__r.isEmpty()) {
                 ver = tmpl.Versions__r[0];
                 if (String.isNotBlank(ver.Content_Version_Id__c)) {
+                    // FLS-guard + SYSTEM_MODE, NOT USER_MODE. Template-internal CVs
+                    // (docgen_html_body_*, the uploaded template file) carry
+                    // ContentDocumentLinks that default to Visibility=InternalUsers,
+                    // which USER_MODE reads silently drop — the #114 quirk. Under
+                    // USER_MODE this returned empty and the export produced a bundle
+                    // with NO body at all, so the clone was created blank with no error.
+                    DocGenFlsGuard.assertAccessible(
+                        ContentVersion.sObjectType,
+                        new Set<String>{ 'VersionData', 'FileExtension', 'Title' }
+                    );
+                    /* code-analyzer-suppress ApexFlsViolation */
                     List<ContentVersion> cvs = [
                         SELECT VersionData, FileExtension, Title
                         FROM ContentVersion
                         WHERE Id = :ver.Content_Version_Id__c
-                        WITH USER_MODE
+                        WITH SYSTEM_MODE
                         LIMIT 1 // NOPMD — internal template file read
                     ];
                     if (!cvs.isEmpty()) {
@@ -7110,6 +7163,26 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             assetCvIds.addAll(extractShepherdCvIds(tmpl.Header_Html__c));
             assetCvIds.addAll(extractShepherdCvIds(tmpl.Footer_Html__c));
             assetCvIds.addAll(extractShepherdCvIds(htmlBodyText));
+
+            // Also sweep in every image the Designer's picker knows about, whether or
+            // not the current body happens to reference it. Scanning only for shepherd
+            // URLs missed images that were uploaded but not (yet) placed, or placed via
+            // a URL form the regex doesn't match — so a clone silently lost them and the
+            // author had to re-upload. Same title convention listHtmlTemplateImages uses.
+            if (tmpl.Type__c == 'HTML') {
+                String imgPrefix = 'docgen_html_img_' + templateId + '%';
+                DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title', 'IsLatest' });
+                /* code-analyzer-suppress ApexFlsViolation */
+                for (ContentVersion imgCv : [
+                    SELECT Id
+                    FROM ContentVersion
+                    WHERE Title LIKE :imgPrefix AND IsLatest = TRUE
+                    WITH SYSTEM_MODE
+                    LIMIT 200
+                ]) {
+                    assetCvIds.add(imgCv.Id);
+                }
+            }
             Id watermarkCvId = null;
             if (ver != null && String.isNotBlank(ver.Watermark_Image_CV_Id__c)) {
                 try {
@@ -7120,12 +7193,18 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 }
             }
             if (!assetCvIds.isEmpty()) {
+                // SYSTEM_MODE for the same #114 reason as the template-file read above —
+                // these CVs are linked to the template with Visibility=InternalUsers.
+                DocGenFlsGuard.assertAccessible(
+                    ContentVersion.sObjectType,
+                    new Set<String>{ 'Title', 'FileExtension', 'VersionData' }
+                );
                 /* code-analyzer-suppress ApexFlsViolation */
                 List<ContentVersion> assetCvs = [
                     SELECT Id, Title, FileExtension, VersionData
                     FROM ContentVersion
                     WHERE Id IN :assetCvIds
-                    WITH USER_MODE
+                    WITH SYSTEM_MODE
                 ]; // NOPMD ApexCRUDViolation — referenced by template content; gated by template access
                 List<Map<String, Object>> assets = new List<Map<String, Object>>();
                 for (ContentVersion cv : assetCvs) {
@@ -7167,6 +7246,32 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
      * version, and triggers image extraction / pre-decomposition.
      * @return The new template record ID
      */
+    /**
+     * Rewrites a Designer image asset's title so it points at the importing org's
+     * template instead of the source template.
+     *
+     * `listHtmlTemplateImages` finds a template's images purely by the
+     * `docgen_html_img_<templateId>_` title prefix — there is no ContentDocumentLink
+     * scoping — so a copied asset that keeps its original title is invisible to the
+     * new template and simultaneously shows up (duplicated) under the old one.
+     * Titles that don't follow the convention are left alone.
+     */
+    @TestVisible
+    private static String retitleHtmlImageAsset(String originalTitle, Id newTemplateId, String originalCvId) {
+        if (String.isBlank(originalTitle)) {
+            return 'asset_' + originalCvId;
+        }
+        if (!originalTitle.startsWith('docgen_html_img_')) {
+            return originalTitle;
+        }
+        // docgen_html_img_<15-or-18-char templateId>_<remainder>
+        Matcher m = Pattern.compile('^docgen_html_img_[a-zA-Z0-9]{15,18}_').matcher(originalTitle);
+        if (!m.find()) {
+            return originalTitle;
+        }
+        return 'docgen_html_img_' + newTemplateId + '_' + originalTitle.substring(m.end());
+    }
+
     @AuraEnabled
     public static Id importTemplate(String jsonData) {
         try {
@@ -7247,7 +7352,12 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                     String fileName = (String) asset.get('fileName');
                     String ext = (String) asset.get('fileExtension');
                     ContentVersion acv = new ContentVersion();
-                    acv.Title = String.isNotBlank(fileName) ? fileName : ('asset_' + origId);
+                    // Re-key Designer image assets to the NEW template. Their titles encode
+                    // the source template Id (docgen_html_img_<templateId>_<ts>_<name>) and
+                    // listHtmlTemplateImages matches on that prefix alone, with no parent
+                    // scoping — so copying the title verbatim left the clone's image picker
+                    // empty AND polluted the SOURCE template's picker with the duplicates.
+                    acv.Title = retitleHtmlImageAsset(fileName, tmpl.Id, origId);
                     acv.PathOnClient = acv.Title + (String.isNotBlank(ext) ? ('.' + ext) : '');
                     acv.VersionData = EncodingUtil.base64Decode(b64);
                     acv.FirstPublishLocationId = tmpl.Id;
@@ -7283,7 +7393,14 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             String cvId = null;
             if (fileData != null && String.isNotBlank((String) fileData.get('base64'))) {
                 ContentVersion cv = new ContentVersion();
-                cv.Title = tmpl.Name;
+                // HTML bodies MUST keep the docgen_html_body_<templateId>_<ts> convention:
+                // getHtmlTemplateBody finds the body by that title prefix, so titling it
+                // tmpl.Name meant an imported/cloned HTML template rendered fine but opened
+                // with a BLANK Designer canvas — and the first Save wrote that blank back
+                // over the real body.
+                cv.Title = tmpl.Type__c == 'HTML'
+                    ? 'docgen_html_body_' + tmpl.Id + '_' + Datetime.now().getTime()
+                    : tmpl.Name;
                 cv.PathOnClient = tmpl.Name + '.' + (String) fileData.get('fileExtension');
                 Blob bodyBytes = EncodingUtil.base64Decode((String) fileData.get('base64'));
                 // For HTML templates, rewrite embedded shepherd URLs in the body
@@ -7319,6 +7436,19 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             ver.Description__c = (String) tmplData.get('Description__c');
             ver.Type__c = (String) tmplData.get('Type__c');
             ver.Base_Object_API__c = (String) tmplData.get('Base_Object_API__c');
+            // saveTemplate snapshots these four onto every version it creates; import
+            // did not, so the imported version was an incomplete render snapshot. It
+            // matters twice over: the renderer prefers version values over template
+            // values, and activateVersion pushes version fields BACK onto the template —
+            // so re-activating an imported version blanked the template's output format,
+            // header, footer, and title format.
+            ver.Output_Format__c = (String) tmplData.get('Output_Format__c');
+            // Read header/footer off tmpl, NOT tmplData — step 1.6 already rewrote their
+            // shepherd URLs to the newly-inserted CV Ids. The raw bundle values still
+            // point at the SOURCE org's CVs and would render broken images.
+            ver.Header_Html__c = tmpl.Header_Html__c;
+            ver.Footer_Html__c = tmpl.Footer_Html__c;
+            ver.Document_Title_Format__c = (String) tmplData.get('Document_Title_Format__c');
             // Snapshot page-setup onto the version so the renderer reads the imported
             // settings instead of the org-default field values (the A4 → Letter bug).
             ver.Page_Orientation__c = (String) tmplData.get('Page_Orientation__c');
@@ -7347,7 +7477,11 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                     'Page_Size__c',
                     'Page_Margins__c',
                     'Custom_Margins__c',
-                    'Watermark_Image_CV_Id__c'
+                    'Watermark_Image_CV_Id__c',
+                    'Output_Format__c',
+                    'Header_Html__c',
+                    'Footer_Html__c',
+                    'Document_Title_Format__c'
                 }
             );
             /* code-analyzer-suppress ApexFlsViolation */

--- a/force-app/main/default/classes/DocGenControllerTests.cls
+++ b/force-app/main/default/classes/DocGenControllerTests.cls
@@ -4200,6 +4200,354 @@ private class DocGenControllerTests {
     }
 
     // =======================================================================
+    // Designer body load as a NON-ADMIN
+    //
+    // A System Administrator has View All Data and sees every file regardless of how
+    // it is linked, so the Designer canvas always populated for whoever built it. Every
+    // other user — including one holding DocGen_Admin — got an empty body and a blank
+    // canvas. Reproducing it requires System.runAs against a real Standard User.
+    // =======================================================================
+
+    private static User createStandardUserWithDocGenAdmin() {
+        Profile p = [SELECT Id FROM Profile WHERE Name = 'Standard User' LIMIT 1];
+        User u = new User(
+            Username = 'dgdesigner' + System.now().getTime() + '@docgen.test',
+            Email = 'dgdesigner@example.com',
+            FirstName = 'DocGen',
+            LastName = 'DesignerTester',
+            Alias = 'dgdes',
+            ProfileId = p.Id,
+            TimeZoneSidKey = 'America/New_York',
+            LocaleSidKey = 'en_US',
+            EmailEncodingKey = 'UTF-8',
+            LanguageLocaleKey = 'en_US'
+        );
+        insert u;
+        List<PermissionSet> ps = [SELECT Id FROM PermissionSet WHERE Name = 'DocGen_Admin' LIMIT 1];
+        if (!ps.isEmpty()) {
+            insert new PermissionSetAssignment(AssigneeId = u.Id, PermissionSetId = ps[0].Id);
+        }
+        return u;
+    }
+
+    @IsTest
+    static void designerBodyLoadsForNonAdminWithDocGenAdmin() {
+        User stdUser;
+        // User DML is a setup object — isolate it from the template/CV DML below.
+        System.runAs(new User(Id = UserInfo.getUserId())) {
+            stdUser = createStandardUserWithDocGenAdmin();
+        }
+
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'Designer NonAdmin Tpl',
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF'
+        );
+        Database.insert(tpl, AccessLevel.SYSTEM_MODE);
+        ContentVersion cv = new ContentVersion(
+            Title = 'docgen_html_body_' + tpl.Id + '_' + System.now().getTime(),
+            PathOnClient = 'body.html',
+            VersionData = Blob.valueOf('<html><body><p>SENTINEL_BODY {Name}</p></body></html>'),
+            FirstPublishLocationId = tpl.Id
+        );
+        Database.insert(cv, AccessLevel.SYSTEM_MODE);
+
+        String body;
+        Test.startTest();
+        System.runAs(stdUser) {
+            body = DocGenController.getHtmlTemplateBody(tpl.Id);
+        }
+        Test.stopTest();
+
+        // The Designer's whole canvas is this string. Null here IS the blank canvas —
+        // it fails silently, with no toast and no console error, so the only symptom a
+        // user reports is "the template is blank".
+        System.assertNotEquals(null, body, 'A non-admin with DocGen_Admin must be able to read the template body');
+        System.assertEquals(true, body.contains('SENTINEL_BODY'), 'Body should be the stored HTML, got: ' + body);
+    }
+
+    @IsTest
+    static void designerImagePickerListsForNonAdminWithDocGenAdmin() {
+        User stdUser;
+        System.runAs(new User(Id = UserInfo.getUserId())) {
+            stdUser = createStandardUserWithDocGenAdmin();
+        }
+
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'Designer NonAdmin Images',
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF'
+        );
+        Database.insert(tpl, AccessLevel.SYSTEM_MODE);
+        ContentVersion img = new ContentVersion(
+            Title = 'docgen_html_img_' + tpl.Id + '_' + System.now().getTime() + '_logo.png',
+            PathOnClient = 'logo.png',
+            VersionData = Blob.valueOf('PNGBYTES'),
+            FirstPublishLocationId = tpl.Id
+        );
+        Database.insert(img, AccessLevel.SYSTEM_MODE);
+
+        List<Map<String, Object>> images;
+        Test.startTest();
+        System.runAs(stdUser) {
+            images = DocGenController.listHtmlTemplateImages(tpl.Id);
+        }
+        Test.stopTest();
+
+        // Same failure mode one surface over: an empty image picker rather than a blank
+        // canvas. Both read package-internal CVs the running user does not own.
+        System.assertEquals(1, images.size(), 'A non-admin with DocGen_Admin must see the template images');
+    }
+
+    // =======================================================================
+    // Multi-column sorting
+    //
+    // ORDER BY is stored as a raw clause, so "Amount DESC, Name ASC" is already
+    // expressible — but two consumers mishandled it: the giant-path validator
+    // rejected standard relationship fields that the sync path accepted, and the
+    // V3 branch of scoutChildCounts dropped orderBy entirely.
+    // =======================================================================
+
+    @IsTest
+    static void getSortedChildIdsAcceptsMultiColumnOrderBy() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            Opportunity opp = [SELECT Id FROM Opportunity WHERE Name = 'DocGen Test Opp' LIMIT 1];
+
+            Test.startTest();
+            // Product2.Name is a STANDARD relationship traversal — resolved via
+            // Product2Id. The validator here only had the custom __r → __c fallback,
+            // so this threw "Invalid field in ORDER BY" on the client giant path while
+            // the identical clause worked everywhere else.
+            List<Id> ids = DocGenController.getSortedChildIds(
+                'OpportunityLineItem',
+                'OpportunityId',
+                opp.Id,
+                'Product2.Name ASC, Quantity DESC',
+                null
+            );
+            Test.stopTest();
+
+            System.assertNotEquals(null, ids, 'Multi-column ORDER BY with a standard lookup must be accepted');
+        }
+    }
+
+    @IsTest
+    static void getSortedChildIdsStillRejectsUnknownSortFields() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            Opportunity opp = [SELECT Id FROM Opportunity WHERE Name = 'DocGen Test Opp' LIMIT 1];
+
+            Test.startTest();
+            String message = null;
+            try {
+                DocGenController.getSortedChildIds(
+                    'OpportunityLineItem',
+                    'OpportunityId',
+                    opp.Id,
+                    'Quantity DESC, NotARealField__c ASC',
+                    null
+                );
+            } catch (Exception e) {
+                message = e.getMessage();
+            }
+            Test.stopTest();
+
+            // Loosening the lookup fallbacks must not loosen the allowlist itself —
+            // every column is still validated, including ones after the first.
+            System.assertNotEquals(null, message, 'An unknown sort column must still be rejected');
+            System.assertEquals(
+                true,
+                message.toLowerCase().contains('order by'),
+                'Rejection should name the ORDER BY clause: ' + message
+            );
+        }
+    }
+
+    @IsTest
+    static void scoutChildCountsExposesV3SortToTheClient() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            Account acc = TestDataFactory.getTestAccount();
+            DocGen_Template__c tpl = TestDataFactory.getTestTemplate();
+            tpl.Base_Object_API__c = 'Account';
+            tpl.Query_Config__c =
+                '{"v":3,"root":"Account","nodes":[' +
+                '{"id":"n0","object":"Account","parentNode":null,"fields":["Id","Name"],"parentFields":[]},' +
+                '{"id":"n1","object":"Contact","parentNode":"n0","relationshipName":"Contacts",' +
+                '"lookupField":"AccountId","fields":["Id","LastName"],"parentFields":[],' +
+                '"orderBy":"LastName ASC, CreatedDate DESC","limit":"25"}]}';
+            Database.update(tpl, AccessLevel.SYSTEM_MODE);
+
+            Test.startTest();
+            Map<String, Object> scout = DocGenController.scoutChildCounts(acc.Id, tpl.Id);
+            Test.stopTest();
+
+            Map<String, Object> nodes = (Map<String, Object>) scout.get('childNodes');
+            Map<String, Object> contacts = (Map<String, Object>) nodes.get('Contacts');
+            System.assertNotEquals(null, contacts, 'Scout should describe the Contacts child node');
+            // docGenRunner reads serverChildNode.orderBy to drive the client-side giant
+            // DOCX cursor. The V3 branch omitted it (the V1 branch did not), so V3
+            // templates silently rendered child rows unsorted.
+            System.assertEquals(
+                'LastName ASC, CreatedDate DESC',
+                (String) contacts.get('orderBy'),
+                'V3 scout must pass the multi-column sort through to the client'
+            );
+            System.assertEquals('25', (String) contacts.get('limit'), 'V3 scout must pass the limit through');
+        }
+    }
+
+    // =======================================================================
+    // Clone / import of HTML templates — the associated-files contract
+    //
+    // An HTML template's body and its Designer images live in ContentVersions
+    // whose TITLES encode the owning template Id. getHtmlTemplateBody and
+    // listHtmlTemplateImages find them by that title prefix alone — there is no
+    // ContentDocumentLink scoping — so a copy that keeps the source titles is
+    // invisible to the new template and leaks into the old one.
+    // =======================================================================
+
+    private static DocGen_Template__c createHtmlTemplateWithBodyAndImage() {
+        DocGen_Template__c src = new DocGen_Template__c(
+            Name = 'HTML Clone Source',
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF',
+            Document_Title_Format__c = 'Doc-{Name}',
+            Header_Html__c = '<div>hdr</div>',
+            Footer_Html__c = '<div>ftr</div>'
+        );
+        Database.insert(src, AccessLevel.SYSTEM_MODE);
+
+        DocGenController.saveHtmlTemplateImage(src.Id, 'logo.png', EncodingUtil.base64Encode(Blob.valueOf('PNGBYTES')));
+        Map<String, Object> saved = DocGenController.saveHtmlTemplateBody(
+            src.Id,
+            'body.html',
+            '<html><body><p>Hello {Name}</p></body></html>'
+        );
+
+        DocGen_Template_Version__c v = new DocGen_Template_Version__c(
+            Template__c = src.Id,
+            Is_Active__c = true,
+            Type__c = 'HTML',
+            Base_Object_API__c = 'Account',
+            Query_Config__c = 'Name',
+            Content_Version_Id__c = (Id) saved.get('contentVersionId')
+        );
+        Database.insert(v, AccessLevel.SYSTEM_MODE);
+        return src;
+    }
+
+    @IsTest
+    static void clonedHtmlTemplateOpensInDesignerWithItsBody() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c src = createHtmlTemplateWithBodyAndImage();
+
+            Test.startTest();
+            Id cloneId = DocGenController.cloneTemplate(src.Id, 'HTML Clone Copy');
+            Test.stopTest();
+
+            // The whole bug: the clone rendered fine but the Designer canvas was blank,
+            // because the body CV was titled after the template name instead of
+            // docgen_html_body_<templateId>_<ts>. The first Save then wrote the blank back.
+            String body = DocGenController.getHtmlTemplateBody(cloneId);
+            System.assertNotEquals(null, body, 'Cloned HTML template must expose its body to the Designer');
+            System.assertEquals(
+                true,
+                body.contains('Hello {Name}'),
+                'Cloned body should be the source body, got: ' + body
+            );
+        }
+    }
+
+    @IsTest
+    static void clonedHtmlTemplateCarriesItsImagesAndLeavesTheSourceAlone() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c src = createHtmlTemplateWithBodyAndImage();
+            Integer sourceImagesBefore = DocGenController.listHtmlTemplateImages(src.Id).size();
+            System.assertEquals(1, sourceImagesBefore, 'Source should start with exactly one Designer image');
+
+            Test.startTest();
+            Id cloneId = DocGenController.cloneTemplate(src.Id, 'HTML Clone Copy');
+            Test.stopTest();
+
+            System.assertEquals(
+                1,
+                DocGenController.listHtmlTemplateImages(cloneId).size(),
+                'Clone must own a copy of the Designer image'
+            );
+            // The second half of the bug: because the copied asset kept the source
+            // template Id in its title, it also showed up under the SOURCE template.
+            System.assertEquals(
+                sourceImagesBefore,
+                DocGenController.listHtmlTemplateImages(src.Id).size(),
+                'Cloning must not pollute the source template image picker with duplicates'
+            );
+        }
+    }
+
+    @IsTest
+    static void importedVersionCarriesTheFullRenderSnapshot() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c src = createHtmlTemplateWithBodyAndImage();
+
+            Test.startTest();
+            Id cloneId = DocGenController.cloneTemplate(src.Id, 'HTML Clone Snapshot');
+            Test.stopTest();
+
+            DocGen_Template_Version__c v = [
+                SELECT Output_Format__c, Header_Html__c, Footer_Html__c, Document_Title_Format__c
+                FROM DocGen_Template_Version__c
+                WHERE Template__c = :cloneId AND Is_Active__c = TRUE
+                LIMIT 1
+            ];
+            // The renderer prefers version values over template values, and
+            // activateVersion pushes version fields BACK onto the template — so these
+            // being null made the imported version an incomplete snapshot that could
+            // blank the template on re-activation.
+            System.assertEquals('PDF', v.Output_Format__c, 'Version must snapshot Output_Format__c');
+            System.assertEquals('Doc-{Name}', v.Document_Title_Format__c, 'Version must snapshot the title format');
+            System.assertNotEquals(null, v.Header_Html__c, 'Version must snapshot Header_Html__c');
+            System.assertNotEquals(null, v.Footer_Html__c, 'Version must snapshot Footer_Html__c');
+        }
+    }
+
+    @IsTest
+    static void retitleHtmlImageAssetRekeysOnlyConventionalTitles() {
+        Id newTemplateId = TestDataFactory.getTestTemplate().Id;
+        String oldId = 'a00000000000001AAA';
+
+        String rekeyed = DocGenController.retitleHtmlImageAsset(
+            'docgen_html_img_' + oldId + '_1700000000000_logo.png',
+            newTemplateId,
+            '068000000000001AAA'
+        );
+        System.assertEquals(
+            'docgen_html_img_' + newTemplateId + '_1700000000000_logo.png',
+            rekeyed,
+            'Conventional titles should be re-keyed to the new template, preserving the trailing name'
+        );
+
+        // A watermark or header image is not a Designer picker asset — leave it be.
+        System.assertEquals(
+            'company-logo.png',
+            DocGenController.retitleHtmlImageAsset('company-logo.png', newTemplateId, '068000000000001AAA'),
+            'Non-conventional titles must pass through untouched'
+        );
+        System.assertEquals(
+            'asset_068000000000001AAA',
+            DocGenController.retitleHtmlImageAsset(null, newTemplateId, '068000000000001AAA'),
+            'Blank titles keep the existing asset_<cvId> fallback'
+        );
+    }
+
+    // =======================================================================
     // NEW COVERAGE TESTS — exportTemplate
     // =======================================================================
 

--- a/force-app/main/default/classes/DocGenControllerTests.cls
+++ b/force-app/main/default/classes/DocGenControllerTests.cls
@@ -4230,6 +4230,142 @@ private class DocGenControllerTests {
         return u;
     }
 
+    // =======================================================================
+    // Blank-save guard
+    //
+    // The Designer seeds a placeholder scaffold whenever the stored body reads back
+    // blank. That is right for a new template and catastrophic when a READ failure
+    // made an existing body look blank — one Save wrote the placeholder over the
+    // author's work. This guard makes that failure mode non-destructive regardless of
+    // why the read came back empty.
+    // =======================================================================
+
+    private static DocGen_Template__c htmlTemplateWithBody(String bodyHtml) {
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'Blank Guard Tpl ' + System.now().getTime(),
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF'
+        );
+        Database.insert(tpl, AccessLevel.SYSTEM_MODE);
+        ContentVersion cv = new ContentVersion(
+            Title = 'docgen_html_body_' + tpl.Id + '_' + System.now().getTime(),
+            PathOnClient = 'body.html',
+            VersionData = Blob.valueOf(bodyHtml),
+            FirstPublishLocationId = tpl.Id
+        );
+        Database.insert(cv, AccessLevel.SYSTEM_MODE);
+        return tpl;
+    }
+
+    @IsTest
+    static void savingThePlaceholderOverARealBodyIsRefused() {
+        DocGen_Template__c tpl = htmlTemplateWithBody(
+            '<html><body><h1>Quarterly Report</h1><p>{Name}</p></body></html>'
+        );
+        // Byte-for-byte what the Designer seeds when it thinks the template is new.
+        String placeholder =
+            '<!DOCTYPE html><html><head><style>@page { size: Letter portrait; }</style></head>' +
+            '<body><p>Start typing your document here — or drag in blocks, tags, and images from the rail.</p></body></html>';
+
+        Test.startTest();
+        String message = null;
+        try {
+            DocGenController.saveHtmlTemplateBody(tpl.Id, 'body.html', placeholder);
+        } catch (Exception e) {
+            message = e.getMessage();
+        }
+        Test.stopTest();
+
+        System.assertNotEquals(null, message, 'Saving the seed placeholder over a real body must be refused');
+        System.assertEquals(
+            true,
+            message.contains('empty document'),
+            'Error should explain what was prevented: ' + message
+        );
+        // And the stored body must be untouched.
+        String stored = DocGenController.getHtmlTemplateBody(tpl.Id);
+        System.assertEquals(true, stored.contains('Quarterly Report'), 'The original body must survive the refusal');
+    }
+
+    @IsTest
+    static void savingAnEmptyDocumentOverARealBodyIsRefused() {
+        DocGen_Template__c tpl = htmlTemplateWithBody('<html><body><p>Real content {Name}</p></body></html>');
+
+        Test.startTest();
+        String message = null;
+        try {
+            DocGenController.saveHtmlTemplateBody(tpl.Id, 'body.html', '<html><body></body></html>');
+        } catch (Exception e) {
+            message = e.getMessage();
+        }
+        Test.stopTest();
+
+        System.assertNotEquals(null, message, 'An empty document must not overwrite a real body');
+    }
+
+    @IsTest
+    static void guardDoesNotBlockLegitimateEditsOrNewTemplates() {
+        // A real edit must still save.
+        DocGen_Template__c tpl = htmlTemplateWithBody('<html><body><p>Old {Name}</p></body></html>');
+        Map<String, Object> saved = DocGenController.saveHtmlTemplateBody(
+            tpl.Id,
+            'body.html',
+            '<html><body><p>New content {Name}</p></body></html>'
+        );
+        System.assertNotEquals(null, saved.get('contentVersionId'), 'A normal edit must save');
+
+        // A brand-new template has no body to protect — seeding the placeholder is
+        // exactly what should happen, and blocking it would break template creation.
+        DocGen_Template__c fresh = new DocGen_Template__c(
+            Name = 'Blank Guard Fresh ' + System.now().getTime(),
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF'
+        );
+        Database.insert(fresh, AccessLevel.SYSTEM_MODE);
+        Map<String, Object> seeded = DocGenController.saveHtmlTemplateBody(
+            fresh.Id,
+            'body.html',
+            '<html><body><p>Start typing your document here — or drag in blocks.</p></body></html>'
+        );
+        System.assertNotEquals(null, seeded.get('contentVersionId'), 'Seeding a brand-new template must be allowed');
+    }
+
+    @IsTest
+    static void hasSubstantiveHtmlCountsStructuralContent() {
+        // No visible text, but losing any of these would be a real loss — the guard
+        // must err toward "this is content".
+        System.assertEquals(true, DocGenController.hasSubstantiveHtml('<body><img src="x.png" /></body>'), 'image');
+        System.assertEquals(
+            true,
+            DocGenController.hasSubstantiveHtml('<body><table><tr><td></td></tr></table></body>'),
+            'table'
+        );
+        System.assertEquals(
+            true,
+            DocGenController.hasSubstantiveHtml('<body><p>{#Lines}{Name}{/Lines}</p></body>'),
+            'merge tags'
+        );
+
+        // And these are genuinely nothing.
+        System.assertEquals(false, DocGenController.hasSubstantiveHtml(null), 'null');
+        System.assertEquals(false, DocGenController.hasSubstantiveHtml('   '), 'whitespace');
+        System.assertEquals(false, DocGenController.hasSubstantiveHtml('<html><body></body></html>'), 'empty body');
+        System.assertEquals(
+            false,
+            DocGenController.hasSubstantiveHtml('<html><head><style>p{color:red}</style></head><body> </body></html>'),
+            'style-only is not author content'
+        );
+        System.assertEquals(
+            false,
+            DocGenController.hasSubstantiveHtml(
+                '<body><p>Start typing your document here — or drag in blocks.</p></body>'
+            ),
+            'the seed placeholder is not author content'
+        );
+    }
+
     @IsTest
     static void designerBodyLoadsForNonAdminWithDocGenAdmin() {
         User stdUser;

--- a/force-app/main/default/classes/DocGenDataRetriever.cls
+++ b/force-app/main/default/classes/DocGenDataRetriever.cls
@@ -737,6 +737,12 @@ public with sharing class DocGenDataRetriever {
             tn.parentNodeId = (String) n.get('parentNode');
             tn.lookupField = (String) n.get('lookupField');
             tn.relationshipName = (String) n.get('relationshipName');
+            // Must mirror getRecordDataV3. dataMapKey() is alias ?? relationshipName,
+            // and it is the key the child block is stitched under. Dropping alias here
+            // filed the collection under the relationship name, so an aliased loop tag
+            // ({#OpenCases} over a Cases node) resolved null in bulk only — rendering
+            // nothing for {#…}, and firing the inverse branch for {^…}, with no error.
+            tn.alias = (String) n.get('alias');
             tn.whereClause = (String) n.get('where');
             tn.orderByClause = (String) n.get('orderBy');
             tn.limitClause = (String) n.get('limit');
@@ -785,6 +791,24 @@ public with sharing class DocGenDataRetriever {
         }
         if (root == null) {
             throw new DocGenException('No root node found in query tree.');
+        }
+        // Same sibling-uniqueness guard as getRecordDataV3. Without it, two aliased
+        // filtered subsets of one relationship collapse to the same data-map key and
+        // the second silently overwrites the first — in bulk only.
+        Set<String> seenKeysPerParent = new Set<String>();
+        for (TreeNode tn : allNodes) {
+            if (tn.parentNodeId == null) {
+                continue;
+            }
+            String key = tn.parentNodeId + '::' + tn.dataMapKey();
+            if (seenKeysPerParent.contains(key)) {
+                throw new DocGenException(
+                    'Duplicate loop key under same parent: ' +
+                        tn.dataMapKey() +
+                        '. Set a unique alias on each filtered subset.'
+                );
+            }
+            seenKeysPerParent.add(key);
         }
 
         // Bulk root query: SELECT fields FROM object WHERE Id IN :recordIds
@@ -1081,6 +1105,10 @@ public with sharing class DocGenDataRetriever {
                 child.objectApiName == 'ProcessInstanceWorkitem';
 
             List<SObject> childResults;
+            // Set only on the flat-query branch below, where the authored per-record
+            // LIMIT has to be re-applied in memory after grouping. The ProcessInstance
+            // branch uses a correlated subquery, whose LIMIT is already per-parent.
+            Integer perParentLimit = null;
             if (isProcessInstanceChild) {
                 String piQuery =
                     'SELECT Id, (SELECT ' +
@@ -1131,7 +1159,32 @@ public with sharing class DocGenDataRetriever {
                         childQuery += ' ORDER BY ' + sanitizeClause(child.orderByClause, 'ORDER BY', bulkChildFieldMap);
                     }
                     if (String.isNotBlank(child.limitClause)) {
-                        childQuery += ' LIMIT ' + sanitizeClause(child.limitClause, 'LIMIT');
+                        String safeLimit = sanitizeClause(child.limitClause, 'LIMIT');
+                        Integer authored = null;
+                        try {
+                            authored = Integer.valueOf(safeLimit.trim());
+                        } catch (Exception parseIgnored) {
+                            authored = null;
+                        }
+                        if (authored != null && authored > 0) {
+                            // The authored LIMIT is PER RECORD. Unlike the single-record path
+                            // — where parentIds holds exactly one Id, so LIMIT n is naturally
+                            // per record — this query spans every record in the batch. A bare
+                            // LIMIT n returned n rows for the WHOLE job: the first parents
+                            // consumed them all and every other record got an empty collection,
+                            // so {#Children} rendered nothing and {^Children} fired its inverse
+                            // branch.
+                            //
+                            // No flat SOQL LIMIT can express "n per parent" — scaling it to
+                            // n × parentCount still starves a skewed set, because one parent
+                            // with more than n children eats the surplus. So the clause is
+                            // dropped from the query and re-applied per parent after grouping.
+                            // This fetches no more rows than a child node with NO limit clause
+                            // already fetches on this same path, so it adds no new ceiling risk.
+                            perParentLimit = authored;
+                        } else {
+                            childQuery += ' LIMIT ' + safeLimit;
+                        }
                     }
 
                     childResults = Database.query(childQuery, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection — all dynamic elements allowlist-validated against Schema.describeSObjects() field map; USER_MODE enforced
@@ -1147,6 +1200,13 @@ public with sharing class DocGenDataRetriever {
                 Id parentRecId = (Id) rec.get(child.lookupField);
                 if (!grouped.containsKey(parentRecId)) {
                     grouped.put(parentRecId, new List<Map<String, Object>>());
+                }
+                // Re-apply the authored per-record LIMIT. The query's ORDER BY survives
+                // grouping — a global sort keeps the correct relative order inside each
+                // parent's bucket — so taking the first n per parent yields the same rows
+                // the single-record path would have returned.
+                if (perParentLimit != null && grouped.get(parentRecId).size() >= perParentLimit) {
+                    continue;
                 }
                 grouped.get(parentRecId).add(mapSObject(rec));
             }

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -163,7 +163,50 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         return new PreDecompXmlLoader().loadForLinkedEntityByTitlePrefix(versionId, titlePrefix);
     }
 
+    /**
+     * Metadata-only, CDL-scoped file listing — no VersionData.
+     *
+     * For listing a template's files (the Designer's image picker) rather than reading
+     * one. Pulling VersionData for every image would load every blob into heap just to
+     * render a list of links.
+     *
+     * MUST be scoped by ContentDocumentId, not by a bare Title LIKE. Measured on a
+     * Standard User holding DocGen_Admin: the user could read the template (1 row) and
+     * its ContentDocumentLink (1 row), but a title-only ContentVersion query returned
+     * ZERO in user mode, in SYSTEM_MODE, and from a `without sharing` class alike —
+     * file access is not governed by Apex sharing keywords. Resolving the document Ids
+     * from the link first returns the rows. See loadForLinkedEntityByTitlePrefix.
+     */
+    public static List<ContentVersion> loadInternalContentVersionMetaForEntityByTitlePrefix(
+        Id linkedEntityId,
+        String titlePrefix
+    ) {
+        return new PreDecompXmlLoader().loadMetaForLinkedEntityByTitlePrefix(linkedEntityId, titlePrefix);
+    }
+
     private without sharing class PreDecompXmlLoader {
+        /** Id / Title / PathOnClient only, scoped to one record's linked documents. */
+        public List<ContentVersion> loadMetaForLinkedEntityByTitlePrefix(Id linkedEntityId, String titlePrefix) {
+            Set<Id> docIds = getLinkedContentDocumentIds(linkedEntityId);
+            if (docIds.isEmpty()) {
+                return new List<ContentVersion>();
+            }
+            String likePattern = titlePrefix + '%';
+            DocGenFlsGuard.assertAccessible(
+                ContentVersion.sObjectType,
+                new Set<String>{ 'ContentDocumentId', 'Title', 'PathOnClient', 'IsLatest' }
+            );
+            /* code-analyzer-suppress ApexFlsViolation */
+            return [
+                SELECT Id, Title, PathOnClient
+                FROM ContentVersion
+                WHERE ContentDocumentId IN :docIds AND Title LIKE :likePattern AND IsLatest = TRUE
+                WITH SYSTEM_MODE // NOPMD — package-internal template assets
+                ORDER BY CreatedDate DESC
+                LIMIT 50
+            ];
+        }
+
         public List<ContentVersion> loadByTitlePrefix(String titlePrefix) {
             String likePattern = titlePrefix + '%';
             DocGenFlsGuard.assertAccessible(
@@ -3429,6 +3472,22 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             );
         }
 
+        // PowerPoint and Excel have no DOCX→HTML conversion. Before this guard they
+        // fell through to the Word branch below, which looks for word/document.xml,
+        // found nothing, and returned empty HTML — so a combined-PDF bulk job over a
+        // PPTX or XLSX template produced a PDF of blank pages with no error at all.
+        // (generateDocument catches this via validateOutputFormatOverride, but that
+        // runs on the individual-file path only; this method calls mergeTemplate with
+        // a hardcoded 'PDF' and never passes through it.)
+        if (mr.templateType == 'PowerPoint' || mr.templateType == 'Excel') {
+            throw new DocGenException(
+                mr.templateType +
+                    ' templates cannot be combined into a single PDF. Run the bulk job as Individual Files to get one ' +
+                    (mr.templateType == 'Excel' ? '.xlsx' : '.pptx') +
+                    ' per record.'
+            );
+        }
+
         // HTML template type: mr.documentXml is already a ready-to-render HTML
         // document — skip the DOCX→HTML conversion (which would return empty
         // since there are no DOCX processedXmlEntries for HTML templates).
@@ -5219,14 +5278,24 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         if (parent == null || !parent.containsKey('__docgenPicklistLabels')) {
             return fallback;
         }
-        Map<String, String> labels = (Map<String, String>) parent.get('__docgenPicklistLabels');
+        // Read as Map<String,Object>, NOT Map<String,String>. The bulk path serializes
+        // the whole data map to JSON for the batch data cache (DocGenBatch.buildDataCache)
+        // and re-hydrates it with JSON.deserializeUntyped, which reconstitutes every
+        // nested map as Map<String,Object>. The stricter cast threw
+        // "Invalid conversion from runtime type Map<String,ANY> to Map<String,String>"
+        // for any template using {Field:label} — a hard failure in bulk only.
+        // Map<String,Object> accepts both the live and the round-tripped shape.
+        Map<String, Object> labels = (Map<String, Object>) parent.get('__docgenPicklistLabels');
+        if (labels == null) {
+            return fallback;
+        }
         String leaf = path.contains('.') ? path.substringAfterLast('.') : path;
         if (labels.containsKey(leaf)) {
-            return labels.get(leaf);
+            return labels.get(leaf) == null ? fallback : String.valueOf(labels.get(leaf));
         }
         for (String key : labels.keySet()) {
             if (key.equalsIgnoreCase(leaf)) {
-                return labels.get(key);
+                return labels.get(key) == null ? fallback : String.valueOf(labels.get(key));
             }
         }
         return fallback;

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -10907,7 +10907,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                         }
                         only.remove();
                     }
-                } else if (cell.innerHTML.trim()) {
+                    // "Does this cell hold anything?" via childNodes rather than
+                    // innerHTML — same predicate as the allWrapped check above, and it
+                    // keeps @lwc/lwc/no-inner-html quiet. textContent is NOT equivalent:
+                    // a cell holding only an <img> has empty text but is not empty.
+                } else if (Array.from(cell.childNodes).some((n) => n.nodeType !== 3 || n.nodeValue.trim())) {
                     const el = (cell.ownerDocument || document).createElement(tag);
                     while (cell.firstChild) {
                         el.appendChild(cell.firstChild);

--- a/force-app/main/default/lwc/docGenBulkRunner/docGenBulkRunner.html
+++ b/force-app/main/default/lwc/docGenBulkRunner/docGenBulkRunner.html
@@ -93,11 +93,12 @@
                                     Pick a record to preview what your document will look like before running the bulk
                                     job.
                                 </p>
-                                <template if:true={baseObject}>
+                                <template for:each={recordPickerKeys} for:item="rp">
                                     <lightning-record-picker
+                                        key={rp.key}
                                         label="Sample Record"
                                         variant="label-hidden"
-                                        object-api-name={baseObject}
+                                        object-api-name={rp.objectApiName}
                                         value={sampleRecordId}
                                         onchange={handleSampleRecordChange}
                                         placeholder="Search for a record..."

--- a/force-app/main/default/lwc/docGenBulkRunner/docGenBulkRunner.js
+++ b/force-app/main/default/lwc/docGenBulkRunner/docGenBulkRunner.js
@@ -151,6 +151,19 @@ export default class DocGenBulkRunner extends NavigationMixin(LightningElement) 
         return this.selectedTemplateId && this.sampleRecordId;
     }
 
+    /**
+     * Single-item list used to key the sample-record picker by base object.
+     *
+     * lightning-record-picker reads object-api-name at construction. Because the
+     * picker lives inside an if:true={baseObject} that stays true across a template
+     * switch, LWC reused the same instance and it kept searching the PREVIOUS
+     * template's object. Iterating a list keyed on baseObject forces a real teardown
+     * and rebuild whenever the object changes.
+     */
+    get recordPickerKeys() {
+        return this.baseObject ? [{ key: this.baseObject, objectApiName: this.baseObject }] : [];
+    }
+
     handleSampleRecordChange(event) {
         this.sampleRecordId = event.detail.recordId;
     }
@@ -177,6 +190,10 @@ export default class DocGenBulkRunner extends NavigationMixin(LightningElement) 
             this.recordCount = null;
             this.analysis = null;
             this.filterValidated = false;
+            // The sample record belongs to the PREVIOUS template's base object. Left in
+            // place it kept the Preview button enabled against a record of the wrong
+            // sObject type, and handed the record picker a value it cannot resolve.
+            this.sampleRecordId = '';
             this.loadSavedQueries();
             this.applyAutoFilter();
         }
@@ -324,6 +341,9 @@ export default class DocGenBulkRunner extends NavigationMixin(LightningElement) 
             this.recordCount = null;
             this.analysis = null;
             this.filterValidated = false;
+            // See handleTemplateSelect — a stale sample record from the previous
+            // template's object must not survive the switch.
+            this.sampleRecordId = '';
             this.loadSavedQueries();
             this.applyAutoFilter();
         }

--- a/force-app/main/default/lwc/docGenTreeNode/docGenTreeNode.html
+++ b/force-app/main/default/lwc/docGenTreeNode/docGenTreeNode.html
@@ -346,15 +346,6 @@
                     >
                     </lightning-input>
                     <lightning-input
-                        label="Sort by"
-                        variant="label-inline"
-                        placeholder="e.g. CreatedDate DESC"
-                        value={nodeOrderBy}
-                        onchange={handleOrderByChange}
-                        style="flex: 1; min-width: 120px"
-                    >
-                    </lightning-input>
-                    <lightning-input
                         label="Limit"
                         variant="label-inline"
                         type="number"
@@ -364,6 +355,71 @@
                         style="flex: 0 0 70px"
                     >
                     </lightning-input>
+                </div>
+
+                <!-- ═══ Sort — one row per column, applied in order ═══ -->
+                <div style="margin-top: 8px">
+                    <template for:each={sortRows} for:item="sr">
+                        <div
+                            key={sr.key}
+                            style="display: flex; gap: 8px; align-items: end; margin-bottom: 4px; flex-wrap: wrap"
+                        >
+                            <lightning-combobox
+                                label={sr.positionLabel}
+                                variant="label-inline"
+                                placeholder="Choose a field"
+                                data-index={sr.index}
+                                value={sr.field}
+                                options={sr.fieldOptions}
+                                onchange={handleSortFieldChange}
+                                style="flex: 2; min-width: 170px"
+                            >
+                            </lightning-combobox>
+                            <lightning-combobox
+                                label="Order"
+                                variant="label-hidden"
+                                data-index={sr.index}
+                                value={sr.direction}
+                                options={sr.directionOptions}
+                                onchange={handleSortDirectionChange}
+                                style="flex: 1; min-width: 150px"
+                            >
+                            </lightning-combobox>
+                            <lightning-button-icon
+                                icon-name="utility:up"
+                                variant="bare"
+                                size="small"
+                                data-index={sr.index}
+                                alternative-text={sr.moveUpLabel}
+                                title={sr.moveUpLabel}
+                                disabled={sr.isFirst}
+                                onclick={handleMoveSortUp}
+                            >
+                            </lightning-button-icon>
+                            <lightning-button-icon
+                                icon-name="utility:delete"
+                                variant="bare"
+                                size="small"
+                                data-index={sr.index}
+                                alternative-text={sr.removeLabel}
+                                title={sr.removeLabel}
+                                onclick={handleRemoveSort}
+                            >
+                            </lightning-button-icon>
+                        </div>
+                    </template>
+                    <lightning-button
+                        variant="base"
+                        icon-name="utility:add"
+                        label="Add sort column"
+                        onclick={handleAddSort}
+                    >
+                    </lightning-button>
+                    <template lwc:if={hasSortRows}>
+                        <p class="slds-text-body_small slds-text-color_weak" style="margin-top: 2px">
+                            Rows are sorted by the first column; later columns break ties.
+                        </p>
+                    </template>
                 </div>
             </template>
         </div>

--- a/force-app/main/default/lwc/docGenTreeNode/docGenTreeNode.js
+++ b/force-app/main/default/lwc/docGenTreeNode/docGenTreeNode.js
@@ -13,6 +13,10 @@ export default class DocGenTreeNode extends LightningElement {
 
     @track _pickerOpen = false;
     @track _pickerSearch = '';
+    // Sort rows the user has added but not yet chosen a field for. These can't live
+    // in the ORDER BY clause string — an empty column serializes to nothing — so
+    // they're held as local UI state until a field is picked.
+    _blankSortRows = 0;
 
     // ── Field picker ────────────────────────────────────────────
     togglePicker() {
@@ -131,14 +135,96 @@ export default class DocGenTreeNode extends LightningElement {
             })
         );
     }
-    handleOrderByChange(event) {
+    // ── Multi-column sort ───────────────────────────────────────
+    // Storage stays a single SOQL ORDER BY clause string ("Amount DESC, Name ASC").
+    // Every Apex consumer already splits that on commas, so multi-column needs no
+    // schema change — only an editor that can express more than one column. These
+    // handlers parse the clause into rows, mutate one row, and re-serialize.
+
+    handleSortFieldChange(event) {
+        const rows = this._sortRowsRaw();
+        const i = parseInt(event.target.dataset.index, 10);
+        if (i >= rows.length) {
+            rows.push({ field: event.detail.value, direction: 'ASC' });
+            if (this._blankSortRows > 0) this._blankSortRows -= 1;
+        } else {
+            rows[i].field = event.detail.value;
+        }
+        this._emitOrderBy(this._serializeSortRows(rows));
+    }
+
+    handleSortDirectionChange(event) {
+        const rows = this._sortRowsRaw();
+        const i = parseInt(event.target.dataset.index, 10);
+        // Direction on a not-yet-chosen column has nothing to attach to; ignore it
+        // rather than emitting a clause the user didn't ask for.
+        if (i >= rows.length) return;
+        rows[i].direction = event.detail.value;
+        this._emitOrderBy(this._serializeSortRows(rows));
+    }
+
+    handleAddSort() {
+        this._blankSortRows += 1;
+    }
+
+    handleRemoveSort(event) {
+        const rows = this._sortRowsRaw();
+        const i = parseInt(event.target.dataset.index, 10);
+        if (i >= rows.length) {
+            if (this._blankSortRows > 0) this._blankSortRows -= 1;
+            return;
+        }
+        rows.splice(i, 1);
+        this._emitOrderBy(this._serializeSortRows(rows));
+    }
+
+    handleMoveSortUp(event) {
+        const rows = this._sortRowsRaw();
+        const i = parseInt(event.target.dataset.index, 10);
+        if (i > 0 && i < rows.length) {
+            [rows[i - 1], rows[i]] = [rows[i], rows[i - 1]];
+            this._emitOrderBy(this._serializeSortRows(rows));
+        }
+    }
+
+    _emitOrderBy(value) {
         this.dispatchEvent(
             new CustomEvent('clausechange', {
                 bubbles: true,
                 composed: true, // NOPMD — composed required for recursive tree node events
-                detail: { path: this.nodeData.path, field: 'orderBy', value: event.target.value }
+                detail: { path: this.nodeData.path, field: 'orderBy', value }
             })
         );
+    }
+
+    /**
+     * Splits the stored clause into {field, direction} pairs.
+     *
+     * Anything after the field token is kept verbatim as the direction so clauses
+     * the picker can't model (e.g. "NULLS LAST") survive an edit to a sibling row
+     * instead of being silently dropped.
+     */
+    _sortRowsRaw() {
+        const clause = this.nodeData && this.nodeData.orderBy ? this.nodeData.orderBy : '';
+        if (!clause.trim()) return [];
+        return clause
+            .split(',')
+            .map((part) => part.trim())
+            .filter((part) => part)
+            .map((part) => {
+                const tokens = part.split(/\s+/);
+                return {
+                    field: tokens[0],
+                    direction: tokens.slice(1).join(' ').toUpperCase() || 'ASC'
+                };
+            });
+    }
+
+    _serializeSortRows(rows) {
+        return rows
+            .filter((r) => r.field)
+            .map((r) => `${r.field} ${r.direction || 'ASC'}`.trim())
+            .join(', ');
     }
     handleLimitChange(event) {
         this.dispatchEvent(
@@ -148,6 +234,64 @@ export default class DocGenTreeNode extends LightningElement {
                 detail: { path: this.nodeData.path, field: 'limitAmount', value: event.target.value }
             })
         );
+    }
+
+    // ── Multi-column sort getters ───────────────────────────────
+
+    get sortDirectionOptions() {
+        return [
+            { label: 'A → Z', value: 'ASC' },
+            { label: 'Z → A', value: 'DESC' },
+            { label: 'A → Z, blanks last', value: 'ASC NULLS LAST' },
+            { label: 'Z → A, blanks last', value: 'DESC NULLS LAST' }
+        ];
+    }
+
+    /**
+     * Every field on this node, whether or not it's selected for output — you can
+     * legitimately sort by a column you don't render.
+     */
+    get sortFieldOptions() {
+        if (!this.nodeData || !this.nodeData.fields) return [];
+        return this.nodeData.fields
+            .map((f) => ({ label: f.displayLabel || f.apiName, value: f.apiName }))
+            .sort((a, b) => a.label.localeCompare(b.label));
+    }
+
+    get sortRows() {
+        const options = this.sortFieldOptions;
+        const known = new Set(options.map((o) => o.value));
+        const rows = this._sortRowsRaw();
+        for (let n = 0; n < this._blankSortRows; n++) {
+            rows.push({ field: '', direction: 'ASC' });
+        }
+        const directions = this.sortDirectionOptions.map((d) => d.value);
+        return rows.map((r, i) => {
+            // A hand-authored clause may reference a relationship field (Product2.Name)
+            // or a field not in this node's list. Surface it as its own option rather
+            // than letting the combobox render blank and lose it on the next save.
+            const fieldOptions =
+                known.has(r.field) || !r.field ? options : [{ label: r.field, value: r.field }, ...options];
+            const directionOptions = directions.includes(r.direction)
+                ? this.sortDirectionOptions
+                : [{ label: r.direction, value: r.direction }, ...this.sortDirectionOptions];
+            return {
+                key: `sort-${i}`,
+                index: i,
+                field: r.field,
+                direction: r.direction,
+                fieldOptions,
+                directionOptions,
+                isFirst: i === 0,
+                positionLabel: i === 0 ? 'Sort by' : 'then by',
+                removeLabel: `Remove sort column ${i + 1}`,
+                moveUpLabel: `Move sort column ${i + 1} earlier`
+            };
+        });
+    }
+
+    get hasSortRows() {
+        return this.sortRows.length > 0;
     }
 
     // ── Template getters ────────────────────────────────────────

--- a/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
@@ -9,6 +9,34 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DocGenAiTemplateController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DocGenAiHtmlValidator</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DocGenChartImageController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DocGenChartCvReaper</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DocGenFlsGuard</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DocGenFieldWritebackService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DocGenSignaturePdfFlowAction</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DocGenEmailTemplateController</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
@@ -8,6 +8,27 @@
         <apexClass>BarcodeGenerator</apexClass>
         <enabled>true</enabled>
     </classAccesses>
+    <!-- AI template authoring (DocGenAiTemplateController / DocGenAiHtmlValidator) is
+         deliberately NOT granted here. Only docGenAdmin imports it, and the Designer is
+         an admin surface — DocGen_User has no Template Manager tab and read-only access
+         to DocGen_Template__c. DocGenChartImageController IS needed: docGenRunner imports
+         it to rasterize charts, and a missing Apex import blanks the whole component. -->
+    <classAccesses>
+        <apexClass>DocGenChartImageController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DocGenFlsGuard</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DocGenFieldWritebackService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DocGenSignaturePdfFlowAction</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
     <classAccesses>
         <apexClass>DocGenEmailTemplateController</apexClass>
         <enabled>true</enabled>

--- a/scripts/audit-blanked-template-bodies.apex
+++ b/scripts/audit-blanked-template-bodies.apex
@@ -1,0 +1,129 @@
+// DocGen — find HTML template bodies that may have been overwritten with a blank
+// document, and show what to restore them from.
+//
+// Run: sf apex run --target-org <org> -f scripts/audit-blanked-template-bodies.apex
+//
+// WHY: before v3.48, getHtmlTemplateBody looked its file up with a bare
+// `WHERE Title LIKE 'docgen_html_body_<templateId>%'`. File access is not governed by
+// Apex sharing keywords or WITH SYSTEM_MODE, so that query returned ZERO rows for any
+// user without View All Data. The Designer treats a blank read as a new template and
+// seeds a placeholder scaffold — and a Save then wrote that placeholder over the
+// author's real body. Admins never saw it; everyone else did.
+//
+// The read is fixed and saveHtmlTemplateBody now refuses to overwrite a real body with
+// an empty one, but neither helps a body already clobbered. This finds those.
+//
+// READ-ONLY. It reports; it does not modify anything. Restore instructions are printed
+// per finding.
+
+// Substantive = something an author would be sorry to lose. Mirrors
+// DocGenController.hasSubstantiveHtml.
+Boolean isSubstantive(String html) {
+    if (String.isBlank(html)) {
+        return false;
+    }
+    String lower = html.toLowerCase();
+    if (lower.contains('<img') || lower.contains('<table') || lower.contains('<svg')) {
+        return true;
+    }
+    if (Pattern.compile('\\{[#^/%@]?[A-Za-z_][^}]*\\}').matcher(html).find()) {
+        return true;
+    }
+    String text = html.replaceAll('(?is)<(head|style|script)\\b[^>]*>.*?</\\1\\s*>', ' ');
+    text = text.replaceAll('(?s)<[^>]*>', ' ');
+    text = text.replaceAll('&nbsp;|&#160;', ' ').replaceAll('\\s+', ' ').trim();
+    if (String.isBlank(text)) {
+        return false;
+    }
+    return !text.startsWithIgnoreCase('Start typing your document here');
+}
+
+// Every body file, newest first per document. ALL versions, not just IsLatest — the
+// previous version is the thing worth restoring.
+List<ContentVersion> all = [
+    SELECT Id, Title, ContentDocumentId, VersionNumber, CreatedDate, CreatedBy.Name, IsLatest, VersionData
+    FROM ContentVersion
+    WHERE Title LIKE 'docgen_html_body_%'
+    ORDER BY ContentDocumentId, CreatedDate DESC
+];
+
+Map<Id, List<ContentVersion>> byDoc = new Map<Id, List<ContentVersion>>();
+for (ContentVersion cv : all) {
+    if (!byDoc.containsKey(cv.ContentDocumentId)) {
+        byDoc.put(cv.ContentDocumentId, new List<ContentVersion>());
+    }
+    byDoc.get(cv.ContentDocumentId).add(cv);
+}
+
+Integer scanned = 0, suspect = 0, recoverable = 0;
+List<String> findings = new List<String>();
+
+for (Id docId : byDoc.keySet()) {
+    List<ContentVersion> versions = byDoc.get(docId);
+    ContentVersion newest = versions[0];
+    scanned++;
+    if (isSubstantive(newest.VersionData.toString())) {
+        continue;
+    }
+    suspect++;
+    // Walk back for the most recent version that still had content.
+    ContentVersion restoreFrom = null;
+    for (Integer i = 1; i < versions.size(); i++) {
+        if (isSubstantive(versions[i].VersionData.toString())) {
+            restoreFrom = versions[i];
+            break;
+        }
+    }
+    String tplId = newest.Title.substringAfter('docgen_html_body_').substringBefore('_');
+    if (restoreFrom == null) {
+        findings.add(
+            'BLANK (no prior content to restore) template=' +
+                tplId +
+                ' doc=' +
+                docId +
+                ' savedBy=' +
+                newest.CreatedBy.Name +
+                ' on ' +
+                newest.CreatedDate
+        );
+    } else {
+        recoverable++;
+        findings.add(
+            'BLANKED template=' +
+                tplId +
+                ' doc=' +
+                docId +
+                ' blankedBy=' +
+                newest.CreatedBy.Name +
+                ' on ' +
+                newest.CreatedDate +
+                ' | RESTORE FROM ContentVersion ' +
+                restoreFrom.Id +
+                ' (v' +
+                restoreFrom.VersionNumber +
+                ', ' +
+                restoreFrom.VersionData.size() +
+                ' bytes, ' +
+                restoreFrom.CreatedDate +
+                ')'
+        );
+    }
+}
+
+for (String f : findings) {
+    System.debug('AUDIT >> ' + f);
+}
+System.debug(
+    'AUDIT RESULT >> templatesScanned=' +
+        scanned +
+        ' blankBodies=' +
+        suspect +
+        ' recoverable=' +
+        recoverable +
+        (suspect == 0 ? ' >> ALL CLEAN' : ' >> REVIEW THE FINDINGS ABOVE')
+);
+System.debug(
+    'AUDIT RESTORE HOWTO >> For each BLANKED row, re-upload the named ContentVersion\'s ' +
+        'VersionData as a NEW version of the same ContentDocument, or paste it back via ' +
+        'the Designer Source view. Nothing was deleted — the old version is still there.'
+);

--- a/scripts/e2e-01-permissions.apex
+++ b/scripts/e2e-01-permissions.apex
@@ -47,12 +47,18 @@ try {
 
         // Apex class accesses
         Set<String> cls = new Set<String>();
+        Set<Id> clsIds = new Set<Id>();
         for (SetupEntityAccess s : [
             SELECT SetupEntityId
             FROM SetupEntityAccess
             WHERE ParentId = :psId AND SetupEntityType = 'ApexClass'
         ]) {
-            cls.add([SELECT Name FROM ApexClass WHERE Id = :s.SetupEntityId LIMIT 1].Name);
+            clsIds.add(s.SetupEntityId);
+        }
+        // Bulk name lookup — a SOQL-in-loop here scaled with the number of
+        // granted entries and blew the 100-query limit as the permsets grew.
+        for (ApexClass a : [SELECT Name FROM ApexClass WHERE Id IN :clsIds]) {
+            cls.add(a.Name);
         }
 
         // Core classes
@@ -135,12 +141,17 @@ try {
 
         // VF page accesses
         Set<String> apgs = new Set<String>();
+        Set<Id> apgIds = new Set<Id>();
         for (SetupEntityAccess s : [
             SELECT SetupEntityId
             FROM SetupEntityAccess
             WHERE ParentId = :psId AND SetupEntityType = 'ApexPage'
         ]) {
-            apgs.add([SELECT Name FROM ApexPage WHERE Id = :s.SetupEntityId LIMIT 1].Name);
+            apgIds.add(s.SetupEntityId);
+        }
+        // Bulk name lookup — see the ApexClass note above.
+        for (ApexPage a : [SELECT Name FROM ApexPage WHERE Id IN :apgIds]) {
+            apgs.add(a.Name);
         }
         Boolean guideOk = apgs.contains('DocGenGuide');
         if (guideOk) {
@@ -299,12 +310,17 @@ try {
 
         // User class accesses
         Set<String> ucls = new Set<String>();
+        Set<Id> uclsIds = new Set<Id>();
         for (SetupEntityAccess s : [
             SELECT SetupEntityId
             FROM SetupEntityAccess
             WHERE ParentId = :upsId AND SetupEntityType = 'ApexClass'
         ]) {
-            ucls.add([SELECT Name FROM ApexClass WHERE Id = :s.SetupEntityId LIMIT 1].Name);
+            uclsIds.add(s.SetupEntityId);
+        }
+        // Bulk name lookup.
+        for (ApexClass a : [SELECT Name FROM ApexClass WHERE Id IN :uclsIds]) {
+            ucls.add(a.Name);
         }
         Boolean uClsOk = ucls.contains('DocGenController');
         if (uClsOk) {
@@ -358,12 +374,17 @@ try {
         }
 
         Set<String> upgs = new Set<String>();
+        Set<Id> upgIds = new Set<Id>();
         for (SetupEntityAccess s : [
             SELECT SetupEntityId
             FROM SetupEntityAccess
             WHERE ParentId = :upsId AND SetupEntityType = 'ApexPage'
         ]) {
-            upgs.add([SELECT Name FROM ApexPage WHERE Id = :s.SetupEntityId LIMIT 1].Name);
+            upgIds.add(s.SetupEntityId);
+        }
+        // Bulk name lookup.
+        for (ApexPage a : [SELECT Name FROM ApexPage WHERE Id IN :upgIds]) {
+            upgs.add(a.Name);
         }
         Boolean uVerifyOk = upgs.contains('DocGenVerify');
         if (uVerifyOk) {
@@ -415,17 +436,26 @@ try {
 
         Set<String> gc = new Set<String>();
         Set<String> gp = new Set<String>();
+        Set<Id> gcIds = new Set<Id>();
+        Set<Id> gpIds = new Set<Id>();
         for (SetupEntityAccess s : [
             SELECT SetupEntityId, SetupEntityType
             FROM SetupEntityAccess
             WHERE ParentId = :gId
         ]) {
             if (s.SetupEntityType == 'ApexClass') {
-                gc.add([SELECT Name FROM ApexClass WHERE Id = :s.SetupEntityId LIMIT 1].Name);
+                gcIds.add(s.SetupEntityId);
             }
             if (s.SetupEntityType == 'ApexPage') {
-                gp.add([SELECT Name FROM ApexPage WHERE Id = :s.SetupEntityId LIMIT 1].Name);
+                gpIds.add(s.SetupEntityId);
             }
+        }
+        // Bulk name lookup.
+        for (ApexClass a : [SELECT Name FROM ApexClass WHERE Id IN :gcIds]) {
+            gc.add(a.Name);
+        }
+        for (ApexPage a : [SELECT Name FROM ApexPage WHERE Id IN :gpIds]) {
+            gp.add(a.Name);
         }
 
         // VF pages

--- a/scripts/seed-permission-test-data.apex
+++ b/scripts/seed-permission-test-data.apex
@@ -1,0 +1,47 @@
+// DocGen — sample data for a permission-test scratch org.
+//
+// Run: sf apex run --target-org docgen-permtest -f scripts/seed-permission-test-data.apex
+// (scripts/setup-permission-test-org.sh runs this automatically.)
+//
+// Separate from setup-permission-test-org.apex on purpose: User and
+// PermissionSetAssignment are SETUP objects, and DML on those cannot share a
+// transaction with Account/Contact — Salesforce throws MIXED_DML_OPERATION.
+//
+// Accounts + Contacts specifically: both are available to the Salesforce Platform
+// license, so the restricted tester can exercise a real parent/child template.
+// Opportunity, Case and Lead are NOT visible to a Platform user, so a template
+// built on those would fail for reasons that have nothing to do with DocGen.
+//
+// Idempotent: re-running does not duplicate the data.
+
+Integer existing = [SELECT COUNT() FROM Account WHERE Name LIKE 'DocGen Test Account%'];
+if (existing == 0) {
+    List<Account> accs = new List<Account>();
+    for (Integer i = 1; i <= 3; i++) {
+        accs.add(new Account(Name = 'DocGen Test Account ' + i, Industry = 'Technology'));
+    }
+    insert accs;
+
+    List<Contact> cons = new List<Contact>();
+    for (Account a : accs) {
+        for (Integer j = 1; j <= 4; j++) {
+            cons.add(
+                new Contact(
+                    FirstName = 'Test',
+                    LastName = 'Contact ' + j,
+                    AccountId = a.Id,
+                    Email = 'contact' + j + '@example.com'
+                )
+            );
+        }
+    }
+    insert cons;
+}
+
+System.debug(
+    'SEED RESULT >> accounts=' +
+        [SELECT COUNT() FROM Account WHERE Name LIKE 'DocGen Test Account%'] +
+        ' contacts=' +
+        [SELECT COUNT() FROM Contact WHERE Account.Name LIKE 'DocGen Test Account%'] +
+        ' >> ALL GOOD'
+);

--- a/scripts/setup-permission-test-org.apex
+++ b/scripts/setup-permission-test-org.apex
@@ -1,0 +1,164 @@
+// DocGen — seed a permission-test scratch org: two non-admin users, their
+// permission sets, login passwords, and enough data to exercise the UI.
+//
+// Normally run via scripts/setup-permission-test-org.sh, which creates the org and
+// substitutes the password placeholder. To run standalone, replace
+// __DOCGEN_TEST_PASSWORD__ with a real password first.
+//
+// WHY NON-ADMIN USERS: a System Administrator has implicit access to every Apex
+// class, so an LWC whose @salesforce/apex import points at a class missing from the
+// permission set still loads for an admin and renders blank for everyone else. That
+// class of bug is ONLY reproducible as a user whose access comes entirely from the
+// DocGen permission sets — which is what these two users are for. Testing as
+// yourself proves nothing.
+//
+// Idempotent: safe to re-run against the same org.
+
+String pw = '__DOCGEN_TEST_PASSWORD__';
+String orgSuffix = '.docgenperm';
+Integer created = 0, assigned = 0, problems = 0;
+
+// Profile + permission set pairing. The admin-side tester deliberately sits on the
+// Standard User profile, NOT System Administrator — that is the whole point.
+Map<String, Map<String, String>> plan = new Map<String, Map<String, String>>{
+    'dgadmin' => new Map<String, String>{
+        'profile' => 'Standard User', // Salesforce license
+        'permSet' => 'DocGen_Admin',
+        'last' => 'AdminTester',
+        'alias' => 'dgadm'
+    },
+    'dguser' => new Map<String, String>{
+        'profile' => 'Standard Platform User', // Salesforce Platform license
+        'permSet' => 'DocGen_User',
+        'last' => 'UserTester',
+        'alias' => 'dgusr'
+    }
+};
+
+Map<String, Id> profileIds = new Map<String, Id>();
+for (Profile p : [SELECT Id, Name FROM Profile WHERE Name IN ('Standard User', 'Standard Platform User')]) {
+    profileIds.put(p.Name, p.Id);
+}
+Map<String, Id> permSetIds = new Map<String, Id>();
+for (PermissionSet ps : [SELECT Id, Name FROM PermissionSet WHERE Name IN ('DocGen_Admin', 'DocGen_User')]) {
+    permSetIds.put(ps.Name, ps.Id);
+}
+if (permSetIds.size() < 2) {
+    System.debug('SETUP: FAIL — DocGen permission sets not found. Deploy force-app before running this.');
+}
+
+String adminUsername = [SELECT Username FROM User WHERE Id = :UserInfo.getUserId()].Username;
+String emailDomain = adminUsername.substringAfter('@');
+List<User> toInsert = new List<User>();
+Map<String, String> usernameByKey = new Map<String, String>();
+
+for (String key : plan.keySet()) {
+    Map<String, String> cfg = plan.get(key);
+    String username = key + orgSuffix + '@' + emailDomain;
+    usernameByKey.put(key, username);
+
+    if (profileIds.get(cfg.get('profile')) == null) {
+        problems++;
+        System.debug('SETUP: FAIL — profile not found: ' + cfg.get('profile'));
+        continue;
+    }
+    if (![SELECT Id FROM User WHERE Username = :username LIMIT 1].isEmpty()) {
+        continue; // already exists — re-run
+    }
+    toInsert.add(
+        new User(
+            Username = username,
+            Email = 'davemoudy@gmail.com',
+            FirstName = 'DocGen',
+            LastName = cfg.get('last'),
+            Alias = cfg.get('alias'),
+            ProfileId = profileIds.get(cfg.get('profile')),
+            TimeZoneSidKey = 'America/New_York',
+            LocaleSidKey = 'en_US',
+            EmailEncodingKey = 'UTF-8',
+            LanguageLocaleKey = 'en_US'
+        )
+    );
+}
+if (!toInsert.isEmpty()) {
+    insert toInsert;
+    created = toInsert.size();
+}
+
+Map<String, Id> userIdByUsername = new Map<String, Id>();
+for (User u : [SELECT Id, Username FROM User WHERE Username IN :usernameByKey.values()]) {
+    userIdByUsername.put(u.Username, u.Id);
+}
+
+Set<String> alreadyAssigned = new Set<String>();
+for (PermissionSetAssignment psa : [
+    SELECT AssigneeId, PermissionSetId
+    FROM PermissionSetAssignment
+    WHERE AssigneeId IN :userIdByUsername.values()
+]) {
+    alreadyAssigned.add(psa.AssigneeId + '|' + psa.PermissionSetId);
+}
+
+List<PermissionSetAssignment> psas = new List<PermissionSetAssignment>();
+for (String key : plan.keySet()) {
+    Id uid = userIdByUsername.get(usernameByKey.get(key));
+    Id psid = permSetIds.get(plan.get(key).get('permSet'));
+    if (uid == null || psid == null) {
+        problems++;
+        System.debug('SETUP: FAIL — cannot assign ' + plan.get(key).get('permSet') + ' for ' + key);
+        continue;
+    }
+    if (!alreadyAssigned.contains(uid + '|' + psid)) {
+        psas.add(new PermissionSetAssignment(AssigneeId = uid, PermissionSetId = psid));
+    }
+}
+if (!psas.isEmpty()) {
+    insert psas;
+    assigned = psas.size();
+}
+
+// Passwords. Requires the EnableSetPasswordInApi feature, which the scratch org
+// definition supplies — `sf org generate password` can't reach these users because
+// they were created through Apex and are not in the CLI's auth store.
+if (pw != '__DOCGEN_TEST' + '_PASSWORD__') {
+    for (Id uid : userIdByUsername.values()) {
+        try {
+            System.setPassword(uid, pw);
+        } catch (Exception e) {
+            // "invalid repeated password" means the user already has exactly this
+            // password — which is the desired end state, so a re-run should not fail.
+            // Anything else is a real problem.
+            if (!e.getMessage().containsIgnoreCase('repeated password')) {
+                problems++;
+                System.debug('SETUP: FAIL — setPassword: ' + e.getMessage());
+            }
+        }
+    }
+} else {
+    problems++;
+    System.debug('SETUP: FAIL — password placeholder was not substituted; run via setup-permission-test-org.sh');
+}
+
+// Sample data is deliberately NOT created here — User and PermissionSetAssignment
+// are setup objects, and mixing them with Account/Contact DML in one transaction
+// throws MIXED_DML_OPERATION. seed-permission-test-data.apex runs separately.
+
+for (String key : plan.keySet()) {
+    System.debug(
+        'SETUP USER >> ' +
+            usernameByKey.get(key) +
+            ' >> profile=' +
+            plan.get(key).get('profile') +
+            ' >> permSet=' +
+            plan.get(key).get('permSet')
+    );
+}
+System.debug(
+    'SETUP RESULT >> created=' +
+        created +
+        ' assigned=' +
+        assigned +
+        ' problems=' +
+        problems +
+        (problems == 0 ? ' >> ALL GOOD' : ' >> PROBLEMS')
+);

--- a/scripts/setup-permission-test-org.sh
+++ b/scripts/setup-permission-test-org.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# DocGen — spin up a permission-test scratch org, end to end, in one command.
+#
+#   ./scripts/setup-permission-test-org.sh
+#   ./scripts/setup-permission-test-org.sh --alias my-org --duration 7
+#   ./scripts/setup-permission-test-org.sh --recreate        # delete + rebuild
+#
+# Creates the org, deploys force-app, then creates two NON-ADMIN users, assigns
+# their permission sets, sets passwords, and seeds Accounts + Contacts.
+#
+# WHY THIS EXISTS: a System Administrator has implicit access to every Apex class,
+# so a permission-set gap (an LWC importing a class the permset never granted)
+# renders blank for real users and works fine for you. Reproducing that needs users
+# whose access comes only from the DocGen permission sets.
+#
+# NOTE ON NAMESPACE: the org is created WITH the portwoodglobal namespace, which is
+# what makes it representative of an installed package. The trade-off is that the
+# scripts/e2e-*.apex suites use bare, unprefixed class and field references and will
+# NOT compile here — run those against a --no-namespace org instead.
+
+set -euo pipefail
+
+ALIAS="docgen-permtest"
+DURATION="30"
+DEVHUB="Portwood Global - Production"
+DEF_FILE="config/permission-test-scratch-def.json"
+RECREATE="false"
+TEST_PASSWORD="${DOCGEN_TEST_PASSWORD:-DocGenTest2026!}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --alias)     ALIAS="$2"; shift 2 ;;
+        --duration)  DURATION="$2"; shift 2 ;;
+        --devhub)    DEVHUB="$2"; shift 2 ;;
+        --recreate)  RECREATE="true"; shift ;;
+        -h|--help)   sed -n '2,20p' "$0"; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ ! -f "$DEF_FILE" ]]; then
+    echo "ERROR: scratch org definition not found: $DEF_FILE" >&2
+    exit 1
+fi
+
+echo "==> Scratch org: $ALIAS (${DURATION}d, Dev Hub: $DEVHUB)"
+
+if [[ "$RECREATE" == "true" ]]; then
+    echo "==> Deleting any existing org aliased $ALIAS"
+    sf org delete scratch --target-org "$ALIAS" --no-prompt >/dev/null 2>&1 || true
+fi
+
+if sf org display --target-org "$ALIAS" >/dev/null 2>&1; then
+    echo "==> Reusing existing org (pass --recreate to rebuild)"
+else
+    echo "==> Creating scratch org"
+    sf org create scratch \
+        --definition-file "$DEF_FILE" \
+        --alias "$ALIAS" \
+        --duration-days "$DURATION" \
+        --target-dev-hub "$DEVHUB" \
+        --wait 30
+fi
+
+echo "==> Deploying force-app"
+sf project deploy start --target-org "$ALIAS" --source-dir force-app --wait 45
+
+# The scratch org's own admin needs DocGen_Admin too. Without it, anonymous Apex
+# hits field-level security and reports a deployed field as "Field does not exist:
+# Query_Config__c" — which reads like corrupted metadata rather than a missing
+# permission set. Every later step here runs as this user.
+echo "==> Assigning DocGen_Admin to the org admin"
+sf org assign permset --target-org "$ALIAS" --name DocGen_Admin >/dev/null 2>&1 \
+    || echo "    (already assigned)"
+
+# The password is injected here rather than committed. Anonymous Apex takes no
+# parameters, so the placeholder in the .apex file is substituted into a temp copy.
+tmp_dir="$(mktemp -d -t docgen-setup-XXXXXX)"
+trap 'rm -rf "$tmp_dir"' EXIT
+tmp_apex="$tmp_dir/setup.apex"
+sed "s|__DOCGEN_TEST_PASSWORD__|${TEST_PASSWORD}|g" \
+    scripts/setup-permission-test-org.apex > "$tmp_apex"
+
+# Two separate runs, not one: User and PermissionSetAssignment are setup objects and
+# cannot share a transaction with Account/Contact DML (MIXED_DML_OPERATION).
+echo "==> Creating users and assigning permission sets"
+setup_out="$(sf apex run --target-org "$ALIAS" -f "$tmp_apex" 2>&1 || true)"
+# Filter to real log output first: `sf apex run` echoes the script source, so an
+# unfiltered grep also matches the string literals and prints them as if they fired.
+echo "$setup_out" | grep '|DEBUG|' | grep -oE 'SETUP USER >> .*|SETUP RESULT >> .*|SETUP: FAIL .*' | sed 's/^/    /' || true
+if ! echo "$setup_out" | grep '|DEBUG|' | grep -q 'SETUP RESULT.*ALL GOOD'; then
+    echo "ERROR: user setup failed — full output below" >&2
+    echo "$setup_out" >&2
+    exit 1
+fi
+
+echo "==> Seeding sample data"
+seed_out="$(sf apex run --target-org "$ALIAS" -f scripts/seed-permission-test-data.apex 2>&1 || true)"
+echo "$seed_out" | grep '|DEBUG|' | grep -oE 'SEED RESULT >> .*' | sed 's/^/    /' || true
+if ! echo "$seed_out" | grep '|DEBUG|' | grep -q 'SEED RESULT.*ALL GOOD'; then
+    echo "ERROR: data seeding failed — full output below" >&2
+    echo "$seed_out" >&2
+    exit 1
+fi
+
+instance_url="$(sf org display --target-org "$ALIAS" --json | python3 -c 'import json,sys; print(json.load(sys.stdin)["result"]["instanceUrl"])')"
+email_domain="$(sf org display --target-org "$ALIAS" --json | python3 -c 'import json,sys; print(json.load(sys.stdin)["result"]["username"].split("@")[1])')"
+
+cat <<EOF
+
+============================================================
+  DocGen permission-test org is ready
+============================================================
+  Login URL : ${instance_url}
+  Password  : ${TEST_PASSWORD}   (both users)
+
+  dgadmin.docgenperm@${email_domain}
+      Standard User profile / Salesforce license + DocGen_Admin
+      -> Designer, clone, bulk screen, query builder sort
+
+  dguser.docgenperm@${email_domain}
+      Standard Platform User profile / Platform license + DocGen_User
+      -> runner as a restricted user
+
+  Admin shell:  sf org open --target-org ${ALIAS}
+  Seeded:       3 Accounts x 4 Contacts
+
+  Log in as the two users above in a private window — as a System
+  Administrator you will not reproduce permission-set gaps.
+============================================================
+EOF

--- a/scripts/setup-permission-test-org.sh
+++ b/scripts/setup-permission-test-org.sh
@@ -5,19 +5,30 @@
 #   ./scripts/setup-permission-test-org.sh
 #   ./scripts/setup-permission-test-org.sh --alias my-org --duration 7
 #   ./scripts/setup-permission-test-org.sh --recreate        # delete + rebuild
+#   ./scripts/setup-permission-test-org.sh --recreate --install 04t...   # real install
 #
-# Creates the org, deploys force-app, then creates two NON-ADMIN users, assigns
-# their permission sets, sets passwords, and seeds Accounts + Contacts.
+# Creates the org, puts DocGen in it, then creates two NON-ADMIN users, assigns their
+# permission sets, sets passwords, and seeds Accounts + Contacts.
+#
+# TWO MODES:
+#   default    source-deploy force-app into a NAMESPACED org. Fast iteration; the
+#              scripts/e2e-*.apex suites can run against it.
+#   --install  create a NO-NAMESPACE org and install a built package version, exactly
+#              as a customer would. This is the only mode that catches packaging traps
+#              — missing permission-set entries, `public` where `global` was needed,
+#              post-install script failures. The e2e suites CANNOT run here: they call
+#              public (subscriber-invisible) classes unprefixed. Use the default mode
+#              for those, and drive the UI for install verification.
 #
 # WHY THIS EXISTS: a System Administrator has implicit access to every Apex class,
 # so a permission-set gap (an LWC importing a class the permset never granted)
 # renders blank for real users and works fine for you. Reproducing that needs users
 # whose access comes only from the DocGen permission sets.
 #
-# NOTE ON NAMESPACE: the org is created WITH the portwoodglobal namespace, which is
-# what makes it representative of an installed package. The trade-off is that the
-# scripts/e2e-*.apex suites use bare, unprefixed class and field references and will
-# NOT compile here — run those against a --no-namespace org instead.
+# NOTE ON NAMESPACE: default mode creates the org WITH the portwoodglobal namespace so
+# namespace-sensitive behaviour (LWS sandbox, prefixed SObject keys) is representative.
+# --install mode does the opposite on purpose — a subscriber does not own the namespace,
+# it receives it from the package.
 
 set -euo pipefail
 
@@ -26,6 +37,7 @@ DURATION="30"
 DEVHUB="Portwood Global - Production"
 DEF_FILE="config/permission-test-scratch-def.json"
 RECREATE="false"
+INSTALL_VERSION=""
 TEST_PASSWORD="${DOCGEN_TEST_PASSWORD:-DocGenTest2026!}"
 
 while [[ $# -gt 0 ]]; do
@@ -34,7 +46,8 @@ while [[ $# -gt 0 ]]; do
         --duration)  DURATION="$2"; shift 2 ;;
         --devhub)    DEVHUB="$2"; shift 2 ;;
         --recreate)  RECREATE="true"; shift ;;
-        -h|--help)   sed -n '2,20p' "$0"; exit 0 ;;
+        --install)   INSTALL_VERSION="$2"; shift 2 ;;
+        -h|--help)   sed -n '2,30p' "$0"; exit 0 ;;
         *) echo "Unknown option: $1" >&2; exit 2 ;;
     esac
 done
@@ -58,16 +71,46 @@ if sf org display --target-org "$ALIAS" >/dev/null 2>&1; then
     echo "==> Reusing existing org (pass --recreate to rebuild)"
 else
     echo "==> Creating scratch org"
+    # Install mode creates the org WITHOUT the namespace: a subscriber org does not
+    # own portwoodglobal, it receives it from the package. Creating it namespaced
+    # would let namespace-visibility bugs pass that a real customer would hit.
+    ns_flag=()
+    if [[ -n "$INSTALL_VERSION" ]]; then
+        ns_flag=(--no-namespace)
+    fi
     sf org create scratch \
         --definition-file "$DEF_FILE" \
         --alias "$ALIAS" \
         --duration-days "$DURATION" \
         --target-dev-hub "$DEVHUB" \
+        "${ns_flag[@]}" \
         --wait 30
 fi
 
-echo "==> Deploying force-app"
-sf project deploy start --target-org "$ALIAS" --source-dir force-app --wait 45
+if [[ -n "$INSTALL_VERSION" ]]; then
+    # REAL INSTALL PATH — exercises what a customer actually gets.
+    #
+    # Note what this can and cannot cover. The scripts/e2e-*.apex suites call
+    # DocGenController, DocGenBulkController, DocGenDataRetriever, DocGenHtmlRenderer
+    # and DocGenService.processXmlForTest — all `public`, so INVISIBLE to a subscriber,
+    # and all referenced unprefixed. They cannot run here by construction; they are a
+    # source-deploy suite. Run them against a --no-namespace org instead.
+    #
+    # What an install test DOES catch, and nothing else does: packaging traps. Missing
+    # permission-set entries, public-where-global-was-needed, post-install script
+    # failures, and anything that only misbehaves under the namespace.
+    echo "==> Installing package version $INSTALL_VERSION (real subscriber install)"
+    sf package install \
+        --target-org "$ALIAS" \
+        --package "$INSTALL_VERSION" \
+        --security-type AdminsOnly \
+        --no-prompt \
+        --publish-wait 20 \
+        --wait 30
+else
+    echo "==> Deploying force-app (source deploy)"
+    sf project deploy start --target-org "$ALIAS" --source-dir force-app --wait 45
+fi
 
 # The scratch org's own admin needs DocGen_Admin too. Without it, anonymous Apex
 # hits field-level security and reports a deployed field as "Field does not exist:
@@ -107,6 +150,11 @@ if ! echo "$seed_out" | grep '|DEBUG|' | grep -q 'SEED RESULT.*ALL GOOD'; then
     exit 1
 fi
 
+MODE_LABEL="source deploy (namespaced) — e2e suites can run here"
+if [[ -n "$INSTALL_VERSION" ]]; then
+    MODE_LABEL="REAL INSTALL of ${INSTALL_VERSION} (no-namespace subscriber org)"
+fi
+
 instance_url="$(sf org display --target-org "$ALIAS" --json | python3 -c 'import json,sys; print(json.load(sys.stdin)["result"]["instanceUrl"])')"
 email_domain="$(sf org display --target-org "$ALIAS" --json | python3 -c 'import json,sys; print(json.load(sys.stdin)["result"]["username"].split("@")[1])')"
 
@@ -128,6 +176,7 @@ cat <<EOF
 
   Admin shell:  sf org open --target-org ${ALIAS}
   Seeded:       3 Accounts x 4 Contacts
+  Mode:         ${MODE_LABEL}
 
   Log in as the two users above in a private window — as a System
   Administrator you will not reproduce permission-set gaps.

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,15 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.47.0 \u2014 PowerPoint table loops, GUID preservation, split-run merge tags",
-      "versionNumber": "3.47.0.NEXT",
+      "versionName": "v3.48.0 \u2014 Bulk generation: conditionals, charts, sorting, permissions",
+      "versionNumber": "3.48.0.NEXT",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "postInstallScript": "DocGenEmailTemplateInstall",
       "package": "Portwood DocGen Managed",
-      "ancestorVersion": "3.46.0"
+      "ancestorVersion": "3.47.0",
+      "versionDescription": "Portwood DocGen generates PDFs and Word documents from any Salesforce record. v3.48 is a bulk generation release: conditional sections and filtered loops now behave the same in bulk as they do for a single record, charts render in bulk jobs, and you can sort related lists by more than one column. Template cloning now brings every file with it, and the Template Designer opens correctly for users with the DocGen Admin permission set. 100% native Salesforce \u2014 no external services or callouts. Free for all users."
     },
     {
       "versionName": "v1.0.0 \u2014 Agentforce template authoring",


### PR DESCRIPTION
Bulk-generation release. Most of what follows is **silent wrong output** — paths that reported success while producing documents that were subtly or completely wrong.

## Bulk merge-tag resolution

`getRecordDataV3Bulk` is a hand-written twin of `getRecordDataV3` and had drifted four ways, none of which raised an error:

- **Aliased loops resolved to nothing.** The bulk node parser never read `alias`, and `dataMapKey()` is `alias ?? relationshipName` — so a template using a Tag name (`{#OpenCases}` over a Cases node) filed its collection under the raw relationship name. `{#Tag}` rendered nothing, `{^Tag}` fired its inverse branch. **V3 configs only** (V1 falls through to the single-record path), which is why it looked intermittent.
- **Per-record `LIMIT` applied per job.** The bulk child query spans every record in the batch, so `LIMIT 10` returned 10 rows for the *whole job*. No flat SOQL LIMIT can express "n per parent" — scaling by parent count still starves a skewed set — so the clause is dropped and re-applied per parent after grouping.
- **`{Field:label}` threw in bulk only** — the batch cache round-trips through `JSON.deserializeUntyped`, which yields `Map<String,Object>`.
- **`{#Approvals}` never populated** on the cached path.

## Charts in bulk

`DocGenChartRasterizer` (pure-Apex PNG) and `prepareChartImagesServerSide` were built for DOM-less callers and documented for *"batch jobs and bulk runners"* — and never called. `DocGenBatch` now rasterizes per record, seeds the chart context, and reaps transient CVs in a `finally`. A `hasChartTags` probe resolves once per job so chart-free templates never pay a per-record SOQL.

Adds **`DocGenChartCvReaper`** — the old docblock claimed an orphan reaper existed and none did. Fine when a human clicks Generate; not once bulk creates CVs per record.

> Chart bulk jobs should stay at **batchSize=1** (the default). Rasterizing is CPU-heavy — the code's own measurement is ~11s for one chart at `scale=2`, which is why the server path forces `scale=1`.

`{#ChartBucket:…}` and HTML CSS-bar charts were never affected — they resolve inside `processXml`.

## PowerPoint / Excel in Combined PDF produced blank pages

`generateHtmlForRecord` let them fall into the Word DOCX→HTML branch, which found no `word/document.xml` and returned empty HTML. `generateDocument` catches this via `validateOutputFormatOverride`, but the merge path calls `mergeTemplate` with a hardcoded `'PDF'` and never passes through it. Now rejected in `analyzeJob`, `submitJobInternal`, and `generateHtmlForRecord`. **Individual Files remains fully supported** — `assembleZip` builds the OOXML package in Apex.

## Designer blank for non-admins — two causes

1. `docGenAdmin` imports `DocGenChartImageController` and `DocGenAiTemplateController`, neither with a `classAccesses` entry. LWC Apex imports resolve at module load, so one missing class blanks the whole component.
2. **The real one.** `getHtmlTemplateBody` / `listHtmlTemplateImages` found files with a bare `WHERE Title LIKE …`. **File access is not governed by Apex sharing keywords or `WITH SYSTEM_MODE`.** Measured on a Standard User holding `DocGen_Admin`:

```
template=1  cdl=1  cvUserMode=0  cvSystemMode=0  cvViaWithoutSharingLoader=0
                   cvScopedByContentDocumentId=1
```

Admins have View All Data and never saw it — the canvas populated for whoever built the template and was blank for everyone else, silently (no toast, no console error). Because it looked like a permissions problem, the natural response was to grant more permission sets, which changed nothing. Both methods now scope by `ContentDocumentId` from the template's link. Covered by `System.runAs` tests — the only way to reproduce it.

⚠️ If a non-admin ever hit **Save** on that blank canvas, it would have overwritten the stored body.

## Bulk screen refused jobs the Flow action ran

The Run button was gated on `analyzeJob().canProceed`, which the server enforces nowhere. The estimates are measured in a 6MB sync request but judged against the 12MB async ceiling, multiply once-per-`execute()` costs by batch size, and ignore both the data cache and the existing giant-query retry. At `batchSize=1` it emitted "reduce batch size to 1". `canProceed` is now reserved for hard blockers.

## Template cloning dropped HTML files

Body CV titled after the template name instead of the `docgen_html_body_` convention (clone rendered fine, opened blank, first Save overwrote the real body); copied images kept the **source** template id (clone's picker empty, source's picker duplicated); imported version never carried `Output_Format__c` / `Header_Html__c` / `Footer_Html__c` / `Document_Title_Format__c`.

## Multi-column sorting

Repeatable field + direction editor, plus the two consumers that broke a multi-column clause: `scoutChildCounts`' V3 branch dropped `orderBy` entirely (V1 didn't), and `getSortedChildIds` lacked the standard-relationship fallback `sanitizeClause` has.

## Also

- Bulk Flow action **Template API Name** (closes #256)
- Bulk sample record cleared on template switch; record picker re-keyed on base object
- `e2e-01` bulkified — SOQL-in-loop the six new permset entries pushed past 100
- Scratch-org tooling: two non-admin test users in one command
- `docGenAdmin` `innerHTML` read → `childNodes` predicate, clearing the last code-analyzer High (fixed, not suppressed)
- UserGuide §9.4 bulk format matrix; §9.5 corrected ("blocks submission" was no longer true)

## Validation

| Check | Result |
|---|---|
| e2e 01–08 + 07-syntax1–4 | **13/13**, 253 assertions, FAIL 0 |
| RunLocalTests | 1956 run — **no real failures** (54 ContentFolder lock contention + 2 LMA `PackageSubscriber`; all green in isolation) |
| `sf code-analyzer` | **0 violations** |
| prettier | clean |

Designer fix confirmed end-to-end in Portwood Dev as a real non-admin user: canvas went from the empty-state placeholder to the actual 12,931-char template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)