### PR TITLE
v3.49.0 — Bulk sort order, {RowNumber}, Save & Download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,150 @@
 # Changelog
 
+## v3.49.0 — Bulk sort order, `{RowNumber}`, Save & Download (unreleased)
+
+Not yet built or promoted — no package version id.
+
+### Fixed — Designer could load an OLD template body (silent)
+
+Found by `RunLocalTests` during release validation for this version, not by the features
+in it — `DocGenHtmlTemplateTest.getHtmlTemplateBodyReturnsLatestBody` saved two bodies and
+read back the **first** one.
+
+`PreDecompXmlLoader` picks the newest internal ContentVersion with
+`ORDER BY CreatedDate DESC` and takes row 0. `CreatedDate` has **one-second granularity**,
+so two versions written in the same second — an edit saved twice in quick succession, or
+both writes inside one transaction — tie, and SOQL breaks a tie arbitrarily. "Newest wins"
+then returned whichever row the optimizer preferred.
+
+The visible symptom is an editor that silently shows **stale content**: open the Designer,
+get the previous body, save, and the newer one is overwritten. No error, nothing in the
+log. Fixed with `ORDER BY CreatedDate DESC, Id DESC` on both loader queries — Ids are
+assigned in insert order, so the higher Id is the later write.
+
+### Added — "Save & Download" output option (#260)
+
+Customer request via support: the runner made you choose between attaching the document to
+the record and downloading it. There is now a third pill, **Save & Download**, offered
+whenever the placement leaves both destinations enabled — it is the combination of the
+two, not a new destination, so unticking either in App Builder removes it.
+
+It costs nothing extra. Five of the six generation paths already held the base64 in the
+browser and simply picked one of two things to do with it:
+
+```js
+if (saveToRecord) { await saveGeneratedDocument({...}); }
+else { this.downloadBase64(result.base64, ...); }
+```
+
+"Both" is just not choosing. All six now route through one `_deliverGeneratedDocument`
+helper that downloads, saves, or does both from a **single generation** — which also
+collapses six copies of that if/else, and moves the 5 MB ceiling and its drag-to-attach
+fallback into one place instead of two divergent copies. Above the ceiling a Save &
+Download behaves exactly as Save to Record does today: the file downloads and the
+drag-to-attach box appears, which already satisfies both halves.
+
+**PDF keeps the asynchronous route, and gains no size ceiling.** Save to Record hands the
+whole render to a Queueable deliberately — it keeps a long render from tripping
+Salesforce's CSRF timeout — and returns before the file exists, so there are initially no
+bytes to download. Rather than forcing that render synchronous to obtain them (which would
+reintroduce the exact timeout the Queueable exists to avoid, on the largest documents),
+Save & Download waits for the job via the existing `getPdfSampleGenerationStatus` poll and
+then points the **browser** at the saved ContentVersion. The file streams from Salesforce's
+own file endpoint, so neither half passes through the Aura response and neither has a size
+limit. `NavigationMixin` builds that URL rather than a hand-written `/sfc/...` anchor,
+because the runner also runs on Experience Cloud pages where a bare path misses the site
+prefix.
+
+The poll allows 5 minutes — this path exists FOR documents too big to render synchronously,
+and those are the ones that take minutes. On timeout the message says the save is still
+running and to collect the file from the record, rather than implying it was lost.
+
+The 30 MB attached-image pre-flight guard now fires for Save & Download too; it was
+previously gated on the save-only flag, so routing "both" past it would have skipped the
+check and failed at the ContentVersion insert with no useful message.
+
+New `DocGenRunner_SaveAndDownload` Custom Label, translated into all 10 shipped languages.
+
+### Fixed — lone output-destination button
+
+When a placement left only one destination enabled, the runner still rendered a single
+pill that looked interactive and did nothing. `showOutputDestinationSelector` now requires
+more than one option. Safe because generation never reads `outputMode` directly — every
+call site goes through `resolvedOutputMode`, which falls back to whichever mode is allowed.
+
+### Added — `{RowNumber}` loop counter
+
+Inside any loop, `{RowNumber}` renders the row's 1-based position. There was no way to
+number table rows before this: the only index token anywhere was `{index}` inside
+`{#ChartBucket}` buckets, and a `{#Child}` loop handed each iteration nothing but the
+record's own data map.
+
+The number counts **rendered** rows, so it follows whatever the Query Config's
+`WHERE`/`ORDER BY`/`LIMIT` produced. Nested loops each count their own rows and the outer
+number is intact after the inner loop closes — the counter goes into a per-row **copy** of
+the data map, never the record map itself, so it cannot leak into the record's fields or
+be seen as a stale value by a nested loop.
+
+Both resolution paths carry it, per the three-paths rule:
+
+- **In-memory loops** — `processXml`'s two section-loop branches (bare list and the
+  `{records: […]}` relationship shape).
+- **Giant-query** — `renderLoopBodyForRecords` gains a `rowNumberOffset` parameter, and
+  `DocGenGiantQueryBatch` accumulates it across `execute()` calls. Without that, every
+  fragment restarts at 1 and a 30,000-row table counts 1..50 over and over — right on
+  page one, wrong everywhere after.
+
+Whether the body uses the tag is probed once per loop (same shape as
+`loopBodyHasImageTag`), because supplying the number means copying each row's map. A
+template that doesn't ask for it pays nothing.
+
+New `scripts/e2e-07-syntax5.apex` covers the syntax: basic numbering, 1-based, the
+`records` shape, nesting, field shadowing, absence, and use outside a loop. It is a new
+file because syntax1–4 are each within a few hundred characters of the Anonymous Apex
+size ceiling.
+
+### Added — parent-level sort for bulk jobs
+
+The bulk query had no `ORDER BY`. Records were processed in whatever order the
+QueryLocator returned them, which is effectively record-Id (creation) order, and nothing
+in the runner or the Flow action could change it. That is invisible for Individual Files
+but it decides **page order in a Combined PDF**: `DocGenBatch` stamps a zero-padded
+sequence on each HTML snippet as it processes records and `DocGenMergeJob` assembles by
+that title. 200 Opportunities merged into one packet came out in creation order with no
+way to group them by Account.
+
+Sorting the QueryLocator is therefore the whole fix — the merge pipeline is unchanged.
+
+- **Bulk runner**: a **Sort By** picker listing every sortable field on the base object
+  plus each lookup's parent name field (`Account > Account Name`), with a direction
+  toggle. Backed by the new `getSortableFields`.
+- **`DocGen: Generate Bulk Documents` Flow action**: a **Sort Order** text input taking
+  the same clause. A bad field fails the action on `Error Message` rather than faulting
+  the interview. The `Record IDs` input's description now says what was previously a
+  silent trap — SOQL does not preserve that collection's order, so sorting it in the
+  Flow does nothing.
+- **`DocGen_Job__c.Sort_Order__c`** stores the validated clause, so `DocGenBatch` (which
+  is constructed from a job Id) can read it in `start()`.
+
+`DocGenBulkController.normalizeSortOrder` validates and canonicalizes the clause against
+the base object's schema. Injection defense is a **character allowlist**, not a keyword
+blocklist: an `ORDER BY` clause needs only field paths, commas, spaces and
+`ASC`/`DESC`/`NULLS FIRST`/`NULLS LAST`, so quotes, parens, semicolons and comment
+markers are rejected outright. Every field path is then resolved through describe — up to
+two relationship hops, each verified to be sortable — so an unknown field is an error at
+submit time rather than a batch that dies in `start()` leaving a job stuck at Processing.
+
+Two behaviours worth knowing:
+
+- **Blanks sort last.** SOQL puts them first on an ascending sort, which would open a
+  packet with the records that have nothing in the sort field.
+- **A single sort field gains the object's name field as a tie-break.** Sorting
+  Opportunities by `Account.Name` leaves each same-account group in arbitrary order, so
+  two runs of the same job could produce two different packets.
+
+Validated at submit time _and_ re-validated in `DocGenBatch.start()` — `Sort_Order__c` is
+writable metadata and that string is what reaches the query.
+
 ## v3.48.0 — Bulk generation: conditionals, charts, sorting, permissions
 
 `04tVx000000zgS9IAI` (build 3.48.0-1, promoted 2026-07-30, ancestor 3.47.0).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,10 +103,11 @@ sf apex run --target-org <org> -f scripts/e2e-07-syntax1.apex
 sf apex run --target-org <org> -f scripts/e2e-07-syntax2.apex
 sf apex run --target-org <org> -f scripts/e2e-07-syntax3.apex
 sf apex run --target-org <org> -f scripts/e2e-07-syntax4.apex
+sf apex run --target-org <org> -f scripts/e2e-07-syntax5.apex
 sf apex run --target-org <org> -f scripts/e2e-08-cleanup.apex
 ```
 
-Each script must print `PASS: N  FAIL: 0  ALL TESTS PASSED`. Sequence: 01 standalone, 02 creates test data, 03/03b–06b depend on 02, 07-syntax1/2/3/4 standalone (use `processXmlForTest`), 08 cleans up. **03b is split out of 03** because each full `generateDocument` costs ~10 SOQL and the combined generations exceeded the 100-SOQL synchronous limit in one anonymous transaction — a governor-limit throw prints NO summary line, so watch for a script that emits no `PASS: N` at all, not just a non-zero FAIL. Note for new scripts: anonymous Apex cannot catch a thrown `AuraHandledException` (uncatchable LimitException) — negative-path assertions on `@AuraEnabled` guard methods belong in unit tests, not e2e.
+Each script must print `PASS: N  FAIL: 0  ALL TESTS PASSED`. Sequence: 01 standalone, 02 creates test data, 03/03b–06b depend on 02, 07-syntax1/2/3/4/5 standalone (use `processXmlForTest`), 08 cleans up. **syntax1–4 are all within a few hundred characters of the Anonymous Apex ceiling** — put new parser assertions in syntax5 (or a new syntax6) rather than growing them. **03b is split out of 03** because each full `generateDocument` costs ~10 SOQL and the combined generations exceeded the 100-SOQL synchronous limit in one anonymous transaction — a governor-limit throw prints NO summary line, so watch for a script that emits no `PASS: N` at all, not just a non-zero FAIL. Note for new scripts: anonymous Apex cannot catch a thrown `AuraHandledException` (uncatchable LimitException) — negative-path assertions on `@AuraEnabled` guard methods belong in unit tests, not e2e.
 
 When fixing a parser-level bug, add a regression assertion in `e2e-07-syntax1` or `e2e-07-syntax2` that exercises the offending pattern via `processXmlForTest`. Each script must stay under 18,000 chars (Anonymous Apex limit is 20,000).
 

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1548,6 +1548,21 @@ Nested loops are supported:
 
 Empty loops (null or empty child list) render nothing — no error.
 
+**Numbering the rows — `{RowNumber}`.** Inside any loop, `{RowNumber}` is the row's position, starting at **1**:
+
+```
+| # | Product | Qty |
+| {#OpportunityLineItems}{RowNumber} | {Product2.Name} | {Quantity}{/OpportunityLineItems} |
+```
+
+- **Counts rendered rows**, so it reflects whatever the Query Config's `WHERE`/`ORDER BY`/`LIMIT` actually returned — not the record's position in the database.
+- **Nested loops each count their own rows.** An inner `{RowNumber}` restarts at 1 for every parent row, and the outer number is intact again after the inner loop closes.
+- **Counts continuously through very large tables.** A 30,000-row giant-query table numbers 1…30,000 straight through, not per page or per batch.
+- **Restarts per group** inside a `{#GroupBy}` block — each group's table numbers from 1.
+- Verified in Word and HTML templates across single, bulk and giant-query generation. PowerPoint and Excel loops run through the same engine and should behave identically, but that combination hasn't been exercised end-to-end.
+- Outside a loop it isn't a tag and resolves to nothing.
+- If a record happens to have a field literally named `RowNumber`, the counter wins inside the loop body.
+
 **Group into a table (or block) per value — `{#GroupBy}` (v3.42+).** When you want one table per _type_ / _category_ / _status_ — and you don't want to hand-write a separate loop for every value — group a child relationship by a field and repeat the block once per distinct value:
 
 ```
@@ -2444,13 +2459,21 @@ Comments: {Comments}
 1. Open any record (Account, Opportunity, Case, etc.).
 2. The **DocGen Runner** LWC appears (placed via Lightning App Builder or via the Command Hub's "Generate from Record" flow).
 3. Pick a template.
-4. Choose **Save to Record** (attaches as ContentDocumentLink) or **Download** (sent to your browser).
+4. Choose **Save to Record** (attaches as ContentDocumentLink), **Download** (sent to your browser), or **Save & Download** (both, from a single generation).
 5. Optional: override output format if the template isn't locked (§5.4).
 6. Click **Generate**.
 
 **Picker order & grouping.** Templates are grouped by their **Category** field, the object's **Default** template (★) floats to the top, and **Sort Order** (lower = higher) breaks ties — blank Sort Order falls back to Default-first, then name. A category dropdown filters the list when you have many templates. All three are plain fields on the template (Settings tab).
 
 **Where the runner can live.** Record pages, App Builder pages, the Command Hub, Experience Cloud pages, Flow screens, and the utility bar. In App Builder, per-placement toggles let you hide **Download**, **Save to Record**, **Document Packet**, **Combine PDFs**, or **Combine with existing PDFs** for that page. On mobile, the runner is save-to-record only (mobile browsers can't take the download hand-off); packets and combines are download-only, so they're desktop features.
+
+**Save & Download (v3.49+).** Offered whenever the placement leaves _both_ Download and Save to Record enabled — it's the combination of the two, so turning either off removes it. The document is generated **once**, and both copies come from that single render.
+
+For **PDF**, it keeps the same background generation that Save to Record uses, waits for the file to land on the record, then hands your browser the saved file. That means **no size ceiling on either half** — the document never has to squeeze through the page's own response, so very large PDFs work exactly as they do with Save to Record. Expect it to take about as long as a Save to Record; the download starts when the file is ready. If it is still generating after a few minutes, the runner says so and points you at the record — the save itself still finishes.
+
+For **Word, Excel and PowerPoint**, the file is assembled in your browser, so both copies are immediate. Above the ~5 MB attachment ceiling these behave exactly as Save to Record does today: the file downloads and a drag-to-attach box appears, which already satisfies both halves.
+
+**Hiding the choice entirely (v3.49+).** When a placement leaves only one destination enabled, the selector no longer renders at all — previously a single, pointless button remained. Untick the destinations you don't want in App Builder and users simply click **Generate**.
 
 ### 8.2 What happens behind the scenes
 
@@ -2523,10 +2546,26 @@ Mass-generate documents for many records in one batch.
     - **Combined PDF** — all records merged into one PDF (memory-efficient, compliance bundles).
     - **Individual files** — one PDF per record saved to that record.
     - **Both** — individual files + a combined bundle.
-5. Adjust batch size if needed (1–200; default 1 — one record per batch execution is the safest for heap-heavy templates; raise it for small, simple templates).
-6. Submit.
+5. Optionally set a **Sort By** field and direction (see §9.1.1).
+6. Adjust batch size if needed (1–200; default 1 — one record per batch execution is the safest for heap-heavy templates; raise it for small, simple templates).
+7. Submit.
 
 **Preview one record first.** Before launching a big job, pick a record under **Preview Sample Record** and hit **Preview Sample PDF** — the bulk runner produces one real PDF from it so you can sanity-check the output. The sample record clears when you switch templates, since it belongs to the previous template's object.
+
+### 9.1.1 Sort order — controlling document order
+
+**Sort By** decides the order records are processed, and therefore **the page order of a Combined PDF**. Without it, records come out in the order Salesforce returns them — effectively creation order — which is rarely the order you want to hand someone.
+
+- The picker lists every sortable field on the template's base object, plus each lookup's parent name field, shown as `Account > Account Name`. So 200 Opportunities can be ordered by their Account name in one click, with no SOQL to write.
+- Pick a **Direction**: ascending (A→Z, oldest first) or descending.
+- Blank values always sort to the **end**, so records missing the sort field don't open the packet.
+- Records tied on the sort field fall back to name order, so re-running the same job produces the same packet rather than a reshuffle.
+
+Sorting applies to Individual Files too — it decides the order records are processed and the order they appear in Job History.
+
+**In Flows**, the `DocGen: Generate Bulk Documents` action takes the same thing as a **Sort Order** text input, written as a SOQL `ORDER BY` clause without the keywords: `Account.Name ASC`, `CloseDate DESC`, or up to three comma-separated fields (`Account.Name ASC, Amount DESC`). Field API names only; `ASC`/`DESC` and `NULLS FIRST`/`NULLS LAST` are supported. An unknown or unsortable field fails the action with a message on **Error Message** rather than faulting the interview.
+
+> **If your Flow passes a Record IDs collection:** SOQL does not preserve the order of that collection, so sorting the collection in the Flow has no effect on the document. Use **Sort Order**.
 
 ### 9.2 Saved queries
 

--- a/force-app/main/default/classes/DocGenBatch.cls
+++ b/force-app/main/default/classes/DocGenBatch.cls
@@ -4,6 +4,9 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
     public String baseObject;
     public String condition;
     public String queryConfig;
+    // Validated ORDER BY clause for the bulk query (see DocGenBulkController
+    // .normalizeSortOrder). Null for the historical unordered behaviour.
+    public String sortOrder;
     public Boolean mergeMode;
     public Boolean mergeOnly;
 
@@ -91,11 +94,16 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
         // DocGenFlsGuard.cls.
         DocGenFlsGuard.assertAccessible(
             DocGen_Job__c.sObjectType,
-            new Set<String>{ 'Template__c', 'Query_Condition__c' }
+            new Set<String>{ 'Template__c', 'Query_Condition__c', 'Sort_Order__c' }
         );
         /* code-analyzer-suppress ApexFlsViolation */
         DocGen_Job__c job = [
-            SELECT Template__c, Template__r.Base_Object_API__c, Template__r.Query_Config__c, Query_Condition__c
+            SELECT
+                Template__c,
+                Template__r.Base_Object_API__c,
+                Template__r.Query_Config__c,
+                Query_Condition__c,
+                Sort_Order__c
             FROM DocGen_Job__c
             WHERE Id = :jobId
             WITH SYSTEM_MODE
@@ -104,6 +112,7 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
         this.baseObject = job.Template__r.Base_Object_API__c;
         this.condition = job.Query_Condition__c;
         this.queryConfig = job.Template__r.Query_Config__c;
+        this.sortOrder = job.Sort_Order__c;
     }
 
     /**
@@ -193,6 +202,18 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
             query += ' WHERE ' + sanitizedCondition;
         }
         query += ' WITH USER_MODE';
+
+        // ORDER BY the parent records. Batch chunks are handed to execute() in
+        // QueryLocator order, and merge mode stamps its sequence counter as it goes
+        // (see buildMergeSnippet), so ordering the locator is the whole fix: the
+        // merged PDF comes out in this order with no change to the merge pipeline.
+        //
+        // Re-validated here rather than trusted from the field: Sort_Order__c is
+        // writable metadata, and this is the string that reaches the query.
+        String safeSortOrder = DocGenBulkController.normalizeSortOrder(baseObject, sortOrder);
+        if (String.isNotBlank(safeSortOrder)) {
+            query += ' ORDER BY ' + safeSortOrder;
+        }
 
         // Count total records for progress tracking
         String countQuery = 'SELECT Count() FROM ' + baseObject;

--- a/force-app/main/default/classes/DocGenBulkController.cls
+++ b/force-app/main/default/classes/DocGenBulkController.cls
@@ -224,6 +224,304 @@ public with sharing class DocGenBulkController {
         return condition;
     }
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // Sort order (parent-level ORDER BY for the bulk query)
+    //
+    // The bulk query had no ORDER BY at all, so records were processed in
+    // whatever order the QueryLocator returned them — effectively record Id, i.e.
+    // creation order. That is invisible for individual files but decides page
+    // order in a merged PDF: DocGenBatch stamps a zero-padded counter on each
+    // HTML snippet as it processes records, and DocGenMergeJob assembles by that
+    // title. Sorting the locator therefore sorts the packet, with no change to
+    // the merge pipeline itself.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /** Relationship hops permitted in one sort field path (Account.Owner.Name = 2). */
+    private static final Integer MAX_SORT_HOPS = 2;
+
+    /** Sort terms permitted in one clause — bounded so the result fits Sort_Order__c (255). */
+    private static final Integer MAX_SORT_TERMS = 3;
+
+    /**
+     * Validates a SOQL ORDER BY clause against the base object's schema and returns
+     * it in canonical form (correct field casing, explicit direction and NULLS
+     * handling on every term).
+     *
+     * Deliberately NOT DocGenDataRetriever.sanitizeClause(…, 'ORDER BY', …), which
+     * validates the CHILD-relationship sort clauses stored in a Query Config. That
+     * one keeps a free-text clause intact for an author editing raw SOQL; this one
+     * backs a field picker, so it can canonicalize, verify the field is actually
+     * sortable, and check what follows a relationship hop rather than only the
+     * token before the dot.
+     *
+     * Injection defense is an ALLOWLIST OF CHARACTERS, not a keyword blocklist like
+     * sanitizeCondition(). An ORDER BY clause needs only field paths, commas,
+     * spaces and the ASC/DESC/NULLS/FIRST/LAST keywords — quotes, parentheses,
+     * semicolons and comment markers have no legitimate use here, so rejecting
+     * every character outside that alphabet leaves nothing to keep ahead of. Every
+     * field path is then resolved through Schema describe, so an unknown field is
+     * an error at submit time rather than a batch that dies in start().
+     *
+     * @param objectName The base SObject the bulk query runs against
+     * @param sortOrder Author-supplied clause, with or without a leading "ORDER BY"
+     * @return The canonical clause, or null when nothing was supplied
+     */
+    public static String normalizeSortOrder(String objectName, String sortOrder) {
+        if (String.isBlank(sortOrder)) {
+            return null;
+        }
+        SObjectType objType = String.isBlank(objectName) ? null : Schema.getGlobalDescribe().get(objectName);
+        if (objType == null) {
+            throw new DocGenException('Invalid or inaccessible object: ' + objectName);
+        }
+        String clause = sortOrder.trim();
+        // Authors paste the whole clause as readily as just the field list.
+        if (clause.length() > 9 && clause.substring(0, 9).equalsIgnoreCase('ORDER BY ')) {
+            clause = clause.substring(9).trim();
+        }
+        if (!Pattern.matches('[A-Za-z0-9_., ]+', clause)) {
+            throw new DocGenException('Invalid characters in sort order: ' + sortOrder);
+        }
+
+        List<String> terms = new List<String>();
+        Set<String> seenPaths = new Set<String>();
+        for (String rawTerm : clause.split(',')) {
+            String term = rawTerm.trim();
+            if (String.isBlank(term)) {
+                continue;
+            }
+            if (terms.size() >= MAX_SORT_TERMS) {
+                throw new DocGenException('A sort order may combine at most ' + MAX_SORT_TERMS + ' fields.');
+            }
+            terms.add(normalizeSortTerm(objType, term, seenPaths));
+        }
+        if (terms.isEmpty()) {
+            return null;
+        }
+
+        // Deterministic tie-break. Sorting 200 Opportunities by Account.Name leaves
+        // every same-account group in arbitrary order, so two runs of the same job
+        // can produce two different packets. Appending the base object's own name
+        // field makes the order reproducible; skipped when the author already
+        // supplied more than one term, or when that field is already in the clause.
+        if (terms.size() == 1) {
+            String tieBreak = nameFieldPath(objType);
+            if (tieBreak != null && !seenPaths.contains(tieBreak.toLowerCase())) {
+                terms.add(tieBreak + ' ASC NULLS LAST');
+            }
+        }
+
+        String result = String.join(terms, ', ');
+        if (result.length() > 255) {
+            throw new DocGenException('Sort order is too long — use fewer or shorter fields.');
+        }
+        return result;
+    }
+
+    /**
+     * Canonicalizes one `Field [ASC|DESC] [NULLS FIRST|LAST]` term.
+     */
+    private static String normalizeSortTerm(SObjectType objType, String term, Set<String> seenPaths) {
+        List<String> tokens = term.split(' +');
+        String path = validateSortFieldPath(objType, tokens[0]);
+        if (!seenPaths.add(path.toLowerCase())) {
+            throw new DocGenException('Duplicate sort field: ' + tokens[0]);
+        }
+
+        String direction = 'ASC';
+        String nullsClause = null;
+        Integer i = 1;
+        if (i < tokens.size() && (tokens[i].equalsIgnoreCase('ASC') || tokens[i].equalsIgnoreCase('DESC'))) {
+            direction = tokens[i].toUpperCase();
+            i++;
+        }
+        if (i < tokens.size() && tokens[i].equalsIgnoreCase('NULLS')) {
+            i++;
+            if (i >= tokens.size() || !(tokens[i].equalsIgnoreCase('FIRST') || tokens[i].equalsIgnoreCase('LAST'))) {
+                throw new DocGenException('NULLS must be followed by FIRST or LAST: ' + term);
+            }
+            nullsClause = ' NULLS ' + tokens[i].toUpperCase();
+            i++;
+        }
+        if (i < tokens.size()) {
+            throw new DocGenException('Unrecognized sort option: ' + tokens[i]);
+        }
+        // SOQL sorts blanks first on an ascending sort, which would open a merged
+        // packet with the records that have nothing in the sort field. Default the
+        // empties to the back unless the author asked for the opposite.
+        if (nullsClause == null) {
+            nullsClause = ' NULLS LAST';
+        }
+        return path + ' ' + direction + nullsClause;
+    }
+
+    /**
+     * Resolves a (possibly relationship-traversing) sort field path against Schema
+     * and returns it with the API's own casing. Throws for anything unknown,
+     * unsortable, or beyond MAX_SORT_HOPS.
+     *
+     * Polymorphic lookups (OwnerId on Case, WhatId on Task) are carried as a LIST
+     * of candidate types: SOQL only permits traversing one when the field being
+     * reached exists on every type the lookup can point at, so that is exactly the
+     * condition checked at each hop.
+     */
+    @TestVisible
+    private static String validateSortFieldPath(SObjectType objType, String path) {
+        List<String> parts = path.split('\\.');
+        if (parts.size() > MAX_SORT_HOPS + 1) {
+            throw new DocGenException('A sort field may traverse at most ' + MAX_SORT_HOPS + ' relationships: ' + path);
+        }
+        List<SObjectType> currentTypes = new List<SObjectType>{ objType };
+        List<String> canonical = new List<String>();
+
+        for (Integer i = 0; i < parts.size(); i++) {
+            String part = parts[i];
+            if (String.isBlank(part)) {
+                throw new DocGenException('Invalid sort field: ' + path);
+            }
+            Boolean isLast = (i == parts.size() - 1);
+
+            if (isLast) {
+                String resolvedName = null;
+                for (SObjectType t : currentTypes) {
+                    Schema.SObjectField f = t.getDescribe().fields.getMap().get(part.toLowerCase());
+                    if (f == null) {
+                        throw new DocGenException('Unknown sort field: ' + path);
+                    }
+                    Schema.DescribeFieldResult dfr = f.getDescribe();
+                    if (!dfr.isSortable()) {
+                        throw new DocGenException('This field cannot be sorted on: ' + path);
+                    }
+                    resolvedName = dfr.getName();
+                }
+                canonical.add(resolvedName);
+            } else {
+                List<SObjectType> nextTypes = new List<SObjectType>();
+                String relationshipName = null;
+                for (SObjectType t : currentTypes) {
+                    Schema.DescribeFieldResult rel = findRelationshipField(t, part);
+                    if (rel == null) {
+                        throw new DocGenException('Unknown relationship in sort field: ' + part);
+                    }
+                    relationshipName = rel.getRelationshipName();
+                    nextTypes.addAll(rel.getReferenceTo());
+                }
+                canonical.add(relationshipName);
+                currentTypes = nextTypes;
+            }
+        }
+        return String.join(canonical, '.');
+    }
+
+    /**
+     * Finds the lookup field on objType whose relationship name matches relName
+     * (`Account` -> AccountId, `Custom__r` -> Custom__c). Null when there is none.
+     */
+    private static Schema.DescribeFieldResult findRelationshipField(SObjectType objType, String relName) {
+        for (Schema.SObjectField f : objType.getDescribe().fields.getMap().values()) {
+            Schema.DescribeFieldResult dfr = f.getDescribe();
+            if (dfr.getType() != Schema.DisplayType.REFERENCE || dfr.getReferenceTo().isEmpty()) {
+                continue;
+            }
+            if (relName.equalsIgnoreCase(dfr.getRelationshipName())) {
+                return dfr;
+            }
+        }
+        return null;
+    }
+
+    /** The object's sortable name field (`Name`, `CaseNumber`, …), or null when it has none. */
+    private static String nameFieldPath(SObjectType objType) {
+        for (Schema.SObjectField f : objType.getDescribe().fields.getMap().values()) {
+            Schema.DescribeFieldResult dfr = f.getDescribe();
+            if (dfr.isNameField() && dfr.isSortable()) {
+                return dfr.getName();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Field options for the bulk runner's Sort By picker: every sortable field on
+     * the base object, plus the name field of each lookup's parent so the common
+     * "order these Opportunities by Account name" case is one click rather than a
+     * hand-typed relationship path.
+     *
+     * @param objectName The base SObject the bulk query runs against
+     * @return Picklist-shaped options, ordered by label
+     */
+    @AuraEnabled(cacheable=true)
+    public static List<SortFieldOption> getSortableFields(String objectName) {
+        try {
+            SObjectType objType = String.isBlank(objectName) ? null : Schema.getGlobalDescribe().get(objectName);
+            if (objType == null) {
+                return new List<SortFieldOption>();
+            }
+            List<SortFieldOption> options = new List<SortFieldOption>();
+            List<Schema.DescribeFieldResult> lookups = new List<Schema.DescribeFieldResult>();
+
+            for (Schema.SObjectField f : objType.getDescribe().fields.getMap().values()) {
+                Schema.DescribeFieldResult dfr = f.getDescribe();
+                if (!dfr.isSortable() || !dfr.isAccessible()) {
+                    continue;
+                }
+                options.add(new SortFieldOption(dfr.getLabel(), dfr.getName()));
+                // Single-target lookups only: a polymorphic one needs the reached
+                // field to exist on every candidate type, which is more than a
+                // picker entry can promise.
+                if (dfr.getType() == Schema.DisplayType.REFERENCE && dfr.getReferenceTo().size() == 1) {
+                    lookups.add(dfr);
+                }
+            }
+
+            for (Schema.DescribeFieldResult lookup : lookups) {
+                if (String.isBlank(lookup.getRelationshipName())) {
+                    continue;
+                }
+                SObjectType parent = lookup.getReferenceTo()[0];
+                for (Schema.SObjectField pf : parent.getDescribe().fields.getMap().values()) {
+                    Schema.DescribeFieldResult pdfr = pf.getDescribe();
+                    if (!pdfr.isNameField() || !pdfr.isSortable() || !pdfr.isAccessible()) {
+                        continue;
+                    }
+                    options.add(
+                        new SortFieldOption(
+                            lookup.getLabel() + ' > ' + pdfr.getLabel(),
+                            lookup.getRelationshipName() + '.' + pdfr.getName()
+                        )
+                    );
+                    break;
+                }
+            }
+
+            options.sort();
+            return options;
+        } catch (Exception e) {
+            throw DocGenService.ahe(e, 'Error loading sortable fields.');
+        }
+    }
+
+    /** One entry in the bulk runner's Sort By picker. */
+    public class SortFieldOption implements Comparable {
+        @AuraEnabled
+        public String label { get; set; }
+        @AuraEnabled
+        public String value { get; set; }
+
+        public SortFieldOption(String label, String value) {
+            this.label = label;
+            this.value = value;
+        }
+
+        public Integer compareTo(Object other) {
+            SortFieldOption o = (SortFieldOption) other;
+            Integer byLabel = this.label.compareTo(o.label);
+            // Labels are not unique on a Salesforce object; fall back to the API
+            // name so the picker order is stable rather than describe-order.
+            return byLabel != 0 ? byLabel : this.value.compareTo(o.value);
+        }
+    }
+
     /**
      * Analyzes a bulk job for governor limit risks before execution.
      * Checks SOQL queries, DML statements, heap (merge mode), and record count.
@@ -600,6 +898,7 @@ public with sharing class DocGenBulkController {
      * @param mergePdf Whether to merge all outputs into a single PDF
      * @param batchSize Number of records per batch execution (1-200)
      * @param mergeOnly Whether to only generate merged PDF without individual files
+     * @param sortOrder Optional SOQL ORDER BY clause controlling processing (and merged page) order
      * @return The DocGen_Job__c record ID
      */
     @AuraEnabled
@@ -609,11 +908,12 @@ public with sharing class DocGenBulkController {
         String jobLabel,
         Boolean mergePdf,
         Integer batchSize,
-        Boolean mergeOnly
+        Boolean mergeOnly,
+        String sortOrder
     ) {
         // The LWC boundary, and the ONLY place AuraHandledException may be raised.
         try {
-            return submitJobInternal(templateId, condition, jobLabel, mergePdf, batchSize, mergeOnly);
+            return submitJobInternal(templateId, condition, jobLabel, mergePdf, batchSize, mergeOnly, sortOrder);
         } catch (Exception e) {
             throw DocGenService.ahe(e, 'Error starting bulk generation job.');
         }
@@ -646,6 +946,22 @@ public with sharing class DocGenBulkController {
         Integer batchSize,
         Boolean mergeOnly
     ) {
+        return submitJobInternal(templateId, condition, jobLabel, mergePdf, batchSize, mergeOnly, null);
+    }
+
+    /**
+     * As above, with an ORDER BY clause for the bulk query. Plain-Apex overload —
+     * NOT @AuraEnabled, which permits only one method of a given name.
+     */
+    public static Id submitJobInternal(
+        Id templateId,
+        String condition,
+        String jobLabel,
+        Boolean mergePdf,
+        Integer batchSize,
+        Boolean mergeOnly,
+        String sortOrder
+    ) {
         try {
             Boolean isMergeOnly = (mergeOnly == true);
             Boolean isMergeMode = (mergePdf == true) || isMergeOnly;
@@ -667,12 +983,21 @@ public with sharing class DocGenBulkController {
                 );
             }
 
+            // Validate the sort clause HERE, where the caller still has somewhere to
+            // put the error. DocGenBatch.start() re-validates it, but a throw there
+            // aborts the batch after the job record already exists — the author sees
+            // a job that never leaves Processing instead of "Unknown sort field".
+            String safeSortOrder = String.isBlank(sortOrder)
+                ? null
+                : normalizeSortOrder(templateBaseObject(templateId), sortOrder);
+
             // 1. Create Job Record
             DocGen_Job__c job = new DocGen_Job__c(
                 Template__c = templateId,
                 Query_Condition__c = condition,
                 Status__c = 'Queued',
-                Merge_Only__c = isMergeOnly
+                Merge_Only__c = isMergeOnly,
+                Sort_Order__c = safeSortOrder
             );
             if (String.isNotBlank(jobLabel)) {
                 job.Label__c = jobLabel;
@@ -686,7 +1011,14 @@ public with sharing class DocGenBulkController {
             // documented in DocGenFlsGuard.cls.
             DocGenFlsGuard.assertCreateable(
                 job,
-                new Set<String>{ 'Template__c', 'Query_Condition__c', 'Status__c', 'Merge_Only__c', 'Label__c' }
+                new Set<String>{
+                    'Template__c',
+                    'Query_Condition__c',
+                    'Status__c',
+                    'Merge_Only__c',
+                    'Label__c',
+                    'Sort_Order__c'
+                }
             );
             /* code-analyzer-suppress ApexFlsViolation */
             Database.insert(job, AccessLevel.SYSTEM_MODE);
@@ -701,6 +1033,30 @@ public with sharing class DocGenBulkController {
             // Catchable by design — see the note above.
             throw new DocGenException('Error starting bulk generation job. (' + e.getMessage() + ')');
         }
+    }
+
+    /**
+     * The SObject a template runs against — the schema a sort clause is validated
+     * against. Queried only when a sort order was actually supplied, so the common
+     * unsorted job pays nothing for it.
+     */
+    private static String templateBaseObject(Id templateId) {
+        if (templateId == null) {
+            return null;
+        }
+        DocGenFlsGuard.assertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Base_Object_API__c' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Template__c> templates = [
+            SELECT Base_Object_API__c
+            FROM DocGen_Template__c
+            WHERE Id = :templateId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (templates.isEmpty()) {
+            throw new DocGenException('Template not found.');
+        }
+        return templates[0].Base_Object_API__c;
     }
 
     private static Boolean isFillablePdfTemplate(Id templateId) {

--- a/force-app/main/default/classes/DocGenBulkControllerTest.cls
+++ b/force-app/main/default/classes/DocGenBulkControllerTest.cls
@@ -200,7 +200,7 @@ public with sharing class DocGenBulkControllerTest {
         DocGen_Template__c temp = [SELECT Id FROM DocGen_Template__c LIMIT 1];
 
         Test.startTest();
-        Id jobId = DocGenBulkController.submitJob(temp.Id, 'Name != null', 'Test Job', true, 10, false);
+        Id jobId = DocGenBulkController.submitJob(temp.Id, 'Name != null', 'Test Job', true, 10, false, null);
         Test.stopTest();
 
         System.assertNotEquals(null, jobId, 'Job ID should be returned');

--- a/force-app/main/default/classes/DocGenBulkFlowAction.cls
+++ b/force-app/main/default/classes/DocGenBulkFlowAction.cls
@@ -26,9 +26,16 @@ global with sharing class DocGenBulkFlowAction { // NOPMD AvoidGlobalModifier â€
         @InvocableVariable(
             label='Record IDs'
             required=false
-            description='Optional collection of record IDs to generate documents for. When supplied, the bulk job runs against just these records (Id IN clause). Combine with WHERE Condition to filter the set further. Skips the need to save a Query Filter when the calling Flow has already determined which records to target.'
+            description='Optional collection of record IDs to generate documents for. When supplied, the bulk job runs against just these records (Id IN clause). Combine with WHERE Condition to filter the set further. Skips the need to save a Query Filter when the calling Flow has already determined which records to target. Note: SOQL does not preserve the order of this collection â€” use Sort Order to control document order.'
         )
         global List<String> recordIds;
+
+        @InvocableVariable(
+            label='Sort Order'
+            required=false
+            description='Optional SOQL ORDER BY clause controlling the order records are processed â€” and therefore the page order of the combined PDF. Field API names only, ASC/DESC and NULLS FIRST/LAST supported, up to 3 fields. Relationship fields work (e.g. Account.Name DESC). Leave blank to keep the previous behaviour (record creation order).'
+        )
+        global String sortOrder;
 
         @InvocableVariable(label='Job Label' description='A friendly label for this job (shown in Job History)')
         global String jobLabel;
@@ -65,7 +72,7 @@ global with sharing class DocGenBulkFlowAction { // NOPMD AvoidGlobalModifier â€
 
     @InvocableMethod(
         label='Generate Bulk Documents'
-        description='Starts a batch job to generate documents for multiple records. Supports combined PDF, individual files, batch sizing, and WHERE filters.'
+        description='Starts a batch job to generate documents for multiple records. Supports combined PDF, individual files, batch sizing, WHERE filters, and sort order.'
     )
     global static List<Response> generateBulkDocuments(List<Request> requests) {
         List<Response> responses = new List<Response>();
@@ -108,7 +115,8 @@ global with sharing class DocGenBulkFlowAction { // NOPMD AvoidGlobalModifier â€
                     req.jobLabel,
                     mergePdf,
                     batchSize,
-                    mergeOnly
+                    mergeOnly,
+                    req.sortOrder
                 );
                 res.jobId = jobId;
                 res.success = true;

--- a/force-app/main/default/classes/DocGenBulkFlowActionTest.cls
+++ b/force-app/main/default/classes/DocGenBulkFlowActionTest.cls
@@ -204,6 +204,61 @@ private class DocGenBulkFlowActionTest {
     }
 
     @IsTest
+    static void testGenerateBulk_sortOrderReachesTheJob() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c temp = [SELECT Id FROM DocGen_Template__c LIMIT 1];
+
+            DocGenBulkFlowAction.Request req = new DocGenBulkFlowAction.Request();
+            req.templateId = temp.Id;
+            // Scoped to one record: an unfiltered set spans more than one batch
+            // execution, and a test method may only trigger executeBatch once.
+            req.queryCondition = 'Name = \'Test Account 1\'';
+            req.sortOrder = 'name desc';
+
+            Test.startTest();
+            List<DocGenBulkFlowAction.Response> responses = DocGenBulkFlowAction.generateBulkDocuments(
+                new List<DocGenBulkFlowAction.Request>{ req }
+            );
+            Test.stopTest();
+
+            System.assertEquals(
+                true,
+                responses[0].success,
+                'Sorted Flow job should start: ' + responses[0].errorMessage
+            );
+            DocGen_Job__c job = [SELECT Sort_Order__c FROM DocGen_Job__c WHERE Id = :responses[0].jobId];
+            System.assertEquals(
+                'Name DESC NULLS LAST',
+                job.Sort_Order__c,
+                'The Flow input should be validated and canonicalized like the runner\'s.'
+            );
+        }
+    }
+
+    @IsTest
+    static void testGenerateBulk_badSortOrderFailsTheActionNotTheInterview() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c temp = [SELECT Id FROM DocGen_Template__c LIMIT 1];
+
+            DocGenBulkFlowAction.Request req = new DocGenBulkFlowAction.Request();
+            req.templateId = temp.Id;
+            req.sortOrder = 'Bogus__c ASC';
+
+            Test.startTest();
+            List<DocGenBulkFlowAction.Response> responses = DocGenBulkFlowAction.generateBulkDocuments(
+                new List<DocGenBulkFlowAction.Request>{ req }
+            );
+            Test.stopTest();
+
+            // Reported on the outputs — a fault would take the whole Flow down.
+            System.assertEquals(false, responses[0].success, 'A bad sort field should fail the action.');
+            System.assertNotEquals(null, responses[0].errorMessage, 'The Flow author needs to be told why.');
+        }
+    }
+
+    @IsTest
     static void testBulkFlowActionResponseCoverage() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {

--- a/force-app/main/default/classes/DocGenBulkTests.cls
+++ b/force-app/main/default/classes/DocGenBulkTests.cls
@@ -379,7 +379,8 @@ private class DocGenBulkTests {
                 'Test Job',
                 false,
                 1,
-                false
+                false,
+                null
             );
             Test.stopTest();
 
@@ -403,7 +404,8 @@ private class DocGenBulkTests {
                 'AcroForm Bulk Individual',
                 false,
                 1,
-                false
+                false,
+                null
             );
             Test.stopTest();
 
@@ -465,7 +467,8 @@ private class DocGenBulkTests {
                     'AcroForm Bulk Merge',
                     true,
                     1,
-                    false
+                    false,
+                    null
                 );
                 System.assert(false, 'Merged AcroForm bulk jobs should be rejected before the batch queues.');
             } catch (AuraHandledException e) {
@@ -1231,7 +1234,15 @@ private class DocGenBulkTests {
 
             // Submit via controller with mergePdf=true
             Test.startTest();
-            Id jobId = DocGenBulkController.submitJob(t.Id, 'Name = \'ChainTestAcct\'', 'Chain Job', true, 1, false);
+            Id jobId = DocGenBulkController.submitJob(
+                t.Id,
+                'Name = \'ChainTestAcct\'',
+                'Chain Job',
+                true,
+                1,
+                false,
+                null
+            );
             Test.stopTest();
 
             DocGen_Job__c updated = [SELECT Status__c FROM DocGen_Job__c WHERE Id = :jobId];
@@ -1370,7 +1381,8 @@ private class DocGenBulkTests {
                 'Merge PDF Job',
                 true,
                 1,
-                false
+                false,
+                null
             );
             Test.stopTest();
 
@@ -1411,7 +1423,8 @@ private class DocGenBulkTests {
                 'MergeOnly Job',
                 false,
                 1,
-                true
+                true,
+                null
             );
             Test.stopTest();
 
@@ -1436,7 +1449,15 @@ private class DocGenBulkTests {
             DocGen_Template__c t = TestDataFactory.getTestTemplate();
 
             Test.startTest();
-            Id jobId = DocGenBulkController.submitJob(t.Id, 'Name = \'DocGen Test Account\'', null, false, 50, false);
+            Id jobId = DocGenBulkController.submitJob(
+                t.Id,
+                'Name = \'DocGen Test Account\'',
+                null,
+                false,
+                50,
+                false,
+                null
+            );
             Test.stopTest();
 
             DocGen_Job__c job = [SELECT Id, Status__c, Label__c FROM DocGen_Job__c WHERE Id = :jobId];
@@ -1458,7 +1479,7 @@ private class DocGenBulkTests {
 
             Test.startTest();
             // null batchSize should default to 1
-            Id jobId = DocGenBulkController.submitJob(t.Id, null, null, false, null, false);
+            Id jobId = DocGenBulkController.submitJob(t.Id, null, null, false, null, false, null);
             Test.stopTest();
 
             DocGen_Job__c job = [SELECT Id, Status__c FROM DocGen_Job__c WHERE Id = :jobId];
@@ -1718,7 +1739,8 @@ private class DocGenBulkTests {
                 'MergeOnly Job',
                 false,
                 1,
-                true
+                true,
+                null
             );
             Test.stopTest();
 
@@ -1739,7 +1761,7 @@ private class DocGenBulkTests {
             DocGen_Template__c t = TestDataFactory.getTestTemplate();
 
             Test.startTest();
-            Id jobId = DocGenBulkController.submitJob(t.Id, null, null, false, null, false);
+            Id jobId = DocGenBulkController.submitJob(t.Id, null, null, false, null, false, null);
             Test.stopTest();
 
             DocGen_Job__c job = [SELECT Id, Status__c FROM DocGen_Job__c WHERE Id = :jobId];
@@ -1961,7 +1983,7 @@ private class DocGenBulkTests {
             DocGen_Template__c t = TestDataFactory.getTestTemplate();
 
             Test.startTest();
-            Id jobId = DocGenBulkController.submitJob(t.Id, null, 'My Custom Label', false, 5, false);
+            Id jobId = DocGenBulkController.submitJob(t.Id, null, 'My Custom Label', false, 5, false, null);
             Test.stopTest();
 
             DocGen_Job__c job = [SELECT Label__c FROM DocGen_Job__c WHERE Id = :jobId];
@@ -1980,11 +2002,269 @@ private class DocGenBulkTests {
             DocGen_Template__c t = TestDataFactory.getTestTemplate();
 
             Test.startTest();
-            Id jobId = DocGenBulkController.submitJob(t.Id, null, '', false, 1, false);
+            Id jobId = DocGenBulkController.submitJob(t.Id, null, '', false, 1, false, null);
             Test.stopTest();
 
             DocGen_Job__c job = [SELECT Label__c FROM DocGen_Job__c WHERE Id = :jobId];
             System.assertEquals(null, job.Label__c, 'Blank label should be stored as null');
+        }
+    }
+
+    // =========================================================================
+    // Sort order — parent-level ORDER BY for the bulk query.
+    //
+    // The bulk query had no ORDER BY, so merged PDFs came out in record-creation
+    // order with no way to change it from the runner or the Flow action. These
+    // cover the clause validator, the picker that feeds it, and the fact that the
+    // validated clause survives all the way onto the job record.
+    // =========================================================================
+
+    @IsTest
+    static void testNormalizeSortOrderCanonicalizesFieldAndDirection() {
+        // Lower-case field, lower-case direction — authors type both.
+        String clause = DocGenBulkController.normalizeSortOrder('Account', 'name desc');
+        System.assertEquals(
+            'Name DESC NULLS LAST',
+            clause,
+            'Field casing, direction and NULLS handling should all be canonicalized.'
+        );
+    }
+
+    @IsTest
+    static void testNormalizeSortOrderAppendsNameTieBreak() {
+        String clause = DocGenBulkController.normalizeSortOrder('Account', 'AnnualRevenue DESC');
+        System.assertEquals(
+            'AnnualRevenue DESC NULLS LAST, Name ASC NULLS LAST',
+            clause,
+            'A single sort field should gain the name field as a tie-break so repeat runs produce the same packet order.'
+        );
+    }
+
+    @IsTest
+    static void testNormalizeSortOrderDoesNotDuplicateTieBreak() {
+        String clause = DocGenBulkController.normalizeSortOrder('Account', 'Name ASC');
+        System.assertEquals(
+            'Name ASC NULLS LAST',
+            clause,
+            'The tie-break must not repeat the field already sorted on.'
+        );
+    }
+
+    @IsTest
+    static void testNormalizeSortOrderTraversesRelationship() {
+        // The headline case: order child records by a PARENT field.
+        String clause = DocGenBulkController.normalizeSortOrder('Account', 'owner.name');
+        System.assert(
+            clause.startsWith('Owner.Name ASC'),
+            'Relationship traversal should resolve and canonicalize, got: ' + clause
+        );
+    }
+
+    @IsTest
+    static void testNormalizeSortOrderStripsLeadingOrderBy() {
+        String clause = DocGenBulkController.normalizeSortOrder('Account', 'ORDER BY Name');
+        System.assert(clause.startsWith('Name ASC'), 'A pasted "ORDER BY" prefix should be tolerated, got: ' + clause);
+    }
+
+    @IsTest
+    static void testNormalizeSortOrderHonorsExplicitNulls() {
+        String clause = DocGenBulkController.normalizeSortOrder('Account', 'AnnualRevenue ASC NULLS FIRST');
+        System.assert(
+            clause.startsWith('AnnualRevenue ASC NULLS FIRST'),
+            'An explicit NULLS FIRST must survive, got: ' + clause
+        );
+    }
+
+    @IsTest
+    static void testNormalizeSortOrderBlankReturnsNull() {
+        System.assertEquals(null, DocGenBulkController.normalizeSortOrder('Account', null), 'Null in, null out.');
+        System.assertEquals(null, DocGenBulkController.normalizeSortOrder('Account', '   '), 'Blank in, null out.');
+    }
+
+    @IsTest
+    static void testNormalizeSortOrderRejectsInjection() {
+        // Character allowlist: none of these belong in an ORDER BY clause.
+        List<String> attacks = new List<String>{
+            'Name ASC; DELETE FROM Account',
+            'Name) OR (1=1',
+            'Name /* comment */',
+            'Name -- comment',
+            'Name ASC, (SELECT Id FROM Contacts)'
+        };
+        for (String attack : attacks) {
+            Boolean caught = false;
+            try {
+                DocGenBulkController.normalizeSortOrder('Account', attack);
+            } catch (Exception e) {
+                caught = true;
+            }
+            System.assert(caught, 'Sort order should have been rejected: ' + attack);
+        }
+    }
+
+    @IsTest
+    static void testNormalizeSortOrderRejectsUnknownField() {
+        Boolean caught = false;
+        try {
+            DocGenBulkController.normalizeSortOrder('Account', 'NotAField__c ASC');
+        } catch (Exception e) {
+            caught = true;
+            System.assert(
+                e.getMessage().contains('Unknown sort field'),
+                'The error should name the problem, got: ' + e.getMessage()
+            );
+        }
+        System.assert(caught, 'An unknown field must be rejected at submit time, not at batch start.');
+    }
+
+    @IsTest
+    static void testNormalizeSortOrderRejectsUnknownRelationship() {
+        Boolean caught = false;
+        try {
+            DocGenBulkController.normalizeSortOrder('Account', 'Nope__r.Name ASC');
+        } catch (Exception e) {
+            caught = true;
+        }
+        System.assert(caught, 'An unknown relationship must be rejected.');
+    }
+
+    @IsTest
+    static void testNormalizeSortOrderRejectsBadModifier() {
+        Boolean caught = false;
+        try {
+            DocGenBulkController.normalizeSortOrder('Account', 'Name SIDEWAYS');
+        } catch (Exception e) {
+            caught = true;
+        }
+        System.assert(caught, 'Only ASC/DESC/NULLS FIRST/NULLS LAST may follow the field.');
+
+        caught = false;
+        try {
+            DocGenBulkController.normalizeSortOrder('Account', 'Name ASC NULLS');
+        } catch (Exception e) {
+            caught = true;
+        }
+        System.assert(caught, 'A dangling NULLS must be rejected.');
+    }
+
+    @IsTest
+    static void testNormalizeSortOrderRejectsDuplicateAndOverlongClauses() {
+        Boolean caught = false;
+        try {
+            DocGenBulkController.normalizeSortOrder('Account', 'Name ASC, Name DESC');
+        } catch (Exception e) {
+            caught = true;
+        }
+        System.assert(caught, 'The same field twice is a mistake, not an order.');
+
+        caught = false;
+        try {
+            DocGenBulkController.normalizeSortOrder('Account', 'Name, AnnualRevenue, Type, Industry');
+        } catch (Exception e) {
+            caught = true;
+        }
+        System.assert(caught, 'More than 3 sort fields should be rejected — the clause has to fit Sort_Order__c.');
+    }
+
+    @IsTest
+    static void testNormalizeSortOrderRejectsInvalidObject() {
+        Boolean caught = false;
+        try {
+            DocGenBulkController.normalizeSortOrder('NoSuchObject__c', 'Name');
+        } catch (Exception e) {
+            caught = true;
+        }
+        System.assert(caught, 'An unresolvable base object must be rejected.');
+    }
+
+    @IsTest
+    static void testGetSortableFieldsOffersOwnFieldsAndParentNames() {
+        List<DocGenBulkController.SortFieldOption> options = DocGenBulkController.getSortableFields('Account');
+        System.assert(!options.isEmpty(), 'Account should expose sortable fields.');
+
+        Boolean hasOwnField = false;
+        Boolean hasTraversal = false;
+        String previousLabel = null;
+        for (DocGenBulkController.SortFieldOption o : options) {
+            if (o.value == 'Name') {
+                hasOwnField = true;
+            }
+            if (o.value.contains('.')) {
+                hasTraversal = true;
+                // Every offered traversal must survive the validator, or the picker
+                // is handing the user a value the submit path rejects.
+                DocGenBulkController.normalizeSortOrder('Account', o.value);
+            }
+            if (previousLabel != null) {
+                System.assert(previousLabel.compareTo(o.label) <= 0, 'Options should be label-ordered for the picker.');
+            }
+            previousLabel = o.label;
+        }
+        System.assert(hasOwnField, 'The object\'s own Name field should be offered.');
+        System.assert(hasTraversal, 'Parent name fields (e.g. Owner > Full Name) should be offered.');
+
+        System.assert(
+            DocGenBulkController.getSortableFields('NoSuchObject__c').isEmpty(),
+            'An unknown object should yield no options rather than an error.'
+        );
+    }
+
+    @IsTest
+    static void testSubmitJobStoresValidatedSortOrder() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c t = TestDataFactory.getTestTemplate();
+
+            Test.startTest();
+            // startTest/stopTest runs the batch, so this also proves DocGenBatch
+            // .start() builds a QueryLocator the platform accepts with the clause on it.
+            Id jobId = DocGenBulkController.submitJob(t.Id, null, 'Sorted Job', false, 1, false, 'name desc');
+            Test.stopTest();
+
+            DocGen_Job__c job = [SELECT Sort_Order__c, Status__c FROM DocGen_Job__c WHERE Id = :jobId];
+            System.assertEquals(
+                'Name DESC NULLS LAST',
+                job.Sort_Order__c,
+                'The canonical clause should be stored on the job, not the raw input.'
+            );
+            System.assertNotEquals('Queued', job.Status__c, 'The sorted job should have run.');
+        }
+    }
+
+    @IsTest
+    static void testSubmitJobRejectsInvalidSortOrder() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c t = TestDataFactory.getTestTemplate();
+            Boolean caught = false;
+            Test.startTest();
+            try {
+                DocGenBulkController.submitJob(t.Id, null, 'Bad Sort', false, 1, false, 'Bogus__c ASC');
+            } catch (AuraHandledException e) {
+                caught = true;
+            }
+            Test.stopTest();
+            System.assert(caught, 'A bad sort field must fail at submit time.');
+            System.assertEquals(
+                0,
+                [SELECT COUNT() FROM DocGen_Job__c WHERE Label__c = 'Bad Sort'],
+                'No job record should be left behind by a rejected sort order.'
+            );
+        }
+    }
+
+    @IsTest
+    static void testSubmitJobWithoutSortOrderStaysUnordered() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c t = TestDataFactory.getTestTemplate();
+
+            Test.startTest();
+            Id jobId = DocGenBulkController.submitJob(t.Id, null, 'Unsorted Job', false, 1, false, null);
+            Test.stopTest();
+
+            DocGen_Job__c job = [SELECT Sort_Order__c FROM DocGen_Job__c WHERE Id = :jobId];
+            System.assertEquals(null, job.Sort_Order__c, 'Omitting a sort order must remain the default behaviour.');
         }
     }
 }

--- a/force-app/main/default/classes/DocGenGiantQueryBatch.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryBatch.cls
@@ -27,6 +27,9 @@ public with sharing class DocGenGiantQueryBatch implements Database.Batchable<St
     private String lastCursorId;
     private Integer batchSize;
     private Integer fragmentSequence;
+    // Rows rendered by previous fragments, so {RowNumber} keeps counting across
+    // execute() calls instead of restarting at 1 in every chunk. Stateful.
+    private Integer rowNumberOffset;
     private String outputFormat;
     private String giantRelationshipName;
     private String orderByClause;
@@ -51,6 +54,7 @@ public with sharing class DocGenGiantQueryBatch implements Database.Batchable<St
         this.innerXml = innerXml;
         this.outputFormat = outputFormat;
         this.fragmentSequence = 0;
+        this.rowNumberOffset = 0;
         this.batchSize = 50;
         // DOCX loop bodies contain <w:tr>/<w:t>; HTML loop bodies don't. One
         // indexOf is cheap and avoids an extra SOQL for Type__c on every execute.
@@ -281,8 +285,10 @@ public with sharing class DocGenGiantQueryBatch implements Database.Batchable<St
                 innerXml,
                 relationshipName,
                 records,
-                allFields
+                allFields,
+                rowNumberOffset
             );
+            rowNumberOffset += records.size();
 
             String seq = String.valueOf(fragmentSequence++).leftPad(5, '0');
             Blob fragmentData;

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -7464,6 +7464,81 @@ private class DocGenMiscTests {
         }
     }
 
+    // ─── {RowNumber} across giant-query fragments ────────────────────────
+    // The giant path renders its loop in slices of batchSize per execute(), so
+    // each renderLoopBodyForRecords call sees only its own records. Without the
+    // running offset every fragment restarts at 1 — a 30,000-row table counting
+    // 1..50 over and over, which looks right on page one and ships unnoticed.
+
+    @IsTest
+    static void testRenderLoopBodyRowNumberContinuesAcrossFragments() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            Account acc = TestDataFactory.getTestAccount();
+            List<Contact> contacts = new List<Contact>();
+            for (Integer i = 0; i < 4; i++) {
+                contacts.add(new Contact(FirstName = 'Row' + i, LastName = 'Frag', AccountId = acc.Id));
+            }
+            insert contacts;
+            // Scoped by LastName, not AccountId: the shared test Account carries
+            // fixture Contacts of its own, which would pad the list.
+            List<Contact> queried = [
+                SELECT FirstName
+                FROM Contact
+                WHERE AccountId = :acc.Id AND LastName = 'Frag'
+                ORDER BY FirstName
+            ];
+
+            String innerXml = '[{RowNumber}:{FirstName}]';
+            List<Contact> firstHalf = new List<Contact>{ queried[0], queried[1] };
+            List<Contact> secondHalf = new List<Contact>{ queried[2], queried[3] };
+
+            Test.startTest();
+            String frag1 = DocGenService.renderLoopBodyForRecords(
+                innerXml,
+                'Contacts',
+                firstHalf,
+                new List<String>{ 'FirstName' },
+                0
+            );
+            // Offset = rows already rendered, exactly as DocGenGiantQueryBatch accumulates it.
+            String frag2 = DocGenService.renderLoopBodyForRecords(
+                innerXml,
+                'Contacts',
+                secondHalf,
+                new List<String>{ 'FirstName' },
+                firstHalf.size()
+            );
+            Test.stopTest();
+
+            System.assertEquals('[1:Row0][2:Row1]', frag1, 'First fragment should number from 1.');
+            System.assertEquals('[3:Row2][4:Row3]', frag2, 'Second fragment must continue, not restart at 1.');
+        }
+    }
+
+    @IsTest
+    static void testRenderLoopBodyWithoutRowNumberTagIsUnaffected() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            Account acc = TestDataFactory.getTestAccount();
+            insert new Contact(FirstName = 'Plain', LastName = 'NoRowNum', AccountId = acc.Id);
+            List<Contact> queried = [SELECT FirstName FROM Contact WHERE LastName = 'NoRowNum'];
+
+            Test.startTest();
+            // The 4-arg overload is what every pre-existing caller uses; it must
+            // keep behaving exactly as before.
+            String result = DocGenService.renderLoopBodyForRecords(
+                '[{FirstName}]',
+                'Contacts',
+                queried,
+                new List<String>{ 'FirstName' }
+            );
+            Test.stopTest();
+
+            System.assertEquals('[Plain]', result, 'A body without {RowNumber} renders unchanged.');
+        }
+    }
+
     @IsTest
     static void testGenerateDocumentPartsGiantQueryWithInvalidTemplate() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -202,7 +202,9 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                 FROM ContentVersion
                 WHERE ContentDocumentId IN :docIds AND Title LIKE :likePattern AND IsLatest = TRUE
                 WITH SYSTEM_MODE // NOPMD — package-internal template assets
-                ORDER BY CreatedDate DESC
+                // Id DESC breaks same-second CreatedDate ties — see the sibling
+                // loadForLinkedEntityByTitlePrefix query.
+                ORDER BY CreatedDate DESC, Id DESC
                 LIMIT 50
             ];
         }
@@ -254,7 +256,14 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                 FROM ContentVersion
                 WHERE ContentDocumentId IN :docIds AND Title LIKE :likePattern AND IsLatest = TRUE
                 WITH SYSTEM_MODE // NOPMD — package-internal pre-decomposed parts linked to template version
-                ORDER BY CreatedDate DESC // newest snapshot wins if duplicates exist (#203)
+                // Newest snapshot wins if duplicates exist (#203). Id DESC breaks the
+                // tie: CreatedDate has one-second granularity, so two versions saved
+                // in the same second — an edit saved twice, or both writes inside one
+                // transaction — order arbitrarily, and "newest wins" silently returned
+                // whichever row the optimizer felt like. That reads back an OLD body
+                // into the Designer with no error. Ids are assigned in insert order,
+                // so the higher Id is the later write.
+                ORDER BY CreatedDate DESC, Id DESC
             ];
         }
 
@@ -4190,9 +4199,15 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                                     prefetchImagesForIds(loopIds);
                                 }
                                 Integer iterCount = 0;
+                                Boolean wantsRowNumber = loopBodyHasRowNumberTag(trueBranch);
+                                Integer rowNumber = 0;
                                 for (Object item : records) {
                                     if (item instanceof Map<String, Object>) {
-                                        sectionResult += processXml(trueBranch, (Map<String, Object>) item);
+                                        rowNumber++;
+                                        sectionResult += processXml(
+                                            trueBranch,
+                                            rowContext((Map<String, Object>) item, wantsRowNumber, rowNumber)
+                                        );
                                     }
                                     iterCount++;
                                     if (Math.mod(iterCount, HEAP_CHECK_EVERY_N_ITERS) == 0) {
@@ -4224,9 +4239,15 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                                 prefetchImagesForIds(loopIds);
                             }
                             Integer iterCount = 0;
+                            Boolean wantsRowNumber = loopBodyHasRowNumberTag(trueBranch);
+                            Integer rowNumber = 0;
                             for (Object item : listVal) {
                                 if (item instanceof Map<String, Object>) {
-                                    sectionResult += processXml(trueBranch, (Map<String, Object>) item);
+                                    rowNumber++;
+                                    sectionResult += processXml(
+                                        trueBranch,
+                                        rowContext((Map<String, Object>) item, wantsRowNumber, rowNumber)
+                                    );
                                 }
                                 iterCount++;
                                 if (Math.mod(iterCount, HEAP_CHECK_EVERY_N_ITERS) == 0) {
@@ -8234,6 +8255,39 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
     }
 
     /**
+     * True when a loop body references {RowNumber} (bare or with a format suffix).
+     *
+     * Probed once per loop rather than assumed, because supplying the number means
+     * COPYING each row's data map to add the key — cheap for one table, real heap on
+     * a 30,000-row giant-query loop. Templates that don't ask for it pay nothing.
+     */
+    @TestVisible
+    private static Boolean loopBodyHasRowNumberTag(String innerXml) {
+        if (String.isBlank(innerXml)) {
+            return false;
+        }
+        String lower = innerXml.toLowerCase();
+        return lower.contains('{rownumber}') || lower.contains('{rownumber:');
+    }
+
+    /**
+     * The per-row context for one loop iteration: the record's own map, plus
+     * {RowNumber} when the body asks for it.
+     *
+     * The copy is deliberate — writing the key into the caller's map would leak the
+     * counter into the record data itself, and a nested loop would then see its
+     * parent's row number as a stale field.
+     */
+    private static Map<String, Object> rowContext(Map<String, Object> row, Boolean wantsRowNumber, Integer rowNumber) {
+        if (!wantsRowNumber) {
+            return row;
+        }
+        Map<String, Object> ctx = new Map<String, Object>(row);
+        ctx.put('RowNumber', rowNumber);
+        return ctx;
+    }
+
+    /**
      * Applies {%Image:N:SIZE} size token to an ImageRenderSpec.
      *   single number   → max dimension (preserves aspect)
      *   WxH             → explicit width × height
@@ -9205,7 +9259,29 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         List<SObject> records,
         List<String> fieldNames
     ) {
+        return renderLoopBodyForRecords(innerXml, relationshipName, records, fieldNames, 0);
+    }
+
+    /**
+     * As above, continuing {RowNumber} from a running offset.
+     *
+     * The giant-query path renders its loop in fragments of `batchSize` records per
+     * execute(), so each call sees only its own slice. Without the offset every
+     * fragment would restart at 1 and a 30,000-row table would count 1..200 over and
+     * over — which looks plausible enough on page 1 to ship unnoticed.
+     *
+     * @param rowNumberOffset Rows already rendered by previous fragments (0 for the first)
+     */
+    public static String renderLoopBodyForRecords(
+        String innerXml,
+        String relationshipName,
+        List<SObject> records,
+        List<String> fieldNames,
+        Integer rowNumberOffset
+    ) {
         String rendered = '';
+        Boolean wantsRowNumber = loopBodyHasRowNumberTag(innerXml);
+        Integer rowNumber = (rowNumberOffset == null ? 0 : rowNumberOffset);
         for (SObject rec : records) {
             Map<String, Object> dataMap = new Map<String, Object>();
             for (String field : fieldNames) {
@@ -9237,6 +9313,12 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                 } catch (Exception e) {
                     dataMap.put(field, null);
                 }
+            }
+            rowNumber++;
+            if (wantsRowNumber) {
+                // dataMap is built fresh per record here, so it can be written
+                // directly — no copy needed as in the in-memory loop path.
+                dataMap.put('RowNumber', rowNumber);
             }
             rendered += processXml(innerXml, dataMap);
         }

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -96,4 +96,12 @@
         <shortDescription>Runner save-to-record output option</shortDescription>
         <value>Save to Record</value>
     </labels>
+    <labels>
+        <fullName>DocGenRunner_SaveAndDownload</fullName>
+        <categories>DocGenRunner</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Runner save-to-record-and-download output option</shortDescription>
+        <value>Save &amp; Download</value>
+    </labels>
 </CustomLabels>

--- a/force-app/main/default/lwc/docGenBulkRunner/docGenBulkRunner.html
+++ b/force-app/main/default/lwc/docGenBulkRunner/docGenBulkRunner.html
@@ -301,6 +301,54 @@
                     </template>
                 </div>
 
+                <!-- Sort order — decides page order in a combined PDF -->
+                <template if:true={hasSortFields}>
+                    <div class="slds-var-m-top_medium">
+                        <div class="slds-grid slds-gutters_small slds-grid_vertical-align-end slds-wrap">
+                            <div class="slds-col slds-size_1-of-2">
+                                <lightning-combobox
+                                    label="Sort By (optional)"
+                                    value={sortField}
+                                    options={sortFieldOptions}
+                                    onchange={handleSortFieldChange}
+                                    placeholder="Record order (default)"
+                                    disabled={isProcessing}
+                                    field-level-help="Controls the order records are processed — and the page order of a combined PDF. Related fields are listed as 'Account > Account Name'. Leave empty to keep the default record order."
+                                >
+                                </lightning-combobox>
+                            </div>
+                            <div class="slds-col slds-size_1-of-3">
+                                <lightning-combobox
+                                    label="Direction"
+                                    value={sortDirection}
+                                    options={sortDirectionOptions}
+                                    onchange={handleSortDirectionChange}
+                                    disabled={isProcessing}
+                                >
+                                </lightning-combobox>
+                            </div>
+                            <template if:true={isSortSelected}>
+                                <div class="slds-col">
+                                    <lightning-button
+                                        label="Clear"
+                                        onclick={handleClearSort}
+                                        disabled={isProcessing}
+                                        variant="neutral"
+                                    >
+                                    </lightning-button>
+                                </div>
+                            </template>
+                        </div>
+                        <template if:true={isSortSelected}>
+                            <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small">
+                                Documents will be generated in order of
+                                <code class="inline-code">{sortOrderClause}</code>. Records tied on this field fall back
+                                to name order, so the packet is reproducible.
+                            </p>
+                        </template>
+                    </div>
+                </template>
+
                 <!-- Pre-flight Analysis -->
                 <template if:true={filterValidated}>
                     <div class="analysis-card slds-var-m-top_medium">

--- a/force-app/main/default/lwc/docGenBulkRunner/docGenBulkRunner.js
+++ b/force-app/main/default/lwc/docGenBulkRunner/docGenBulkRunner.js
@@ -6,6 +6,7 @@ import { downloadBase64, extractWhereClause } from 'c/docGenUtils';
 import getBulkTemplates from '@salesforce/apex/DocGenBulkController.getBulkTemplates';
 import validateFilter from '@salesforce/apex/DocGenBulkController.validateFilter';
 import submitJob from '@salesforce/apex/DocGenBulkController.submitJob';
+import getSortableFields from '@salesforce/apex/DocGenBulkController.getSortableFields';
 import getJobStatus from '@salesforce/apex/DocGenBulkController.getJobStatus';
 import getSavedQueries from '@salesforce/apex/DocGenBulkController.getSavedQueries';
 import saveQuery from '@salesforce/apex/DocGenBulkController.saveQuery';
@@ -34,6 +35,12 @@ export default class DocGenBulkRunner extends NavigationMixin(LightningElement) 
     @track condition = '';
     @track recordCount = null;
     @track isValidating = false;
+
+    // Sort order — decides the page order of a combined PDF, because the batch
+    // processes records in query order and the merge assembles in that sequence.
+    @track sortFieldOptions = [];
+    @track sortField = '';
+    @track sortDirection = 'ASC';
 
     @track jobId;
     @track jobStatus;
@@ -194,6 +201,7 @@ export default class DocGenBulkRunner extends NavigationMixin(LightningElement) 
             // place it kept the Preview button enabled against a record of the wrong
             // sObject type, and handed the record picker a value it cannot resolve.
             this.sampleRecordId = '';
+            this.resetSortForNewObject();
             this.loadSavedQueries();
             this.applyAutoFilter();
         }
@@ -344,6 +352,7 @@ export default class DocGenBulkRunner extends NavigationMixin(LightningElement) 
             // See handleTemplateSelect — a stale sample record from the previous
             // template's object must not survive the switch.
             this.sampleRecordId = '';
+            this.resetSortForNewObject();
             this.loadSavedQueries();
             this.applyAutoFilter();
         }
@@ -477,6 +486,66 @@ export default class DocGenBulkRunner extends NavigationMixin(LightningElement) 
         this.filterValidated = false;
     }
 
+    // --- Sort order ---
+
+    /**
+     * Clears the sort selection and reloads the picker for the newly selected
+     * template's base object. The old field list belongs to the old object, and a
+     * stale selection would be rejected at submit time.
+     */
+    resetSortForNewObject() {
+        this.sortField = '';
+        this.sortDirection = 'ASC';
+        this.sortFieldOptions = [];
+        this.loadSortableFields();
+    }
+
+    async loadSortableFields() {
+        if (!this.baseObject) return;
+        try {
+            const fields = await getSortableFields({ objectName: this.baseObject });
+            this.sortFieldOptions = fields.map((f) => ({ label: f.label, value: f.value }));
+        } catch (error) {
+            // Non-fatal — the job still runs, just in the previous unordered way.
+            // A toast here would fire on every template click for an object whose
+            // describe the running user cannot read.
+            this.sortFieldOptions = [];
+        }
+    }
+
+    get sortDirectionOptions() {
+        return [
+            { label: 'Ascending (A→Z, oldest first)', value: 'ASC' },
+            { label: 'Descending (Z→A, newest first)', value: 'DESC' }
+        ];
+    }
+
+    get hasSortFields() {
+        return this.sortFieldOptions.length > 0;
+    }
+
+    get isSortSelected() {
+        return !!this.sortField;
+    }
+
+    /** The ORDER BY clause sent to Apex; empty keeps the historical record order. */
+    get sortOrderClause() {
+        return this.sortField ? `${this.sortField} ${this.sortDirection}` : '';
+    }
+
+    handleSortFieldChange(event) {
+        this.sortField = event.detail.value;
+    }
+
+    handleSortDirectionChange(event) {
+        this.sortDirection = event.detail.value;
+    }
+
+    handleClearSort() {
+        this.sortField = '';
+        this.sortDirection = 'ASC';
+    }
+
     async handleValidate() {
         if (!this.baseObject) return;
         this.isValidating = true;
@@ -515,7 +584,8 @@ export default class DocGenBulkRunner extends NavigationMixin(LightningElement) 
                 jobLabel: this.jobLabel,
                 mergePdf: this.mergePdf || false,
                 batchSize: this.batchSize || 1,
-                mergeOnly: this.mergeOnly || false
+                mergeOnly: this.mergeOnly || false,
+                sortOrder: this.sortOrderClause
             });
             this.showToast('Success', 'Job started. Status will auto-refresh every 5 seconds.', 'success');
             this.startPolling();

--- a/force-app/main/default/lwc/docGenRunner/docGenRunner.js
+++ b/force-app/main/default/lwc/docGenRunner/docGenRunner.js
@@ -6,6 +6,7 @@ import getContentVersionBase64 from '@salesforce/apex/DocGenController.getConten
 import generatePdf from '@salesforce/apex/DocGenController.generatePdf';
 import saveGeneratedDocument from '@salesforce/apex/DocGenController.saveGeneratedDocument';
 import generatePdfAsync from '@salesforce/apex/DocGenController.generatePdfAsync';
+import getPdfSampleGenerationStatus from '@salesforce/apex/DocGenController.getPdfSampleGenerationStatus';
 import scoutAttachedImageSize from '@salesforce/apex/DocGenController.scoutAttachedImageSize';
 import getChildRelationships from '@salesforce/apex/DocGenController.getChildRelationships';
 import getChildRecordPdfs from '@salesforce/apex/DocGenController.getChildRecordPdfs';
@@ -48,6 +49,7 @@ import LBL_CREATE_PACKET from '@salesforce/label/c.DocGenRunner_CreatePacket';
 import LBL_COMBINE_PDFS_ACTION from '@salesforce/label/c.DocGenRunner_CombinePdfsAction';
 import LBL_DOWNLOAD from '@salesforce/label/c.DocGenRunner_Download';
 import LBL_SAVE_TO_RECORD from '@salesforce/label/c.DocGenRunner_SaveToRecord';
+import LBL_SAVE_AND_DOWNLOAD from '@salesforce/label/c.DocGenRunner_SaveAndDownload';
 
 export default class DocGenRunner extends NavigationMixin(LightningElement) {
     // Exposed to the template as {label.X}. Custom Labels resolve to the
@@ -59,7 +61,8 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
         chooseTemplate: LBL_CHOOSE_TEMPLATE,
         outputDestination: LBL_OUTPUT_DESTINATION,
         download: LBL_DOWNLOAD,
-        saveToRecord: LBL_SAVE_TO_RECORD
+        saveToRecord: LBL_SAVE_TO_RECORD,
+        saveAndDownload: LBL_SAVE_AND_DOWNLOAD
     };
 
     @api recordId;
@@ -202,6 +205,12 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
         if (this.canSaveToRecord) {
             modes.push('save');
         }
+        // Save & Download is offered only when the admin left BOTH destinations
+        // enabled — it is the combination of the two, not a third destination, so
+        // it must not reintroduce one the admin deliberately turned off.
+        if (this.canDownload && this.canSaveToRecord) {
+            modes.push('both');
+        }
         return modes;
     }
 
@@ -225,11 +234,28 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
                 class: resolvedMode === 'save' ? 'pill-btn active' : 'pill-btn'
             });
         }
+        if (allowedModes.includes('both')) {
+            options.push({
+                label: LBL_SAVE_AND_DOWNLOAD,
+                value: 'both',
+                icon: '⬇️☁️',
+                class: resolvedMode === 'both' ? 'pill-btn active' : 'pill-btn'
+            });
+        }
         return options;
     }
 
     get showOutputDestinationSelector() {
-        return this.modernOutputOptions.length > 0;
+        // Only when there is an actual choice to make. One surviving option — the
+        // admin unchecked the other in App Builder, or the app mode allows only
+        // one (mergeOnly/packet are download-only, mobile is save-only) — used to
+        // render a lone pill that looked interactive and did nothing.
+        //
+        // Safe to hide because generation never reads this.outputMode directly:
+        // all 13 call sites go through resolvedOutputMode, which falls back to
+        // whichever mode IS allowed. Hiding the control cannot strand the user on
+        // a mode the runner won't honour.
+        return this.modernOutputOptions.length > 1;
     }
 
     get resolvedOutputMode() {
@@ -244,6 +270,147 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
             return 'save';
         }
         return 'download';
+    }
+
+    /**
+     * Waits for the Save-to-Record Queueable to land its ContentVersion.
+     *
+     * Reuses getPdfSampleGenerationStatus, which already reports job status and,
+     * on completion, the ContentVersion created on the record since `requestedAt`.
+     *
+     * The ceiling is generous on purpose: this path exists FOR the documents too
+     * big to render synchronously, and those are exactly the ones that take
+     * minutes. A too-short wait would fail the download half on precisely the
+     * files the async route was chosen to support.
+     */
+    async _waitForAsyncSavedPdf(jobId, requestedAt) {
+        const MAX_ATTEMPTS = 150;
+        const INTERVAL_MS = 2000;
+        for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+            // eslint-disable-next-line no-await-in-loop
+            const result = await getPdfSampleGenerationStatus({
+                jobId,
+                recordId: this.recordId,
+                requestedAt
+            });
+            if (result && result.jobStatus === 'Failed') {
+                throw new Error(result.extendedStatus || 'Server-side PDF generation failed.');
+            }
+            if (result && result.jobStatus === 'Aborted') {
+                throw new Error(result.extendedStatus || 'Server-side PDF generation was aborted.');
+            }
+            if (result && result.contentVersionId) {
+                return result;
+            }
+            // eslint-disable-next-line no-await-in-loop
+            await new Promise((resolve) => setTimeout(resolve, INTERVAL_MS));
+        }
+        // The save itself may still succeed — only the download half timed out,
+        // so say that rather than implying the document was lost.
+        throw new Error(
+            'The document is still generating. It will appear on the record when it finishes — ' +
+                'download it from there.'
+        );
+    }
+
+    /**
+     * Hands the browser the saved file by URL rather than by bytes.
+     *
+     * NavigationMixin (not a hand-built anchor) because the runner also lives on
+     * Experience Cloud pages, where a bare '/sfc/...' path misses the site prefix;
+     * standard__webPage resolves it for the current context. Nothing passes
+     * through the Aura response, so file size is irrelevant here.
+     */
+    _downloadSavedContentVersion(contentVersionId) {
+        if (!contentVersionId) {
+            return;
+        }
+        this[NavigationMixin.Navigate]({
+            type: 'standard__webPage',
+            attributes: {
+                url: `/sfc/servlet.shepherd/version/download/${contentVersionId}`
+            }
+        });
+    }
+
+    /** True when the resolved mode attaches the document to the record. */
+    get wantsSaveToRecord() {
+        const mode = this.resolvedOutputMode;
+        return mode === 'save' || mode === 'both';
+    }
+
+    /** True when the resolved mode also hands the file to the browser. */
+    get wantsDownload() {
+        const mode = this.resolvedOutputMode;
+        return mode === 'download' || mode === 'both';
+    }
+
+    /**
+     * Single exit point for generated bytes: downloads, saves, or both, according
+     * to the resolved output mode.
+     *
+     * Every generation path already held the base64 and chose one of the two —
+     * "Save & Download" is just not choosing. That is why this needs no second
+     * generate call and no extra Apex: the bytes are in the browser either way,
+     * and saveGeneratedDocument is the same call the save-only path already made.
+     *
+     * Downloads BEFORE saving on purpose. If the ContentVersion insert fails, the
+     * user still has the file in hand and gets an error they can act on; the
+     * reverse order would lose both.
+     *
+     * @param {object} opts
+     * @param {string} opts.base64 Generated file content
+     * @param {string} opts.fileName File name WITHOUT extension
+     * @param {string} opts.extension File extension, no dot (pdf, docx, …)
+     * @param {string} opts.mimeType MIME type for the browser download
+     * @param {number} [opts.byteLength] Decoded size, for the 5 MB save ceiling
+     * @param {string} [opts.label] Noun used in the success toast ("PDF", "Document packet")
+     */
+    async _deliverGeneratedDocument({ base64, fileName, extension, mimeType, byteLength, label }) {
+        const fullName = `${fileName}.${extension}`;
+        const noun = label || 'Document';
+        const wantsSave = this.wantsSaveToRecord;
+        const wantsDownload = this.wantsDownload;
+
+        // Above the 5 MB single-CV stitch ceiling the save cannot succeed, so the
+        // runner downloads and offers the drag-to-attach box instead. That path is
+        // already a download, so a 'both' request is fully satisfied by it.
+        const OVERSIZE_LIMIT = 5 * 1024 * 1024;
+        if (wantsSave && byteLength && byteLength > OVERSIZE_LIMIT) {
+            this.downloadBase64(base64, fullName, mimeType);
+            this._oversizedSaveToRecord = {
+                fileName: fullName,
+                sizeMb: (byteLength / 1024 / 1024).toFixed(1)
+            };
+            this.showToast(
+                'Document downloaded',
+                `File is ${this._oversizedSaveToRecord.sizeMb} MB — too large to save automatically. ` +
+                    'Drag the just-downloaded file into the upload box that appeared below to attach it to this record.',
+                'info'
+            );
+            return;
+        }
+
+        if (wantsDownload) {
+            this.downloadBase64(base64, fullName, mimeType);
+        }
+        if (wantsSave) {
+            // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
+            await saveGeneratedDocument({
+                recordId: this.recordId,
+                fileName: fileName,
+                base64Data: base64,
+                extension: extension
+            });
+        }
+
+        if (wantsSave && wantsDownload) {
+            this.showToast('Success', `${noun} saved to record and downloaded.`, 'success');
+        } else if (wantsSave) {
+            this.showToast('Success', `${noun} saved to record.`, 'success');
+        } else {
+            this.showToast('Success', `${noun} downloaded.`, 'success');
+        }
     }
 
     get isGenerateMode() {
@@ -631,16 +798,19 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
             const isPPT = templateType === 'PowerPoint';
             const isExcel = templateType === 'Excel';
             const isPDF = this.effectiveOutputFormat === 'PDF' && !isPPT && !isExcel;
-            const saveToRecord = this.resolvedOutputMode === 'save';
+            const saveToRecord = this.wantsSaveToRecord;
             const shouldMerge = isPDF && this.mergeEnabled && this.selectedPdfCvIds.length > 0;
 
             if (isPDF) {
-                if (shouldMerge) {
-                    await this._generateMergedPdf(saveToRecord);
-                } else if (saveToRecord) {
-                    // Pre-flight size check: attached images >30MB will fail the
-                    // Save-to-Record ContentVersion insert. Warn up front instead
-                    // of letting the Queueable fail silently.
+                // Pre-flight size check: attached images >30MB will fail the
+                // Save-to-Record ContentVersion insert. Warn up front instead
+                // of letting the Queueable fail silently.
+                //
+                // Gated on wantsSaveToRecord, NOT the save-only flag: Save &
+                // Download ends in the same ContentVersion insert, so it needs the
+                // same guard. Scoped to the non-merge branch because that is the
+                // only one that reaches the insert from here.
+                if (!shouldMerge && this.wantsSaveToRecord) {
                     const imgBytes = await scoutAttachedImageSize({ recordId: this.recordId });
                     const LIMIT_BYTES = 30 * 1024 * 1024;
                     if (imgBytes > LIMIT_BYTES) {
@@ -653,20 +823,43 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
                         );
                         return;
                     }
+                }
+                if (shouldMerge) {
+                    await this._generateMergedPdf();
+                } else if (saveToRecord) {
                     // Save-to-record runs fully server-side via a Queueable so the full
                     // render + big-file DML never holds the Aura request open long enough
                     // to trip Salesforce's CSRF timeout (which returns an "Illegal Request"
                     // HTML page instead of the expected JSON). LWC gets back immediately.
+                    //
+                    // Save & Download keeps this async render — deliberately. Doing it
+                    // synchronously to get the bytes back would reintroduce exactly the
+                    // timeout this path exists to avoid, and on the biggest documents
+                    // (the ones most likely to be worth both copies) it would also have
+                    // to squeeze the file through the Aura response. Instead we let the
+                    // Queueable finish, then point the BROWSER at the saved
+                    // ContentVersion — the file streams from Salesforce's own file
+                    // endpoint, so there is no size ceiling on either half.
+                    const requestedAt = new Date().toISOString();
                     this.showToast('Info', 'Generating and saving PDF in the background...', 'info');
-                    await generatePdfAsync({
+                    const jobId = await generatePdfAsync({
                         templateId: this.selectedTemplateId,
                         recordId: this.recordId
                     });
-                    this.showToast(
-                        'Success',
-                        'PDF is being generated. It will appear on the record in a moment — refresh the page to see it.',
-                        'success'
-                    );
+
+                    if (!this.wantsDownload) {
+                        this.showToast(
+                            'Success',
+                            'PDF is being generated. It will appear on the record in a moment — refresh the page to see it.',
+                            'success'
+                        );
+                        return;
+                    }
+
+                    this.loadingMessage = 'Saving to the record, then downloading...';
+                    const saved = await this._waitForAsyncSavedPdf(jobId, requestedAt);
+                    this._downloadSavedContentVersion(saved.contentVersionId);
+                    this.showToast('Success', `${saved.title || 'PDF'} saved to record and downloaded.`, 'success');
                 } else {
                     this.showToast('Info', 'Generating PDF...', 'info');
                     const chartContext = await this._prepareCharts();
@@ -685,7 +878,15 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
                         return;
                     }
                     if (result.base64) {
-                        this.downloadBase64(result.base64, (result.title || 'Document') + '.pdf', 'application/pdf');
+                        // Download-only. Anything that saves — including Save &
+                        // Download — took the async Queueable branch above.
+                        await this._deliverGeneratedDocument({
+                            base64: result.base64,
+                            fileName: result.title || 'Document',
+                            extension: 'pdf',
+                            mimeType: 'application/pdf',
+                            label: 'PDF'
+                        });
                     }
                 }
             } else {
@@ -694,7 +895,7 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
                 // packages avoid Apex Compression.ZipWriter container quirks.
                 const ext = isPPT ? 'pptx' : isExcel ? 'xlsx' : 'docx';
                 this.showToast('Info', 'Generating document...', 'info');
-                await this._generateOfficeClientSide(saveToRecord, ext, 'application/octet-stream');
+                await this._generateOfficeClientSide(ext, 'application/octet-stream');
             }
         } catch (e) {
             this.error = 'Generation Error: ' + (e.body ? e.body.message : e.message || 'Unknown error');
@@ -870,21 +1071,13 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
                     'success'
                 );
             } else if (result.base64) {
-                const saveToRecord = this.resolvedOutputMode === 'save';
-                const docTitle = result.title || 'Document';
-                if (saveToRecord) {
-                    // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
-                    await saveGeneratedDocument({
-                        recordId: this.recordId,
-                        fileName: docTitle,
-                        base64Data: result.base64,
-                        extension: 'pdf'
-                    });
-                    this.showToast('Success', 'PDF saved to record.', 'success');
-                } else {
-                    this.downloadBase64(result.base64, docTitle + '.pdf', 'application/pdf');
-                    this.showToast('Success', 'Document downloaded.', 'success');
-                }
+                await this._deliverGeneratedDocument({
+                    base64: result.base64,
+                    fileName: result.title || 'Document',
+                    extension: 'pdf',
+                    mimeType: 'application/pdf',
+                    label: 'PDF'
+                });
             }
         } catch (e) {
             this.error = 'Giant Query Error: ' + (e.body ? e.body.message : e.message || 'Unknown error');
@@ -893,7 +1086,7 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
         }
     }
 
-    async _generateMergedPdf(saveToRecord) {
+    async _generateMergedPdf() {
         const totalPdfs = this.selectedPdfCvIds.length + 1;
         this.showToast('Info', `Generating and merging ${totalPdfs} PDFs...`, 'info');
         const result = await generatePdf({
@@ -914,19 +1107,14 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
         }
         const mergedBytes = mergePdfs(pdfBytesArray);
         const mergedBase64 = this._uint8ArrayToBase64(mergedBytes);
-        if (saveToRecord) {
-            // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
-            await saveGeneratedDocument({
-                recordId: this.recordId,
-                fileName: docTitle,
-                base64Data: mergedBase64,
-                extension: 'pdf'
-            });
-            this.showToast('Success', 'Merged PDF saved to record.', 'success');
-        } else {
-            this.downloadBase64(mergedBase64, docTitle + '.pdf', 'application/pdf');
-            this.showToast('Success', 'Merged PDF downloaded.', 'success');
-        }
+        await this._deliverGeneratedDocument({
+            base64: mergedBase64,
+            fileName: docTitle,
+            extension: 'pdf',
+            mimeType: 'application/pdf',
+            byteLength: mergedBytes.length,
+            label: 'Merged PDF'
+        });
     }
 
     async generatePacket() {
@@ -960,20 +1148,13 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
             } else {
                 finalBase64 = this._uint8ArrayToBase64(mergePdfs(pdfBytesArray));
             }
-            const saveToRecord = this.resolvedOutputMode === 'save';
-            if (saveToRecord) {
-                // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
-                await saveGeneratedDocument({
-                    recordId: this.recordId,
-                    fileName: 'Document Packet',
-                    base64Data: finalBase64,
-                    extension: 'pdf'
-                });
-                this.showToast('Success', 'Document packet saved to record.', 'success');
-            } else {
-                this.downloadBase64(finalBase64, 'Document Packet.pdf', 'application/pdf');
-                this.showToast('Success', 'Document packet downloaded.', 'success');
-            }
+            await this._deliverGeneratedDocument({
+                base64: finalBase64,
+                fileName: 'Document Packet',
+                extension: 'pdf',
+                mimeType: 'application/pdf',
+                label: 'Document packet'
+            });
         } catch (e) {
             this.error = 'Packet Error: ' + (e.body ? e.body.message : e.message || 'Unknown error');
         } finally {
@@ -999,20 +1180,14 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
             }
             const mergedBytes = mergePdfs(pdfBytesArray);
             const mergedBase64 = this._uint8ArrayToBase64(mergedBytes);
-            const saveToRecord = this.resolvedOutputMode === 'save';
-            if (saveToRecord) {
-                // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
-                await saveGeneratedDocument({
-                    recordId: this.recordId,
-                    fileName: 'Merged Document',
-                    base64Data: mergedBase64,
-                    extension: 'pdf'
-                });
-                this.showToast('Success', 'Merged PDF saved to record.', 'success');
-            } else {
-                this.downloadBase64(mergedBase64, 'Merged Document.pdf', 'application/pdf');
-                this.showToast('Success', 'Merged PDF downloaded.', 'success');
-            }
+            await this._deliverGeneratedDocument({
+                base64: mergedBase64,
+                fileName: 'Merged Document',
+                extension: 'pdf',
+                mimeType: 'application/pdf',
+                byteLength: mergedBytes.length,
+                label: 'Merged PDF'
+            });
         } catch (e) {
             this.error = 'Merge Error: ' + (e.body ? e.body.message : e.message || 'Unknown error');
         } finally {
@@ -1043,20 +1218,14 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
                 finalBytes = mergePdfs(pdfBytesArray);
             }
             const finalBase64 = this._uint8ArrayToBase64(finalBytes);
-            const saveToRecord = this.resolvedOutputMode === 'save';
-            if (saveToRecord) {
-                // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
-                await saveGeneratedDocument({
-                    recordId: this.recordId,
-                    fileName: 'Merged Child PDFs',
-                    base64Data: finalBase64,
-                    extension: 'pdf'
-                });
-                this.showToast('Success', 'Merged PDF saved to record.', 'success');
-            } else {
-                this.downloadBase64(finalBase64, 'Merged Child PDFs.pdf', 'application/pdf');
-                this.showToast('Success', 'Merged PDF downloaded.', 'success');
-            }
+            await this._deliverGeneratedDocument({
+                base64: finalBase64,
+                fileName: 'Merged Child PDFs',
+                extension: 'pdf',
+                mimeType: 'application/pdf',
+                byteLength: finalBytes.length,
+                label: 'Merged PDF'
+            });
         } catch (e) {
             this.error = 'Merge Error: ' + (e.body ? e.body.message : e.message || 'Unknown error');
         } finally {
@@ -1081,7 +1250,7 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
      * Note: Rich text images from rtaImage servlet URLs render in PDF only.
      * For DOCX images, use {%FieldName} tags with ContentVersion IDs.
      */
-    async _generateOfficeClientSide(saveToRecord, extension, mimeType) {
+    async _generateOfficeClientSide(extension, mimeType) {
         // #117 chart pipeline: rasterize any {Chart:...} tags in the template
         // body to PNGs (uploaded as transient CVs) before kicking off the
         // server-side merge. The merge sees the signature → CV Id map and
@@ -1096,13 +1265,13 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
         // whole flow and reap only after the document is fully assembled.
         const chartContext = await this._prepareCharts();
         try {
-            await this._generateOfficeClientSideInner(saveToRecord, extension, mimeType, chartContext);
+            await this._generateOfficeClientSideInner(extension, mimeType, chartContext);
         } finally {
             await this._cleanupCharts(chartContext.cvIds);
         }
     }
 
-    async _generateOfficeClientSideInner(saveToRecord, extension, mimeType, chartContext) {
+    async _generateOfficeClientSideInner(extension, mimeType, chartContext) {
         const parts = await generateDocumentParts({
             templateId: this.selectedTemplateId,
             recordId: this.recordId,
@@ -1167,35 +1336,16 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
         // affordance instead — lightning-file-upload chunks internally up to
         // 2 GB, so the user does the upload themselves with platform-native
         // progress feedback. No new chunked Apex required.
-        const SAVE_TO_RECORD_BINARY_LIMIT = 5 * 1024 * 1024;
-        if (saveToRecord && fileBytes.length > SAVE_TO_RECORD_BINARY_LIMIT) {
-            this.downloadBase64(fileBase64, docTitle + '.' + extension, mimeType);
-            this._oversizedSaveToRecord = {
-                fileName: docTitle + '.' + extension,
-                sizeMb: (fileBytes.length / 1024 / 1024).toFixed(1)
-            };
-            this.showToast(
-                'Document downloaded',
-                'File is ' +
-                    this._oversizedSaveToRecord.sizeMb +
-                    ' MB — too large to save automatically. Drag the just-downloaded file into the upload box that appeared below to attach it to this record.',
-                'info'
-            );
-            return;
-        }
-        if (saveToRecord) {
-            // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
-            await saveGeneratedDocument({
-                recordId: this.recordId,
-                fileName: docTitle,
-                base64Data: fileBase64,
-                extension
-            });
-            this.showToast('Success', extension.toUpperCase() + ' saved to record.', 'success');
-        } else {
-            this.downloadBase64(fileBase64, docTitle + '.' + extension, mimeType);
-            this.showToast('Success', extension.toUpperCase() + ' downloaded.', 'success');
-        }
+        // The 5 MB ceiling and its drag-to-attach fallback now live in
+        // _deliverGeneratedDocument, which every generation path shares.
+        await this._deliverGeneratedDocument({
+            base64: fileBase64,
+            fileName: docTitle,
+            extension: extension,
+            mimeType: mimeType,
+            byteLength: fileBytes.length,
+            label: extension.toUpperCase()
+        });
     }
 
     @track _oversizedSaveToRecord = null;
@@ -1351,34 +1501,14 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
             const fileBase64 = this._uint8ArrayToBase64(fileBytes);
 
             // 8. Download or save (5 MB single-CV stitch ceiling — see _generateOfficeClientSide)
-            const saveToRecord = this.resolvedOutputMode === 'save';
-            const SAVE_TO_RECORD_BINARY_LIMIT = 5 * 1024 * 1024;
-            if (saveToRecord && fileBytes.length > SAVE_TO_RECORD_BINARY_LIMIT) {
-                this.downloadBase64(fileBase64, docTitle + '.docx', 'application/octet-stream');
-                this._oversizedSaveToRecord = {
-                    fileName: docTitle + '.docx',
-                    sizeMb: (fileBytes.length / 1024 / 1024).toFixed(1)
-                };
-                this.showToast(
-                    'Document downloaded',
-                    'File is ' +
-                        this._oversizedSaveToRecord.sizeMb +
-                        ' MB — too large to save automatically. Drag the just-downloaded file into the upload box that appeared below to attach it to this record.',
-                    'info'
-                );
-            } else if (saveToRecord) {
-                // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
-                await saveGeneratedDocument({
-                    recordId: this.recordId,
-                    fileName: docTitle,
-                    base64Data: fileBase64,
-                    extension: 'docx'
-                });
-                this.showToast('Success', 'DOCX saved to record.', 'success');
-            } else {
-                this.downloadBase64(fileBase64, docTitle + '.docx', 'application/octet-stream');
-                this.showToast('Success', 'DOCX downloaded.', 'success');
-            }
+            await this._deliverGeneratedDocument({
+                base64: fileBase64,
+                fileName: docTitle,
+                extension: 'docx',
+                mimeType: 'application/octet-stream',
+                byteLength: fileBytes.length,
+                label: 'DOCX'
+            });
 
             // 9. Clean up fragment CVs server-side
             try {

--- a/force-app/main/default/objects/DocGen_Job__c/fields/Sort_Order__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Job__c/fields/Sort_Order__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Sort_Order__c</fullName>
+    <description
+    >SOQL ORDER BY clause applied to the bulk query. Controls the order records are processed, and therefore the page order of a merged PDF. Validated against the base object's schema before use. Example: Account.Name ASC NULLS LAST, Name ASC</description>
+    <label>Sort Order</label>
+    <length>255</length>
+    <type>Text</type>
+</CustomField>

--- a/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
@@ -305,6 +305,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>DocGen_Job__c.Sort_Order__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>DocGen_Job__c.Status__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
@@ -287,6 +287,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>DocGen_Job__c.Sort_Order__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>DocGen_Job__c.Status__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/translations/de.translation-meta.xml
+++ b/force-app/main/default/translations/de.translation-meta.xml
@@ -48,4 +48,8 @@
         <label>Im Datensatz speichern</label>
         <name>DocGenRunner_SaveToRecord</name>
     </customLabels>
+    <customLabels>
+        <label>Speichern &amp; Herunterladen</label>
+        <name>DocGenRunner_SaveAndDownload</name>
+    </customLabels>
 </Translations>

--- a/force-app/main/default/translations/es.translation-meta.xml
+++ b/force-app/main/default/translations/es.translation-meta.xml
@@ -48,4 +48,8 @@
         <label>Guardar en el registro</label>
         <name>DocGenRunner_SaveToRecord</name>
     </customLabels>
+    <customLabels>
+        <label>Guardar y descargar</label>
+        <name>DocGenRunner_SaveAndDownload</name>
+    </customLabels>
 </Translations>

--- a/force-app/main/default/translations/fr.translation-meta.xml
+++ b/force-app/main/default/translations/fr.translation-meta.xml
@@ -48,4 +48,8 @@
         <label>Enregistrer dans l'enregistrement</label>
         <name>DocGenRunner_SaveToRecord</name>
     </customLabels>
+    <customLabels>
+        <label>Enregistrer et télécharger</label>
+        <name>DocGenRunner_SaveAndDownload</name>
+    </customLabels>
 </Translations>

--- a/force-app/main/default/translations/it.translation-meta.xml
+++ b/force-app/main/default/translations/it.translation-meta.xml
@@ -48,4 +48,8 @@
         <label>Salva nel record</label>
         <name>DocGenRunner_SaveToRecord</name>
     </customLabels>
+    <customLabels>
+        <label>Salva e scarica</label>
+        <name>DocGenRunner_SaveAndDownload</name>
+    </customLabels>
 </Translations>

--- a/force-app/main/default/translations/ja.translation-meta.xml
+++ b/force-app/main/default/translations/ja.translation-meta.xml
@@ -48,4 +48,8 @@
         <label>レコードに保存</label>
         <name>DocGenRunner_SaveToRecord</name>
     </customLabels>
+    <customLabels>
+        <label>保存してダウンロード</label>
+        <name>DocGenRunner_SaveAndDownload</name>
+    </customLabels>
 </Translations>

--- a/force-app/main/default/translations/ko.translation-meta.xml
+++ b/force-app/main/default/translations/ko.translation-meta.xml
@@ -48,4 +48,8 @@
         <label>레코드에 저장</label>
         <name>DocGenRunner_SaveToRecord</name>
     </customLabels>
+    <customLabels>
+        <label>저장 및 다운로드</label>
+        <name>DocGenRunner_SaveAndDownload</name>
+    </customLabels>
 </Translations>

--- a/force-app/main/default/translations/nl_NL.translation-meta.xml
+++ b/force-app/main/default/translations/nl_NL.translation-meta.xml
@@ -48,4 +48,8 @@
         <label>Opslaan in record</label>
         <name>DocGenRunner_SaveToRecord</name>
     </customLabels>
+    <customLabels>
+        <label>Opslaan en downloaden</label>
+        <name>DocGenRunner_SaveAndDownload</name>
+    </customLabels>
 </Translations>

--- a/force-app/main/default/translations/pt_BR.translation-meta.xml
+++ b/force-app/main/default/translations/pt_BR.translation-meta.xml
@@ -48,4 +48,8 @@
         <label>Salvar no registro</label>
         <name>DocGenRunner_SaveToRecord</name>
     </customLabels>
+    <customLabels>
+        <label>Salvar e baixar</label>
+        <name>DocGenRunner_SaveAndDownload</name>
+    </customLabels>
 </Translations>

--- a/force-app/main/default/translations/zh_CN.translation-meta.xml
+++ b/force-app/main/default/translations/zh_CN.translation-meta.xml
@@ -48,4 +48,8 @@
         <label>保存到记录</label>
         <name>DocGenRunner_SaveToRecord</name>
     </customLabels>
+    <customLabels>
+        <label>保存并下载</label>
+        <name>DocGenRunner_SaveAndDownload</name>
+    </customLabels>
 </Translations>

--- a/force-app/main/default/translations/zh_TW.translation-meta.xml
+++ b/force-app/main/default/translations/zh_TW.translation-meta.xml
@@ -48,4 +48,8 @@
         <label>儲存至記錄</label>
         <name>DocGenRunner_SaveToRecord</name>
     </customLabels>
+    <customLabels>
+        <label>儲存並下載</label>
+        <name>DocGenRunner_SaveAndDownload</name>
+    </customLabels>
 </Translations>

--- a/scripts/e2e-01-permissions.apex
+++ b/scripts/e2e-01-permissions.apex
@@ -418,6 +418,18 @@ try {
             fail++;
             System.debug('USER FLD DocGen_Job__c.Merge_Only__c edit: FAIL');
         }
+
+        // v3.49 — submitJobInternal writes Sort_Order__c on every bulk job, so a
+        // missing grant here breaks bulk generation for standard users while an
+        // admin sees nothing wrong. Every new writable DocGen_Job__c field belongs
+        // in this list; the suite passed a release without it once already.
+        Boolean userJobSortOrderOk = containsNs(editableJobFields, 'DocGen_Job__c.Sort_Order__c');
+        if (userJobSortOrderOk) {
+            pass++;
+        } else {
+            fail++;
+            System.debug('USER FLD DocGen_Job__c.Sort_Order__c edit: FAIL');
+        }
     }
 } catch (Exception e) {
     fail++;

--- a/scripts/e2e-05-generate-bulk.apex
+++ b/scripts/e2e-05-generate-bulk.apex
@@ -61,7 +61,15 @@ try {
 
 // ===== Submit Bulk Job =====
 try {
-    jobId = DocGenBulkController.submitJob(tmplId, 'Name = \'E2E Test Corp\'', 'E2E Bulk Test Job', false, 1, false);
+    jobId = DocGenBulkController.submitJob(
+        tmplId,
+        'Name = \'E2E Test Corp\'',
+        'E2E Bulk Test Job',
+        false,
+        1,
+        false,
+        null
+    );
     if (jobId != null) {
         pass++;
         System.debug('SUBMIT JOB: PASS — jobId: ' + jobId);
@@ -72,6 +80,73 @@ try {
 } catch (Exception e) {
     fail++;
     System.debug('SUBMIT JOB: FAIL — ' + e.getMessage());
+}
+
+// ===== Sort Order — parent-level ORDER BY on the bulk query =====
+// The bulk query had no ORDER BY, so a merged PDF came out in record-creation
+// order with no way to change it. Merge order follows query order, so these
+// assertions cover the clause that reaches the QueryLocator.
+try {
+    String canonical = DocGenBulkController.normalizeSortOrder('Account', 'name desc');
+    if (canonical == 'Name DESC NULLS LAST') {
+        pass++;
+        System.debug('SORT CANONICALIZE: PASS — ' + canonical);
+    } else {
+        fail++;
+        System.debug('SORT CANONICALIZE: FAIL — ' + canonical);
+    }
+
+    // Single sort field gains the name field as a tie-break so repeat runs of the
+    // same job produce the same packet.
+    String tie = DocGenBulkController.normalizeSortOrder('Account', 'AnnualRevenue DESC');
+    if (tie == 'AnnualRevenue DESC NULLS LAST, Name ASC NULLS LAST') {
+        pass++;
+        System.debug('SORT TIE-BREAK: PASS — ' + tie);
+    } else {
+        fail++;
+        System.debug('SORT TIE-BREAK: FAIL — ' + tie);
+    }
+
+    // The headline case: order child records by a parent field.
+    String rel = DocGenBulkController.normalizeSortOrder('Account', 'owner.name');
+    if (rel != null && rel.startsWith('Owner.Name ASC')) {
+        pass++;
+        System.debug('SORT TRAVERSAL: PASS — ' + rel);
+    } else {
+        fail++;
+        System.debug('SORT TRAVERSAL: FAIL — ' + rel);
+    }
+
+    Boolean rejected = false;
+    try {
+        DocGenBulkController.normalizeSortOrder('Account', 'Name ASC; DELETE FROM Account');
+    } catch (Exception rejectEx) {
+        rejected = true;
+    }
+    if (rejected) {
+        pass++;
+        System.debug('SORT INJECTION REJECTED: PASS');
+    } else {
+        fail++;
+        System.debug('SORT INJECTION REJECTED: FAIL — clause was accepted');
+    }
+
+    Boolean unknownRejected = false;
+    try {
+        DocGenBulkController.normalizeSortOrder('Account', 'NotAField__c');
+    } catch (Exception rejectEx) {
+        unknownRejected = true;
+    }
+    if (unknownRejected) {
+        pass++;
+        System.debug('SORT UNKNOWN FIELD REJECTED: PASS');
+    } else {
+        fail++;
+        System.debug('SORT UNKNOWN FIELD REJECTED: FAIL — clause was accepted');
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('SORT ORDER: FAIL — ' + e.getMessage());
 }
 
 // ===== Get Job Status =====

--- a/scripts/e2e-07-syntax5.apex
+++ b/scripts/e2e-07-syntax5.apex
@@ -1,0 +1,193 @@
+// DocGen E2E Test 07.5 — {RowNumber} loop counter via processXmlForTest()
+// Run: sf apex run --target-org <org> -f scripts/e2e-07-syntax5.apex
+// Depends on: nothing (uses DocGenService.processXmlForTest directly)
+// Expected: PASS: N  FAIL: 0
+//
+// Split into its own file rather than appended to syntax1-4: those are all within
+// a few hundred characters of the Anonymous Apex size ceiling.
+
+Integer pass = 0;
+Integer fail = 0;
+String r;
+
+// ============================================================
+// RowNumber — numbers a child loop 1..N, in list order
+// ============================================================
+try {
+    Map<String, Object> data = new Map<String, Object>{
+        'Lines' => new List<Object>{
+            new Map<String, Object>{ 'Name' => 'Alpha' },
+            new Map<String, Object>{ 'Name' => 'Beta' },
+            new Map<String, Object>{ 'Name' => 'Gamma' }
+        }
+    };
+    r = DocGenService.processXmlForTest('{#Lines}[{RowNumber}.{Name}]{/Lines}', data);
+    if (r == '[1.Alpha][2.Beta][3.Gamma]') {
+        pass++;
+        System.debug('ROWNUMBER BASIC: PASS — ' + r);
+    } else {
+        fail++;
+        System.debug('ROWNUMBER BASIC: FAIL — ' + r);
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('ROWNUMBER BASIC: FAIL — ' + e.getMessage());
+}
+
+// ============================================================
+// RowNumber — 1-based, not 0-based (off-by-one guard)
+// ============================================================
+try {
+    Map<String, Object> data = new Map<String, Object>{
+        'Lines' => new List<Object>{ new Map<String, Object>{ 'Name' => 'Only' } }
+    };
+    r = DocGenService.processXmlForTest('{#Lines}{RowNumber}{/Lines}', data);
+    if (r == '1') {
+        pass++;
+        System.debug('ROWNUMBER ONE-BASED: PASS');
+    } else {
+        fail++;
+        System.debug('ROWNUMBER ONE-BASED: FAIL — expected 1, got: ' + r);
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('ROWNUMBER ONE-BASED: FAIL — ' + e.getMessage());
+}
+
+// ============================================================
+// RowNumber — the {records: [...]} relationship shape (aliased/subset form)
+// resolves the same as a bare list. These are two separate loop paths in
+// processXml and a fix to one has historically missed the other.
+// ============================================================
+try {
+    Map<String, Object> data = new Map<String, Object>{
+        'Lines' => new Map<String, Object>{
+            'records' => new List<Object>{
+                new Map<String, Object>{ 'Name' => 'One' },
+                new Map<String, Object>{ 'Name' => 'Two' }
+            }
+        }
+    };
+    r = DocGenService.processXmlForTest('{#Lines}[{RowNumber}:{Name}]{/Lines}', data);
+    if (r == '[1:One][2:Two]') {
+        pass++;
+        System.debug('ROWNUMBER RECORDS-SHAPE: PASS — ' + r);
+    } else {
+        fail++;
+        System.debug('ROWNUMBER RECORDS-SHAPE: FAIL — ' + r);
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('ROWNUMBER RECORDS-SHAPE: FAIL — ' + e.getMessage());
+}
+
+// ============================================================
+// RowNumber — nested loops each count their OWN rows, and the inner counter
+// does not leak back into the outer body after the inner loop closes.
+// ============================================================
+try {
+    Map<String, Object> data = new Map<String, Object>{
+        'Groups' => new List<Object>{
+            new Map<String, Object>{
+                'Title' => 'G1',
+                'Items' => new List<Object>{
+                    new Map<String, Object>{ 'Name' => 'a' },
+                    new Map<String, Object>{ 'Name' => 'b' }
+                }
+            },
+            new Map<String, Object>{
+                'Title' => 'G2',
+                'Items' => new List<Object>{ new Map<String, Object>{ 'Name' => 'c' } }
+            }
+        }
+    };
+    r = DocGenService.processXmlForTest(
+        '{#Groups}<{RowNumber}:{Title}{#Items}({RowNumber}{Name}){/Items}={RowNumber}>{/Groups}',
+        data
+    );
+    if (r == '<1:G1(1a)(2b)=1><2:G2(1c)=2>') {
+        pass++;
+        System.debug('ROWNUMBER NESTED: PASS — ' + r);
+    } else {
+        fail++;
+        System.debug('ROWNUMBER NESTED: FAIL — ' + r);
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('ROWNUMBER NESTED: FAIL — ' + e.getMessage());
+}
+
+// ============================================================
+// RowNumber — a record field actually named RowNumber still wins inside the
+// loop body ONLY where the template did not ask for the counter. The counter is
+// injected per row, so it shadows; this asserts the documented precedence
+// rather than leaving it accidental.
+// ============================================================
+try {
+    Map<String, Object> data = new Map<String, Object>{
+        'Lines' => new List<Object>{
+            new Map<String, Object>{ 'Name' => 'X', 'RowNumber' => 'FIELD' },
+            new Map<String, Object>{ 'Name' => 'Y', 'RowNumber' => 'FIELD' }
+        }
+    };
+    r = DocGenService.processXmlForTest('{#Lines}[{RowNumber}]{/Lines}', data);
+    if (r == '[1][2]') {
+        pass++;
+        System.debug('ROWNUMBER SHADOWS FIELD: PASS — ' + r);
+    } else {
+        fail++;
+        System.debug('ROWNUMBER SHADOWS FIELD: FAIL — expected [1][2], got: ' + r);
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('ROWNUMBER SHADOWS FIELD: FAIL — ' + e.getMessage());
+}
+
+// ============================================================
+// RowNumber — a loop that does NOT use the tag is byte-identical to before.
+// The row-map copy is gated on the tag being present, so this guards the
+// no-cost path as much as the output.
+// ============================================================
+try {
+    Map<String, Object> data = new Map<String, Object>{
+        'Lines' => new List<Object>{
+            new Map<String, Object>{ 'Name' => 'P' },
+            new Map<String, Object>{ 'Name' => 'Q' }
+        }
+    };
+    r = DocGenService.processXmlForTest('{#Lines}[{Name}]{/Lines}', data);
+    if (r == '[P][Q]') {
+        pass++;
+        System.debug('ROWNUMBER ABSENT UNCHANGED: PASS — ' + r);
+    } else {
+        fail++;
+        System.debug('ROWNUMBER ABSENT UNCHANGED: FAIL — ' + r);
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('ROWNUMBER ABSENT UNCHANGED: FAIL — ' + e.getMessage());
+}
+
+// ============================================================
+// RowNumber — outside any loop it is not a tag and must not resolve to a
+// number. Left alone, it is a plain unmatched merge tag.
+// ============================================================
+try {
+    r = DocGenService.processXmlForTest('Total: {RowNumber}', new Map<String, Object>{ 'Name' => 'Z' });
+    if (!r.contains('1')) {
+        pass++;
+        System.debug('ROWNUMBER OUTSIDE LOOP: PASS — ' + r);
+    } else {
+        fail++;
+        System.debug('ROWNUMBER OUTSIDE LOOP: FAIL — resolved to a number outside a loop: ' + r);
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('ROWNUMBER OUTSIDE LOOP: FAIL — ' + e.getMessage());
+}
+
+System.debug('========================================');
+System.debug(
+    'E2E-07-SYNTAX5 — PASS: ' + pass + '  FAIL: ' + fail + (fail == 0 ? '  ALL TESTS PASSED' : '  FAILURES DETECTED')
+);
+System.debug('========================================');

--- a/scripts/qa/report/qa-report.json
+++ b/scripts/qa/report/qa-report.json
@@ -1,46 +1,682 @@
 {
     "meta": {
         "org": "docgen-verify",
-        "startedAt": "2026-07-26T13:08:37.461Z",
-        "durationMs": 19995,
-        "args": "--org docgen-verify --suite template-integrity"
+        "startedAt": "2026-07-31T16:14:23.636Z",
+        "durationMs": 400536,
+        "args": "--suite ui-runner --org docgen-verify"
     },
     "tally": {
-        "passed": 2,
-        "failed": 0,
-        "skipped": 1,
-        "evaluated": 2,
-        "total": 3,
-        "rate": 100,
+        "passed": 78,
+        "failed": 3,
+        "skipped": 2,
+        "evaluated": 81,
+        "total": 83,
+        "rate": 96.3,
         "bySeverity": {
             "blocker": 0,
-            "major": 0,
-            "minor": 0
+            "major": 2,
+            "minor": 1
         }
     },
     "suites": [
         {
-            "suite": "template-integrity",
-            "area": "Template integrity",
+            "suite": "ui-runner",
+            "area": "End-user UI",
             "checks": [
                 {
-                    "name": "every HTML template returns a body to the visual Designer",
+                    "name": "runner template picker offers an active, usable template for the record",
                     "ok": true,
-                    "detail": "all 6 HTML templates return a non-empty body from getHtmlTemplateBody",
+                    "detail": "picker returned: UIQA Good PDF, UIQA Locked Format, UIQA No Version — DocGenController.getTemplatesForObjectAndRecord",
                     "severity": "blocker",
-                    "skipped": false
+                    "skipped": false,
+                    "area": "Runner (server contract)"
                 },
                 {
-                    "name": "each template agrees with its active version about its own type",
+                    "name": "picker hides a template whose Record_Filter__c excludes this record",
                     "ok": true,
-                    "detail": "no template/version type disagreements",
-                    "severity": "blocker",
-                    "skipped": false
+                    "detail": "Record_Filter__c = Industry = 'Agriculture'; the record is Technology. Picker: UIQA Good PDF, UIQA Locked Format, UIQA No Version",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (server contract)"
                 },
                 {
-                    "name": "merge-tag pills stay inside their table cells",
+                    "name": "picker hides a template requiring a permission set the user lacks",
+                    "ok": true,
+                    "detail": "Required_Permission_Sets__c = UIQA_No_Such_PermSet. Picker: UIQA Good PDF, UIQA Locked Format, UIQA No Version",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (server contract)"
+                },
+                {
+                    "name": "picker hides an inactive template",
+                    "ok": true,
+                    "detail": "Picker: UIQA Good PDF, UIQA Locked Format, UIQA No Version",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (server contract)"
+                },
+                {
+                    "name": "picker hides a template that has no active version",
                     "ok": false,
-                    "detail": "could not open a template in the Designer: no Designer tab",
+                    "detail": "\"UIQA No Version\" is offered in the runner picker but cannot generate — the user gets \"No template file found (active or attached)\" only after pressing Generate. DocGenController.getTemplatesForObjectInternal filters on Is_Active__c/audience but never checks for an active DocGen_Template_Version__c.",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (server contract)"
+                },
+                {
+                    "name": "generating from the picked template produces a real document",
+                    "ok": true,
+                    "detail": "DocGenService.processDocument returned 66207 bytes",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Runner (server contract)"
+                },
+                {
+                    "name": "the generated document's title resolves merge tokens against the record",
+                    "ok": true,
+                    "detail": "Document_Title_Format__c = \"UIQA-ms957llt {Name}\" → title was \"UIQA-ms957llt UIQA Alpha\", expected \"UIQA-ms957llt UIQA Alpha\"",
+                    "severity": "minor",
+                    "skipped": false,
+                    "area": "Runner (server contract)"
+                },
+                {
+                    "name": "a locked output format cannot be overridden at run time",
+                    "ok": true,
+                    "detail": "Lock_Output_Format__c = true, override 'Word' → \"This template locks its output format. Override not permitted.\"",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (server contract)"
+                },
+                {
+                    "name": "a template with no active version fails with a message, not a blank document",
+                    "ok": true,
+                    "detail": "got: Error retrieving template data: No template file found (active or attached).",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Runner (server contract)"
+                },
+                {
+                    "name": "bulk template picker excludes deactivated templates",
+                    "ok": true,
+                    "detail": "matches the single-record runner",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (server contract)"
+                },
+                {
+                    "name": "a record-filtered template is not silently applied to excluded records in bulk",
+                    "ok": false,
+                    "detail": "\"UIQA Filtered Out\" carries a Record_Filter__c and is offered for bulk, where the filter is never evaluated — DocGenBulkController passes null to filterTemplatesForSender and the batch never calls the per-record check. Documents can be generated for records the template excludes. Either the batch must apply the filter, or the picker must exclude it.",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (server contract)"
+                },
+                {
+                    "name": "the runner shows an actionable empty state when no template matches the record",
+                    "ok": true,
+                    "detail": "with every Account template inactive the runner rendered 581 chars; Create Document disabled=true. The user must be told WHY there is nothing to pick, and must not be able to press a button that cannot work.",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "docGenRunner renders on a record page",
+                    "ok": true,
+                    "detail": "rendered 568 chars, 2 picker(s), 1 primary button(s)",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "the runner shows neither an error nor an empty state on a record that has templates",
+                    "ok": true,
+                    "detail": "component text starts: DocGen Create or combine documents for this record. Create Document Document Packet Combine PDFs Category All Categories Test UIQA (Uncategorized) Select Template Choose a template... Account Certific",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "docGenRunner boots without a console error",
+                    "ok": true,
+                    "detail": "",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "the record-page template picker lists a template the user can actually run",
+                    "ok": true,
+                    "detail": "picker showed: Choose a template... / Account / Certificate / [Test] E2E Test Template / ffff / PDFQA Giant Chrome / playa / test / Test2 / test3 / test345 / test99 / [UIQA] UIQA Good PDF / [UIQA] UIQA Locked Format / [UIQA] UIQA No Version / Verify — Cell Wrap + VAlign / Verify — Designer (pill-dense) / Verify — Landscape Precedence",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "the record-page picker applies the active and audience rules",
+                    "ok": true,
+                    "detail": "Inactive, Record_Filter__c-excluded and permission-gated templates were all withheld",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "the template picker is reachable by a mouse",
+                    "ok": true,
+                    "detail": "found=true hit=ok",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "choosing a category narrows the template list to that category",
+                    "ok": true,
+                    "detail": "after picking category \"UIQA\" the picker showed: [UIQA] UIQA Good PDF / [UIQA] UIQA Locked Format / [UIQA] UIQA No Version",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "the Save to Record output choice is reachable",
+                    "ok": true,
+                    "detail": "found=true hit=ok",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "choosing Save to Record is honoured by the UI",
+                    "ok": true,
+                    "detail": "output pills after the click: download, save(active), both",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "the Create Document button is reachable",
+                    "ok": true,
+                    "detail": "found=true hit=ok",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "pressing Create Document in Save to Record mode puts the document ON the record",
+                    "ok": true,
+                    "detail": "ContentDocument \"UIQA-ms957llt UIQA Alpha\" linked to 001O50000432dmHIAQ",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "the saved file is in the template's own output format",
+                    "ok": true,
+                    "detail": "Output_Format__c = PDF, file extension = .pdf",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "choosing Download is honoured by the UI",
+                    "ok": true,
+                    "detail": "output pills after the click: download(active), save, both",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "pressing Create Document in Download mode downloads the document to the browser",
+                    "ok": true,
+                    "detail": "the browser received \"UIQA-ms957llt UIQA Alpha.pdf\"",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "Download does NOT also attach the document to the record",
+                    "ok": true,
+                    "detail": "files linked to the record: 3 before the run, 3 after. Download and Save to Record are the two halves of one choice; honouring it means Download leaves the record untouched.",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "choosing Save & Download is honoured by the UI",
+                    "ok": true,
+                    "detail": "output pills after the click: download, save, both(active)",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "Save & Download hands the file to the browser",
+                    "ok": true,
+                    "detail": "the browser received \"UIQA-ms957llt UIQA Alpha.pdf\"",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "Save & Download also attaches the document to the record",
+                    "ok": true,
+                    "detail": "files linked to the record: 3 before the run, 4 after. A download alone would leave this unchanged — which is exactly the bug this mode exists to avoid.",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "a template with Lock_Output_Format__c exposes no runtime file-format control",
+                    "ok": true,
+                    "detail": "with the locked template selected the runner offered 2 picker(s) (category + template) and the choice widgets [both, download, save], which are output DESTINATIONS, not formats. The server half of this contract — an explicit override being refused — is asserted in the server-contract area.",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "the Document Packet tab renders its template chooser and it is reachable",
+                    "ok": true,
+                    "detail": "packet tab active=true, dual listboxes=1, source list hit=ok",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "the packet chooser offers the record's PDF templates",
+                    "ok": true,
+                    "detail": "chooser offered 17 template(s): Account / Certificate / E2E Test Template / ffff / PDFQA Giant Chrome / playa",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "the Create Packet button is reachable and refuses to run with nothing chosen",
+                    "ok": true,
+                    "detail": "button hit=ok, disabled=true",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "the Combine PDFs tab lists the record's existing PDFs and they are reachable",
+                    "ok": true,
+                    "detail": "tab active=true, source list hit=ok, it offered 2 file(s) of which 2 are the two PDFs this suite attached to the record",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "the Combine PDFs button is reachable and refuses to run with fewer than two files chosen",
+                    "ok": true,
+                    "detail": "button hit=ok, disabled=true with nothing moved into the Combine list",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Runner (record page)"
+                },
+                {
+                    "name": "docGenSignatureSender renders on a record page",
+                    "ok": true,
+                    "detail": "rendered 321 chars with its template picker, signer table and send button",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Signature sender (record page)"
+                },
+                {
+                    "name": "docGenSignatureSender boots without a console error",
+                    "ok": true,
+                    "detail": "",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Signature sender (record page)"
+                },
+                {
+                    "name": "the send button refuses to send with no document and no signer details",
+                    "ok": true,
+                    "detail": "found=true disabled=true",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Signature sender (record page)"
+                },
+                {
+                    "name": "the signature document picker is reachable",
+                    "ok": true,
+                    "detail": "found=true hit=ok",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Signature sender (record page)"
+                },
+                {
+                    "name": "the signature document picker offers the record’s templates and they can be clicked",
+                    "ok": true,
+                    "detail": "found=true hit=ok",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Signature sender (record page)"
+                },
+                {
+                    "name": "a document alone is not enough to send — the signer is still required",
+                    "ok": true,
+                    "detail": "with a template chosen and the signer row blank, the send button is disabled=true",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Signature sender (record page)"
+                },
+                {
+                    "name": "every signer field is reachable by a mouse",
+                    "ok": true,
+                    "detail": "role=ok name=ok email=ok",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Signature sender (record page)"
+                },
+                {
+                    "name": "a signer with no email address cannot be sent to",
+                    "ok": true,
+                    "detail": "role and name filled, email blank → send button disabled=true",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Signature sender (record page)"
+                },
+                {
+                    "name": "a complete document + signer enables the send button",
+                    "ok": true,
+                    "detail": "role, name and email all filled → send button disabled=false",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Signature sender (record page)"
+                },
+                {
+                    "name": "the send button is reachable by a mouse",
+                    "ok": true,
+                    "detail": "found=true hit=ok",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Signature sender (record page)"
+                },
+                {
+                    "name": "sending a signature request tells the user it worked",
+                    "ok": true,
+                    "detail": "component text: Signature Links Generated! Provide each signer with their unique secure link: UIQA-ms957llt Signer Signer https://<CONFIGURE_SITE_URL_IN_SETUP>/apex/portwoodglobal__DocGenSignaturePdf?token=259490c2f03a49bf2b661a51c8a213",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Signature sender (record page)"
+                },
+                {
+                    "name": "sending writes a DocGen_Signature_Request__c tied to this record and template",
+                    "ok": true,
+                    "detail": "request a08O5000014KMCrIAO: record=001O50000432dmHIAQ (expected 001O50000432dmHIAQ), status=Sent, order=Parallel, sourceDoc=068O500000MQWm2IAH",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Signature sender (record page)"
+                },
+                {
+                    "name": "sending writes exactly one DocGen_Signer__c carrying what was typed",
+                    "ok": true,
+                    "detail": "1 signer row(s) (expected 1); first = name \"UIQA-ms957llt Signer\" (typed \"UIQA-ms957llt Signer\"), email \"uiqa-ms957llt@example.com\" (typed \"uiqa-ms957llt@example.com\"), role \"Signer\" (typed \"Signer\"), status \"Pending\" (expected \"Pending\"), sort order 1 (expected 1)",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Signature sender (record page)"
+                },
+                {
+                    "name": "bulk generation UI renders on its tab",
+                    "ok": true,
+                    "detail": "{\"chars\":251,\"hasHeading\":true,\"hasStep1\":true}",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "bulk generation UI boots without a console error",
+                    "ok": true,
+                    "detail": "",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "the screen stays usable while a job is still running",
+                    "ok": true,
+                    "detail": "template search box is hittable with 1 non-terminal job(s) present",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "focusing the template box lists the available templates",
+                    "ok": true,
+                    "detail": "20 options offered",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "typing narrows the template list to the match",
+                    "ok": true,
+                    "detail": "after typing \"UIQA Good\": UIQA Good PDF (Account • PDF)",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "a search with no matches says so instead of showing an empty box",
+                    "ok": true,
+                    "detail": "expected the \"No templates found\" empty state in the dropdown",
+                    "severity": "minor",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "a template option can be clicked",
+                    "ok": true,
+                    "detail": "found=true hit=ok",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "selecting a template opens the filter and run steps",
+                    "ok": true,
+                    "detail": "Step 2 (Record Filter) and Step 3 (Run Generation) must appear once a template is chosen",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "the bulk screen offers no file-format override — format stays the template’s",
+                    "ok": true,
+                    "detail": "Output Mode options: Individual Files / Print-Ready Packet / Combined + Individual",
+                    "severity": "minor",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "choosing an output mode is honoured by the UI",
+                    "ok": true,
+                    "detail": "after picking \"Individual Files\" the control reads \"Individual Files\"",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "the Validate Filter button is clickable",
+                    "ok": true,
+                    "detail": "found=true hit=ok",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "Validate reports the true number of matching records",
+                    "ok": true,
+                    "detail": "expected \"2 Records Found\" for Name LIKE 'UIQA%' (2 accounts seeded); component text did not contain it",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "the Run button is clickable once the filter is validated",
+                    "ok": true,
+                    "detail": "found=true hit=ok",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "pressing Run creates a bulk job on the server",
+                    "ok": true,
+                    "detail": "DocGen_Job__c a03O500003ig5fGIAQ status Completed",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "the job generates one document per matching record",
+                    "ok": true,
+                    "detail": "status=Completed total=2 success=2 errors=0; error log: ",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "each generated document is attached to its own record",
+                    "ok": true,
+                    "detail": "6 pdf files across 2 records (expected 1 each on 2 records) — Output Mode was Individual Files",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "the output honours the template's Output Format (PDF)",
+                    "ok": true,
+                    "detail": "extensions produced: pdf",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "a run where every record fails is reported as failed, not as success",
+                    "ok": true,
+                    "detail": "status=Failed success=0 errors=2",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "the failing job records WHY each record failed",
+                    "ok": true,
+                    "detail": "Error_Log__c = 001O50000432dmHIAQ — portwoodglobal.DocGenException: Error retrieving template data: No template file found (active or attached).\n001O50000432dmIIAQ — portwoodglobal.DocGenException: Error retrieving ",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "the Recent Jobs list shows the error count to the user",
+                    "ok": true,
+                    "detail": "Recent Jobs did not show \"UIQA-ms957llt-err\" with \"2 errors\" — a user would see the run as finished with no indication anything went wrong",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "a filter that matches no records leaves Run disabled",
+                    "ok": false,
+                    "detail": "Validate returned 0 records but Run Bulk Generation is still enabled — the user can submit a job that will produce nothing. isRunDisabled only requires filterValidated, and runAnalysis() early-returns on a 0 count so no analysis blocks it (docGenBulkRunner.js isRunDisabled / runAnalysis).",
+                    "severity": "minor",
+                    "skipped": false,
+                    "area": "Bulk runner"
+                },
+                {
+                    "name": "the DocGen Command Hub renders with its navigation",
+                    "ok": true,
+                    "detail": "{\"present\":true,\"navs\":[\"My Templates\",\"Bulk Generation\",\"Signatures\",\"Assets\",\"Buttons\",\"Email Templates\",\"Learning Center\",\"MoreTabs\",\"API Name Help Info\",\"Type Help Info\",\"Word\",\"PDF\"]}",
+                    "severity": "blocker",
+                    "skipped": false,
+                    "area": "Command Hub"
+                },
+                {
+                    "name": "Command Hub \"Bulk Generation\" mounts its component",
+                    "ok": true,
+                    "detail": "rendered 372 chars of text; consoleErrors=none",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Command Hub"
+                },
+                {
+                    "name": "Command Hub \"Signatures\" mounts its component",
+                    "ok": true,
+                    "detail": "rendered 1263 chars of text; consoleErrors=none",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Command Hub"
+                },
+                {
+                    "name": "Command Hub \"Assets\" mounts its component",
+                    "ok": true,
+                    "detail": "rendered 489 chars of text; consoleErrors=none",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Command Hub"
+                },
+                {
+                    "name": "Command Hub \"Email Templates\" mounts its component",
+                    "ok": true,
+                    "detail": "rendered 1534 chars of text; consoleErrors=none",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Command Hub"
+                },
+                {
+                    "name": "the document Button builder mounts from the Command Hub",
+                    "ok": true,
+                    "detail": "rendered 994 chars of text",
+                    "severity": "major",
+                    "skipped": false,
+                    "area": "Command Hub"
+                },
+                {
+                    "name": "the DocGen quick action is reachable by a mouse",
+                    "ok": true,
+                    "detail": "clickable on the highlights panel",
+                    "severity": "major",
+                    "skipped": false
+                },
+                {
+                    "name": "a retired or wrong-object button configuration never appears",
+                    "ok": true,
+                    "detail": "getButtons returned only QA_Account_Doc — the inactive fixture and the Contact fixture were both withheld, so the component takes its run-immediately branch",
+                    "severity": "blocker",
+                    "skipped": false
+                },
+                {
+                    "name": "pressing the record action does not error",
+                    "ok": true,
+                    "detail": "the action screen had already closed itself, which it only does after a successful generate",
+                    "severity": "major",
+                    "skipped": false
+                },
+                {
+                    "name": "the record action delivers a document to the browser",
+                    "ok": true,
+                    "detail": "downloaded \"QA Button Document.pdf\"",
+                    "severity": "blocker",
+                    "skipped": false
+                },
+                {
+                    "name": "Save To Record = false leaves the record untouched",
+                    "ok": true,
+                    "detail": "5 files before and after",
+                    "severity": "major",
+                    "skipped": false
+                },
+                {
+                    "name": "a user without the DocGen permission set gets a clear message, not a broken UI",
+                    "ok": false,
+                    "detail": "the restricted user was sent to the first-login \"Change Your Password\" screen, so the record page was never reached. A session cookie IS set, which is why this slipped past the auth gate and previously got reported as the component rendering nothing — a product defect that did not exist. Set the password once by hand and this check runs.",
+                    "severity": "major",
+                    "skipped": true
+                },
+                {
+                    "name": "a Document Packet contains every document it was built from",
+                    "ok": false,
+                    "detail": "could not move templates into the packet: nothing reached the \"In Packet\" column — the move did not take",
                     "severity": "major",
                     "skipped": true
                 }

--- a/scripts/qa/report/qa-report.md
+++ b/scripts/qa/report/qa-report.md
@@ -1,39 +1,126 @@
 # DocGen QA report
 
-**Org** `docgen-verify` · **Run** 2026-07-26T13:08:37.461Z · **Duration** 20s
+**Org** `docgen-verify` · **Run** 2026-07-31T16:14:23.636Z · **Duration** 401s
 
 ## Headline
 
-|                       |          |
-| --------------------- | -------- |
-| Checks evaluated      | 2        |
-| Passed                | 2 (100%) |
-| Failed                | 0        |
-| Skipped (not counted) | 1        |
-| Blockers              | 0        |
-| Major                 | 0        |
-| Minor                 | 0        |
+|                       |            |
+| --------------------- | ---------- |
+| Checks evaluated      | 81         |
+| Passed                | 78 (96.3%) |
+| Failed                | 3          |
+| Skipped (not counted) | 2          |
+| Blockers              | 0          |
+| Major                 | 2          |
+| Minor                 | 1          |
 
 ## Coverage by area
 
-| Suite                | Area               | Passed | Failed | Skipped | Rate |
-| -------------------- | ------------------ | -----: | -----: | ------: | ---: |
-| `template-integrity` | Template integrity |      2 |      0 |       1 | 100% |
+| Suite       | Area        | Passed | Failed | Skipped |  Rate |
+| ----------- | ----------- | -----: | -----: | ------: | ----: |
+| `ui-runner` | End-user UI |     78 |      3 |       2 | 96.3% |
 
 ## What to fix
 
-Nothing — every evaluated check passed.
+Ordered by severity. The detail column is written to say WHERE to look.
+
+| Severity  | Suite       | Check                                                                          | Evidence                                                                                                                                                                                                                                                                                                       |
+| --------- | ----------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **major** | `ui-runner` | picker hides a template that has no active version                             | "UIQA No Version" is offered in the runner picker but cannot generate — the user gets "No template file found (active or attached)" only after pressing Generate. DocGenController.getTemplatesForObjectInternal filters on Is_Active**c/audience but never checks for an active DocGen_Template_Version**c.   |
+| **major** | `ui-runner` | a record-filtered template is not silently applied to excluded records in bulk | "UIQA Filtered Out" carries a Record_Filter\_\_c and is offered for bulk, where the filter is never evaluated — DocGenBulkController passes null to filterTemplatesForSender and the batch never calls the per-record check. Documents can be generated for records the template excludes. Either the batch mu |
+| **minor** | `ui-runner` | a filter that matches no records leaves Run disabled                           | Validate returned 0 records but Run Bulk Generation is still enabled — the user can submit a job that will produce nothing. isRunDisabled only requires filterValidated, and runAnalysis() early-returns on a 0 count so no analysis blocks it (docGenBulkRunner.js isRunDisabled / runAnalysis).              |
 
 ## Not covered by this run
 
 A skipped check is not a passing one. Each of these is a gap in the evidence.
 
-- `template-integrity` — merge-tag pills stay inside their table cells: could not open a template in the Designer: no Designer tab
+- `ui-runner` — a user without the DocGen permission set gets a clear message, not a broken UI: the restricted user was sent to the first-login "Change Your Password" screen, so the record page was never reached. A session cookie IS set, which is why this slipped past the auth gate and previously got reported as the component rendering nothing — a product defect that did not exist. Set the password once by hand and this check runs.
+- `ui-runner` — a Document Packet contains every document it was built from: could not move templates into the packet: nothing reached the "In Packet" column — the move did not take
 
 ## Every check
 
-### template-integrity — Template integrity
+### ui-runner — End-user UI
 
-- ✅ every HTML template returns a body to the visual Designer — all 6 HTML templates return a non-empty body from getHtmlTemplateBody
-- ✅ each template agrees with its active version about its own type — no template/version type disagreements
-- ⊘ merge-tag pills stay inside their table cells — could not open a template in the Designer: no Designer tab
+- ✅ runner template picker offers an active, usable template for the record — picker returned: UIQA Good PDF, UIQA Locked Format, UIQA No Version — DocGenController.getTemplatesForObjectAndRecord
+- ✅ picker hides a template whose Record_Filter**c excludes this record — Record_Filter**c = Industry = 'Agriculture'; the record is Technology. Picker: UIQA Good PDF, UIQA Locked Format, UIQA No Version
+- ✅ picker hides a template requiring a permission set the user lacks — Required_Permission_Sets\_\_c = UIQA_No_Such_PermSet. Picker: UIQA Good PDF, UIQA Locked Format, UIQA No Version
+- ✅ picker hides an inactive template — Picker: UIQA Good PDF, UIQA Locked Format, UIQA No Version
+- ❌ picker hides a template that has no active version — "UIQA No Version" is offered in the runner picker but cannot generate — the user gets "No template file found (active or attached)" only after pressing Generate. DocGenController.getTemplatesForObject
+- ✅ generating from the picked template produces a real document — DocGenService.processDocument returned 66207 bytes
+- ✅ the generated document's title resolves merge tokens against the record — Document_Title_Format\_\_c = "UIQA-ms957llt {Name}" → title was "UIQA-ms957llt UIQA Alpha", expected "UIQA-ms957llt UIQA Alpha"
+- ✅ a locked output format cannot be overridden at run time — Lock_Output_Format\_\_c = true, override 'Word' → "This template locks its output format. Override not permitted."
+- ✅ a template with no active version fails with a message, not a blank document — got: Error retrieving template data: No template file found (active or attached).
+- ✅ bulk template picker excludes deactivated templates — matches the single-record runner
+- ❌ a record-filtered template is not silently applied to excluded records in bulk — "UIQA Filtered Out" carries a Record_Filter\_\_c and is offered for bulk, where the filter is never evaluated — DocGenBulkController passes null to filterTemplatesForSender and the batch never calls the
+- ✅ the runner shows an actionable empty state when no template matches the record — with every Account template inactive the runner rendered 581 chars; Create Document disabled=true. The user must be told WHY there is nothing to pick, and must not be able to press a button that canno
+- ✅ docGenRunner renders on a record page — rendered 568 chars, 2 picker(s), 1 primary button(s)
+- ✅ the runner shows neither an error nor an empty state on a record that has templates — component text starts: DocGen Create or combine documents for this record. Create Document Document Packet Combine PDFs Category All Categories Test UIQA (Uncategorized) Select Template Choose a templ
+- ✅ docGenRunner boots without a console error
+- ✅ the record-page template picker lists a template the user can actually run — picker showed: Choose a template... / Account / Certificate / [Test] E2E Test Template / ffff / PDFQA Giant Chrome / playa / test / Test2 / test3 / test345 / test99 / [UIQA] UIQA Good PDF / [UIQA] UIQ
+- ✅ the record-page picker applies the active and audience rules — Inactive, Record_Filter\_\_c-excluded and permission-gated templates were all withheld
+- ✅ the template picker is reachable by a mouse — found=true hit=ok
+- ✅ choosing a category narrows the template list to that category — after picking category "UIQA" the picker showed: [UIQA] UIQA Good PDF / [UIQA] UIQA Locked Format / [UIQA] UIQA No Version
+- ✅ the Save to Record output choice is reachable — found=true hit=ok
+- ✅ choosing Save to Record is honoured by the UI — output pills after the click: download, save(active), both
+- ✅ the Create Document button is reachable — found=true hit=ok
+- ✅ pressing Create Document in Save to Record mode puts the document ON the record — ContentDocument "UIQA-ms957llt UIQA Alpha" linked to 001O50000432dmHIAQ
+- ✅ the saved file is in the template's own output format — Output_Format\_\_c = PDF, file extension = .pdf
+- ✅ choosing Download is honoured by the UI — output pills after the click: download(active), save, both
+- ✅ pressing Create Document in Download mode downloads the document to the browser — the browser received "UIQA-ms957llt UIQA Alpha.pdf"
+- ✅ Download does NOT also attach the document to the record — files linked to the record: 3 before the run, 3 after. Download and Save to Record are the two halves of one choice; honouring it means Download leaves the record untouched.
+- ✅ choosing Save & Download is honoured by the UI — output pills after the click: download, save, both(active)
+- ✅ Save & Download hands the file to the browser — the browser received "UIQA-ms957llt UIQA Alpha.pdf"
+- ✅ Save & Download also attaches the document to the record — files linked to the record: 3 before the run, 4 after. A download alone would leave this unchanged — which is exactly the bug this mode exists to avoid.
+- ✅ a template with Lock_Output_Format\_\_c exposes no runtime file-format control — with the locked template selected the runner offered 2 picker(s) (category + template) and the choice widgets [both, download, save], which are output DESTINATIONS, not formats. The server half of thi
+- ✅ the Document Packet tab renders its template chooser and it is reachable — packet tab active=true, dual listboxes=1, source list hit=ok
+- ✅ the packet chooser offers the record's PDF templates — chooser offered 17 template(s): Account / Certificate / E2E Test Template / ffff / PDFQA Giant Chrome / playa
+- ✅ the Create Packet button is reachable and refuses to run with nothing chosen — button hit=ok, disabled=true
+- ✅ the Combine PDFs tab lists the record's existing PDFs and they are reachable — tab active=true, source list hit=ok, it offered 2 file(s) of which 2 are the two PDFs this suite attached to the record
+- ✅ the Combine PDFs button is reachable and refuses to run with fewer than two files chosen — button hit=ok, disabled=true with nothing moved into the Combine list
+- ✅ docGenSignatureSender renders on a record page — rendered 321 chars with its template picker, signer table and send button
+- ✅ docGenSignatureSender boots without a console error
+- ✅ the send button refuses to send with no document and no signer details — found=true disabled=true
+- ✅ the signature document picker is reachable — found=true hit=ok
+- ✅ the signature document picker offers the record’s templates and they can be clicked — found=true hit=ok
+- ✅ a document alone is not enough to send — the signer is still required — with a template chosen and the signer row blank, the send button is disabled=true
+- ✅ every signer field is reachable by a mouse — role=ok name=ok email=ok
+- ✅ a signer with no email address cannot be sent to — role and name filled, email blank → send button disabled=true
+- ✅ a complete document + signer enables the send button — role, name and email all filled → send button disabled=false
+- ✅ the send button is reachable by a mouse — found=true hit=ok
+- ✅ sending a signature request tells the user it worked — component text: Signature Links Generated! Provide each signer with their unique secure link: UIQA-ms957llt Signer Signer https://<CONFIGURE_SITE_URL_IN_SETUP>/apex/portwoodglobal\_\_DocGenSignaturePdf?
+- ✅ sending writes a DocGen_Signature_Request\_\_c tied to this record and template — request a08O5000014KMCrIAO: record=001O50000432dmHIAQ (expected 001O50000432dmHIAQ), status=Sent, order=Parallel, sourceDoc=068O500000MQWm2IAH
+- ✅ sending writes exactly one DocGen_Signer\_\_c carrying what was typed — 1 signer row(s) (expected 1); first = name "UIQA-ms957llt Signer" (typed "UIQA-ms957llt Signer"), email "uiqa-ms957llt@example.com" (typed "uiqa-ms957llt@example.com"), role "Signer" (typed "Signer"),
+- ✅ bulk generation UI renders on its tab — {"chars":251,"hasHeading":true,"hasStep1":true}
+- ✅ bulk generation UI boots without a console error
+- ✅ the screen stays usable while a job is still running — template search box is hittable with 1 non-terminal job(s) present
+- ✅ focusing the template box lists the available templates — 20 options offered
+- ✅ typing narrows the template list to the match — after typing "UIQA Good": UIQA Good PDF (Account • PDF)
+- ✅ a search with no matches says so instead of showing an empty box — expected the "No templates found" empty state in the dropdown
+- ✅ a template option can be clicked — found=true hit=ok
+- ✅ selecting a template opens the filter and run steps — Step 2 (Record Filter) and Step 3 (Run Generation) must appear once a template is chosen
+- ✅ the bulk screen offers no file-format override — format stays the template’s — Output Mode options: Individual Files / Print-Ready Packet / Combined + Individual
+- ✅ choosing an output mode is honoured by the UI — after picking "Individual Files" the control reads "Individual Files"
+- ✅ the Validate Filter button is clickable — found=true hit=ok
+- ✅ Validate reports the true number of matching records — expected "2 Records Found" for Name LIKE 'UIQA%' (2 accounts seeded); component text did not contain it
+- ✅ the Run button is clickable once the filter is validated — found=true hit=ok
+- ✅ pressing Run creates a bulk job on the server — DocGen_Job\_\_c a03O500003ig5fGIAQ status Completed
+- ✅ the job generates one document per matching record — status=Completed total=2 success=2 errors=0; error log:
+- ✅ each generated document is attached to its own record — 6 pdf files across 2 records (expected 1 each on 2 records) — Output Mode was Individual Files
+- ✅ the output honours the template's Output Format (PDF) — extensions produced: pdf
+- ✅ a run where every record fails is reported as failed, not as success — status=Failed success=0 errors=2
+- ✅ the failing job records WHY each record failed — Error_Log\_\_c = 001O50000432dmHIAQ — portwoodglobal.DocGenException: Error retrieving template data: No template file found (active or attached). 001O50000432dmIIAQ — portwoodglobal.DocGenException: Er
+- ✅ the Recent Jobs list shows the error count to the user — Recent Jobs did not show "UIQA-ms957llt-err" with "2 errors" — a user would see the run as finished with no indication anything went wrong
+- ❌ a filter that matches no records leaves Run disabled — Validate returned 0 records but Run Bulk Generation is still enabled — the user can submit a job that will produce nothing. isRunDisabled only requires filterValidated, and runAnalysis() early-returns
+- ✅ the DocGen Command Hub renders with its navigation — {"present":true,"navs":["My Templates","Bulk Generation","Signatures","Assets","Buttons","Email Templates","Learning Center","MoreTabs","API Name Help Info","Type Help Info","Word","PDF"]}
+- ✅ Command Hub "Bulk Generation" mounts its component — rendered 372 chars of text; consoleErrors=none
+- ✅ Command Hub "Signatures" mounts its component — rendered 1263 chars of text; consoleErrors=none
+- ✅ Command Hub "Assets" mounts its component — rendered 489 chars of text; consoleErrors=none
+- ✅ Command Hub "Email Templates" mounts its component — rendered 1534 chars of text; consoleErrors=none
+- ✅ the document Button builder mounts from the Command Hub — rendered 994 chars of text
+- ✅ the DocGen quick action is reachable by a mouse — clickable on the highlights panel
+- ✅ a retired or wrong-object button configuration never appears — getButtons returned only QA_Account_Doc — the inactive fixture and the Contact fixture were both withheld, so the component takes its run-immediately branch
+- ✅ pressing the record action does not error — the action screen had already closed itself, which it only does after a successful generate
+- ✅ the record action delivers a document to the browser — downloaded "QA Button Document.pdf"
+- ✅ Save To Record = false leaves the record untouched — 5 files before and after
+- ⊘ a user without the DocGen permission set gets a clear message, not a broken UI — the restricted user was sent to the first-login "Change Your Password" screen, so the record page was never reached. A session cookie IS set, which is why this slipped past the auth gate and previousl
+- ⊘ a Document Packet contains every document it was built from — could not move templates into the packet: nothing reached the "In Packet" column — the move did not take

--- a/scripts/qa/suites/ui-runner.mjs
+++ b/scripts/qa/suites/ui-runner.mjs
@@ -1263,6 +1263,71 @@ export async function run({ org, headed }) {
                         area: runnerArea
                     });
                 }
+
+                /* --- 2e-2. Save & Download must do BOTH -------------- */
+                // The whole point of the mode: one press, one generation, two
+                // outcomes. Asserted as both halves, because the failure modes are
+                // opposite — a download that quietly skipped the save, or a save
+                // whose bytes never reached the browser.
+                const bothPill = await locate(page, '.pill-btn[data-value="both"]');
+                if (!bothPill.found || bothPill.hit !== 'ok') {
+                    add(
+                        skip(
+                            'pressing Create Document in Save & Download mode both saves and downloads',
+                            `the Save & Download output choice was not reachable (${bothPill.hit})`,
+                            SEVERITY.MAJOR
+                        )
+                    );
+                } else {
+                    await clickAt(page, bothPill, 1000);
+                    const afterBoth = await runnerControls(page);
+                    const bothPillNow = (afterBoth.pills || []).find((p) => p.v === 'both');
+                    add({
+                        ...check(
+                            'choosing Save & Download is honoured by the UI',
+                            !!bothPillNow && bothPillNow.active === true,
+                            `output pills after the click: ${(afterBoth.pills || [])
+                                .map((p) => `${p.v}${p.active ? '(active)' : ''}`)
+                                .join(', ')}`,
+                            SEVERITY.MAJOR
+                        ),
+                        area: runnerArea
+                    });
+
+                    const filesBeforeBoth = await recordFileCount(org, acctId);
+                    const bothDownloadName = page
+                        .waitForEvent('download', { timeout: 210000 })
+                        .then((d) => d.suggestedFilename())
+                        .catch(() => null);
+                    const genPos3 = await locate(page, '.cool-brand-btn');
+                    if (genPos3.found && genPos3.hit === 'ok') {
+                        await clickAt(page, genPos3, 1500);
+                    }
+                    const bothName = await bothDownloadName;
+                    add({
+                        ...check(
+                            'Save & Download hands the file to the browser',
+                            !!bothName,
+                            bothName
+                                ? `the browser received "${bothName}"`
+                                : 'no download event fired within 210s — the save half may have run alone',
+                            SEVERITY.MAJOR
+                        ),
+                        area: runnerArea
+                    });
+                    await page.waitForTimeout(8000);
+                    const filesAfterBoth = await recordFileCount(org, acctId);
+                    add({
+                        ...check(
+                            'Save & Download also attaches the document to the record',
+                            filesAfterBoth > filesBeforeBoth,
+                            `files linked to the record: ${filesBeforeBoth} before the run, ${filesAfterBoth} after. ` +
+                                `A download alone would leave this unchanged — which is exactly the bug this mode exists to avoid.`,
+                            SEVERITY.MAJOR
+                        ),
+                        area: runnerArea
+                    });
+                }
             }
 
             /* --- 2f. A locked output format has no runtime control -- */
@@ -1284,7 +1349,11 @@ export async function run({ org, headed }) {
                         (s, i) => i !== lIdx.category && i !== lIdx.template
                     );
                     const pillValues = (lockedControls.pills || []).map((p) => p.v).sort();
-                    const onlyDestination = pillValues.every((v) => v === 'download' || v === 'save');
+                    // 'both' (Save & Download) is a DESTINATION choice like the other
+                    // two — it is the combination of them, not an output format.
+                    const onlyDestination = pillValues.every(
+                        (v) => v === 'download' || v === 'save' || v === 'both'
+                    );
                     add({
                         ...check(
                             'a template with Lock_Output_Format__c exposes no runtime file-format control',

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,15 +1,15 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.48.0 — Bulk generation: conditionals, charts, sorting, permissions",
-      "versionNumber": "3.48.0.NEXT",
+      "versionName": "v3.49.0 — Bulk sort order, {RowNumber}, Save & Download",
+      "versionNumber": "3.49.0.NEXT",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "postInstallScript": "DocGenEmailTemplateInstall",
       "package": "Portwood DocGen Managed",
-      "ancestorVersion": "3.47.0",
-      "versionDescription": "Portwood DocGen generates PDFs and Word documents from any Salesforce record. v3.48 is a bulk generation release: conditional sections and filtered loops now behave the same in bulk as they do for a single record, charts render in bulk jobs, and you can sort related lists by more than one column. Template cloning now brings every file with it, and the Template Designer opens correctly for users with the DocGen Admin permission set. 100% native Salesforce — no external services or callouts. Free for all users."
+      "ancestorVersion": "3.48.0",
+      "versionDescription": "Portwood DocGen generates PDFs and Word documents from any Salesforce record. v3.49 puts you in control of document order. Bulk jobs can now be sorted by any field — including a field on a related record, like the Account name — so a combined PDF comes out in the order you expect instead of the order records happened to be created. Table rows can number themselves with a new {RowNumber} tag. And when you generate a document you no longer have to choose between keeping a copy and filing it: a new Save & Download option does both from one generation, with no size limit. 100% native Salesforce — no external services or callouts. Free for all users."
     },
     {
       "versionName": "v1.0.0 — Agentforce template authoring",


### PR DESCRIPTION
Four features, plus one bug the release gate turned up on the way through.

## Bulk parent-level sort order

The bulk query had **no `ORDER BY` at all**, so records were processed in QueryLocator order — effectively record-Id creation order — and nothing in the runner or the Flow action could change it. That is invisible for Individual Files but it decides **page order in a Combined PDF**: `DocGenBatch` stamps a zero-padded sequence on each HTML snippet as it processes records, and `DocGenMergeJob` assembles by that title. So sorting the locator sorts the packet, with no change to the merge pipeline.

- **Runner** — a **Sort By** picker listing every sortable field on the base object plus each lookup's parent name field, so *"order these 200 Opportunities by Account name"* is one click rather than a hand-typed relationship path.
- **Flow action** — a **Sort Order** input taking the same clause. A bad field fails the action on `Error Message` rather than faulting the interview. The `Record IDs` input's description now documents a silent trap: SOQL does not preserve that collection's order, so sorting it in the Flow does nothing.
- **`DocGen_Job__c.Sort_Order__c`** stores the validated clause so `DocGenBatch` — constructed from a job Id — can read it in `start()`.

`normalizeSortOrder` validates against the base object's schema. Injection defense is a **character allowlist**, not a keyword blocklist: an `ORDER BY` needs only field paths, commas, spaces and `ASC`/`DESC`/`NULLS`, so quotes, parens, semicolons and comment markers are rejected outright — nothing to keep ahead of. Field paths then resolve through describe (max 2 hops, each verified sortable), so an unknown field is an error **at submit time** rather than a batch that dies in `start()` and leaves a job stuck at Processing.

Two deliberate behaviours: blanks sort **last** (SOQL puts them first ascending, which would open a packet with the records that have nothing in the sort field), and a single sort field gains the object's name field as a **tie-break**, so two runs of the same job produce the same packet instead of reshuffling same-account records.

## `{RowNumber}` loop counter

Numbers rows 1..N inside any loop. There was no way to do this before — the only index token anywhere was `{index}` inside `{#ChartBucket}`.

Both resolution paths carry it, per the three-paths rule in CLAUDE.md:
- **In-memory** — `processXml`'s two section-loop branches (bare list and the `{records: […]}` shape).
- **Giant-query** — `renderLoopBodyForRecords` gains a `rowNumberOffset` that `DocGenGiantQueryBatch` accumulates across `execute()`. Without it every fragment restarts at 1 and a 30,000-row table counts 1..50 over and over — correct on page one, wrong everywhere after.

The counter goes into a per-row **copy** of the data map, never the record map, so it cannot leak into record fields or be seen as a stale value by a nested loop. Tag presence is probed once per loop (same shape as `loopBodyHasImageTag`), so templates that don't use it pay nothing for the copy.

## Save & Download (#260)

Customer request via support. A third destination pill, offered only when the placement leaves **both** destinations enabled — it is the combination of the two, so unticking either in App Builder removes it.

Five of the six generation paths already held the base64 in the browser and simply chose one of two things to do with it, so "both" is *just not choosing*. All six now route through one `_deliverGeneratedDocument` helper, which also collapsed six copies of that if/else and put the 5 MB ceiling + drag-to-attach fallback in one place instead of two divergent copies.

**PDF keeps the asynchronous render and gains no size ceiling.** Forcing it synchronous to get the bytes back would reintroduce the CSRF timeout the Queueable exists to avoid, on exactly the largest documents. Instead it polls the existing `getPdfSampleGenerationStatus` — which already returned `contentVersionId` on completion, so **no new Apex** — and points the browser at the saved ContentVersion. Neither half passes through the Aura response. `NavigationMixin` builds the URL because the runner also runs on Experience Cloud pages, where a bare `/sfc/...` path misses the site prefix.

Also closes a hole found while wiring it: the 30 MB attached-image pre-flight guard was gated on the save-only flag, so this mode would have skipped it and failed at the ContentVersion insert with no useful message.

New `DocGenRunner_SaveAndDownload` label, translated into all 10 shipped languages.

## Lone output-destination pill

With only one destination enabled the runner still rendered a single pill that looked interactive and did nothing. Safe to hide because generation never reads `outputMode` directly — every call site goes through `resolvedOutputMode`, which falls back to whichever mode is allowed.

## Designer could load an OLD template body — found by the release gate

Not one of the features; `RunLocalTests` surfaced it during validation. `DocGenHtmlTemplateTest.getHtmlTemplateBodyReturnsLatestBody` saved two bodies and read back the **first**.

`PreDecompXmlLoader` takes row 0 of `ORDER BY CreatedDate DESC`. `CreatedDate` is **second-granular**, so two writes in the same second tie, and SOQL breaks a tie arbitrarily — "newest wins" returned whichever row the optimizer preferred. The symptom is an editor that silently shows **stale content**: open the Designer, get the previous body, save, and the newer one is overwritten. No error, nothing logged. Fixed with a deterministic `Id DESC` tie-break on both loader queries.

Confirmed pre-existing, not a regression from this branch: `DocGenController.cls` and the test are untouched here, and the `DocGenService` diff hunks are at lines 4193/8248/9252+ while the loader is at 140–260.

## Validation

| Gate | Result |
| --- | --- |
| e2e 01..08 + 07-syntax1..5 | **265 assertions, FAIL 0** |
| `RunLocalTests` | **Passed** — 1890 tests, 100%, 78% org-wide |
| `sf code-analyzer` (Security + AppExchange) | **0 violations** |
| `ui-runner` QA suite | 78/81, **0 blockers** |

The 3 `ui-runner` failures are pre-existing and unrelated (template-with-no-active-version in the picker, bulk record-filter evaluation, zero-match filter leaving Run enabled).

New QA coverage in `scripts/qa/suites/ui-runner.mjs` asserts Save & Download does **both** halves — the failure modes are opposite, so a one-sided check would miss either:

```
✅ choosing Save & Download is honoured by the UI — pills: download, save, both(active)
✅ Save & Download hands the file to the browser — received "UIQA-… UIQA Alpha.pdf"
✅ Save & Download also attaches the document to the record — 3 files before, 4 after
```

New `scripts/e2e-07-syntax5.apex` covers `{RowNumber}` syntax — it is a new file because syntax1–4 are each within a few hundred characters of the Anonymous Apex size ceiling. CLAUDE.md's checklist and that note are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
