### PR TITLE
v3.51.0 — teach the AI authoring prompt Portwood's full tag surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## v3.51.0 — Smarter AI template authoring
+
+**No action required.** Nothing about existing templates or generated documents
+changes. This release improves what the AI knows when it writes a template for
+you.
+
+### Changed — a fuller merge-tag reference in the authoring prompt
+
+The prompt the Designer sends (the same one **Copy AI Prompt** puts on your
+clipboard) now spells out the tags it was previously silent about, so the model
+stops reaching for the UserGuide link and stops inventing syntax:
+
+- `{RowNumber}` — 1-based row counter inside any loop, including how it restarts
+  per nested loop and per `{#GroupBy}` group
+- `{#GroupBy Rel by Field}` — expanded with a complete worked example (own
+  `<table>` + `<thead>` per group, `{GroupName}` header, per-group subtotal)
+- `{^Field}` inverse conditionals, and `{#IF …}` comparisons with
+  `AND`/`OR`/`NOT`, parentheses, nesting, and the
+  `{#IF Rel.totalSize != 0}` "render this section if there are rows" idiom
+- `{Chart:Rel:Field:style:opts}` — the one-line chart tag, with all nine styles
+  and every modifier. Previously the prompt only described the hand-authored
+  `{#ChartBucket}` loop, which is now correctly presented as the fallback for
+  layouts the one-liner can't produce.
+- `{%FieldName}` / `{%Image:N}` record images, including that the `:WxH` size
+  token — not CSS — is what sizes them
+- Rich-text passthrough, `{PageNumber}`/`{TotalPages}` (header/footer only, so
+  the model stops putting them in the body), `:Initials`/`:DatePick`/`:inline`
+  signature types, and the `{#Signatures}` variable-signer loop
+
+Also corrected: the prompt advertised `code39` barcodes, which the engine does
+not support and renders as nothing. Only `code128` and `qr` are listed now.
+
+This lands in the **base package**, not in the Agentforce Extension: the prompt is
+assembled by the Designer and passed to whichever AI provider is configured, so
+both the in-org Agentforce button and the copy-paste route pick it up from one
+place.
+
+## Agentforce Extension v1.1.0 — Free install, no installation key
+
+`04tVx000000zxUbIAI` (build 1.1.0-1, promoted 2026-08-01, ancestor 1.0.0.2).
+
+Separate optional package (`Portwood Agentforce Extension`), versioned
+independently of Portwood itself.
+
+### Changed — no installation key
+
+v1.0.0 required an installation key at install. v1.1.0 does not: the extension is
+free for everyone, on the same terms as Portwood. This is also what lets it go
+through AppExchange security review as a free listing.
+
+Prerequisites are unchanged — Portwood 3.46 or later, and Einstein / Prompt
+Builder enabled in the org. Salesforce still enforces both at install.
+
+Install (no password):
+<https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000zxUbIAI>
+
 ## v3.50.0 — Renamed to Portwood
 
 `04tVx000000zxCrIAI` (build 3.50.0-1, promoted 2026-07-31, ancestor 3.49.0). Build

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -998,7 +998,9 @@ ConnectApi.EinsteinPromptTemplateGenerationsInput probe = new ConnectApi.Einstei
 System.debug('Einstein Apex types are visible');
 ```
 
-**Install it,** entering the installation key you were given. Then open any HTML
+**Install it** — v1.1.0 and later need no installation key; it is free, like
+Portwood itself. (v1.0.0 was key-protected. If you were given a key, you are on
+the old build — install v1.1.0 or later instead.) Then open any HTML
 template in the Designer — **Generate with Agentforce** appears next to Copy AI
 Prompt. No permission set beyond **Portwood Admin**, and no settings to change.
 

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -527,12 +527,22 @@ export function buildAiPrompt(shape, options) {
         '- Format suffixes: {CloseDate:MMMM d, yyyy} (Java SimpleDateFormat), {CloseDate:date} (user locale), {Amount:currency}, {Amount:currency:EUR}, {Qty:number}, {Qty:#,##0.00}, {Rate:percent}, {IsActive:checkbox} ([X]/[ ]), {Status__c:label} (picklist label).'
     );
     lines.push(
-        '- Child loop: {#RelationshipName} ... {/RelationshipName} repeats the block per child record; child fields are bare inside the loop. If the tags sit inside a table row, the whole <tr> repeats — put {#Rel} in the first cell and {/Rel} in the last cell of the data row. Use a real <thead> for column headers. Nested loops are supported.'
+        '- Child loop: {#RelationshipName} ... {/RelationshipName} repeats the block per child record; child fields are bare inside the loop. If the tags sit inside a table row, the whole <tr> repeats — put {#Rel} in the first cell and {/Rel} in the last cell of the data row. Use a real <thead> for column headers. Nested loops are supported. An empty child list renders nothing — no error.'
     );
     lines.push(
-        '- Group into separate tables/sections by a field value: {#GroupBy RelationshipName by GroupField} ... {/GroupBy} repeats its whole block once per DISTINCT value of GroupField among the child records (first-seen order; dot-paths like Product2.Family allowed). Inside the block, {GroupName} is that group’s value (use it as the header), the inner {#RelationshipName}...{/RelationshipName} loops only that group’s members, and {SUM|COUNT|AVG:RelationshipName.Field} totals just that group. Ideal when the user wants "a table per <type/category>" without knowing the values in advance.'
+        '- Row numbering: {RowNumber} inside any loop is that row’s 1-based position — use it for a "#" column. It counts the rows actually rendered, keeps counting through very large tables, restarts at 1 for each nested loop and for each {#GroupBy} group, and resolves to nothing outside a loop. Accepts format suffixes ({RowNumber:number}).'
+    );
+    lines.push(
+        '- Group into separate tables/sections by a field value: {#GroupBy RelationshipName by GroupField} ... {/GroupBy} repeats its whole block once per DISTINCT value of GroupField among the child records (first-seen order; dot-paths like Product2.Family allowed). Inside the block, {GroupName} is that group’s value (use it as the header), the inner {#RelationshipName}...{/RelationshipName} loops only that group’s members, {RowNumber} restarts at 1, and {SUM|COUNT|AVG|MIN|MAX:RelationshipName.Field} aggregate just that group. Ideal when the user wants "a table per <type/category>" without knowing the values in advance — 50 distinct values produce 50 tables, with no need to know them up front. Give each group its own <table> WITH its own <thead>, and put the whole table inside the {#GroupBy} block.'
+    );
+    lines.push(
+        '- Group-block example: {#GroupBy Lines by Product2.Family}<h3>{GroupName}</h3><table><thead><tr><th>#</th><th>Product</th><th>Amount</th></tr></thead><tbody><tr><td>{#Lines}{RowNumber}</td><td>{Product2.Name}</td><td>{TotalPrice:currency}{/Lines}</td></tr><tr><td colspan="2">Subtotal</td><td>{SUM:Lines.TotalPrice:currency}</td></tr></tbody></table>{/GroupBy}'
     );
     lines.push('- Conditional: {#SomeField} shown when truthy {:else} otherwise {/SomeField}.');
+    lines.push('- Inverse conditional: {^SomeField} shown when the field is FALSY {:else} otherwise {/SomeField}.');
+    lines.push(
+        "- Comparison conditional: {#IF Amount > 100000} ... {:else} ... {/IF}. Operators > < >= <= = (or ==) != against a field, a number, or a quoted string (case-sensitive). Combine with AND / OR / NOT (or && || !) and parentheses: {#IF (Amount > 1000 AND StageName = 'Closed Won') OR Type = 'Renewal'}. Nest {#IF} blocks freely. To render a section only when a child list has rows, use {#IF RelationshipName.totalSize != 0} — totalSize is 0, never null, on an empty relationship."
+    );
     lines.push(
         '- Aggregates (grand totals across a child list, place OUTSIDE the loop): {SUM:Rel.Field}, {AVG:Rel.Field}, {MIN:Rel.Field}, {MAX:Rel.Field}, {COUNT:Rel} or {COUNT:Rel.Field}. All accept format suffixes: {SUM:Lines.Amount:currency}, {SUM:Lines.Amount:currency:EUR:de_DE} (ISO + locale), {SUM:Lines.Amount:currency:auto} (record currency), {COUNT:Lines:number}. The aggregated field must be in the Query Config, but does NOT need to be a rendered column.'
     );
@@ -540,13 +550,25 @@ export function buildAiPrompt(shape, options) {
         '- Built-ins: {Today:MMMM d, yyyy}, {Now:yyyy-MM-dd HH:mm}, and running-user tags {RunningUser.Name}, {RunningUser.Email}, {RunningUser.Title}.'
     );
     lines.push(
-        '- Barcodes & QR codes (rendered server-side as crisp vectors — no fonts, no external services, no <img>): {*FieldName} = QR code of the field value; {*FieldName:qr:200} = QR at 200px; {*FieldName:code128} and {*FieldName:code39} = linear barcodes (add :WxH like {*Serial__c:code128:300x80} to size). QR handles URLs and long text and survives low print quality best; Code 128/39 suit short IDs and serials. Place the tag alone in its own cell/block with white space around it — do not shrink below the default or scanners will struggle. Any queried field works, e.g. {*Id}, {*Name}, {*Tracking_Number__c}.'
+        '- Barcodes & QR codes (rendered server-side — no fonts, no external services, no <img> of your own): {*FieldName} = Code 128 barcode of the field value; {*FieldName:code128:300x80} = Code 128 sized 300x80px; {*FieldName:qr} = QR code; {*FieldName:qr:200} = QR at 200px. ONLY code128 and qr are supported — any other type renders nothing, silently. QR handles URLs and long text and survives low print quality best; Code 128 suits short IDs and serials. Place the tag alone in its own cell/block with white space around it — do not shrink below the default or scanners will struggle. Any queried field works, e.g. {*Id}, {*Name}, {*Tracking_Number__c}.'
     );
     lines.push(
-        '- Charts (aggregate a child list into bars, place OUTSIDE loops): {#ChartBucket:Rel:Field} {key} {count} {percent} {/ChartBucket} groups child records by Field and repeats the body per bucket — style it as CSS bars (a <div> whose width uses {percent}). Keep charts CSS-only; no SVG or canvas.'
+        '- Charts — ONE-LINE TAG, this is the path to use: {Chart:RelationshipName:FieldToGroupBy:style:opt=value&opt=value}, on its own line as a block-level element. Portwood aggregates the child records server-side and renders it as a real image, so you do NOT style it — no wrapper markup, no CSS bars. Styles: bar (horizontal, best for long labels), column (vertical), pie, donut, line, area, and the cross-tab styles stacked, clustered, pivot (these three REQUIRE groupBy=). Default style is bar. Modifiers, joined with &: title=Text (header drawn above the chart), width=420, height=240, colors=#1e40af,#b91c1c (6-char hex, cycles), groupBy=SecondField__c (second dimension), colSort=A,B,C (column order), where=SOQL fragment, split=; (multi-select field). Examples: {Chart:Survey_Responses__r:Answer__c:bar:title=Responses by Answer} and {Chart:Survey_Responses__r:Answer__c:stacked:groupBy=Location__c&title=Answer by Location}. Inside a {#Rel} loop the chart’s relationship resolves against the record being iterated, giving one chart per row.'
     );
     lines.push(
-        '- E-signature placeholders (only if asked for a signable document): {@Signature_RoleName:1:Full}, {@Signature_RoleName:1:Date}.'
+        '- Charts — hand-authored fallback, use ONLY when the one-line tag cannot produce the layout asked for: {#ChartBucket:Rel:Field} {key} {count} {percent} {/ChartBucket} groups child records by Field and repeats the body per bucket, so you style it yourself as CSS bars (a <div> whose width uses {percent}). Keep it CSS-only; no SVG or canvas.'
+    );
+    lines.push(
+        '- Record images: {%FieldName} renders the image stored in a file/ContentVersion field, {%Image:1} renders the Nth file attached to the record. Size them INSIDE the tag — {%FieldName:160x} (160px wide), {%Image:1:x80} (80px tall), {%FieldName:200x80} (exact) — CSS width/height on the tag does NOT size the image in the PDF.'
+    );
+    lines.push(
+        '- Rich text / long text fields pass their formatting through automatically (paragraphs, bold, italic, links, line breaks). Do not wrap them in <pre> or escape them.'
+    );
+    lines.push(
+        '- Page numbers: {PageNumber} and {TotalPages} work ONLY in the template’s Header HTML / Footer HTML fields, never in the body — do not put them in the document you write; mention them to the user instead if they ask for page numbering.'
+    );
+    lines.push(
+        '- E-signature placeholders (only if asked for a signable document): {@Signature_RoleName:1:Full}, {@Signature_RoleName:1:Initials}, {@Signature_RoleName:1:Date}, {@Signature_RoleName:1:DatePick}. Role is any string (underscores become spaces), then the signing order, then the type. Add :inline as a final suffix for a compact in-place mark instead of a stamp card. When the number of signers varies, use the {#Signatures} ... {/Signatures} loop instead of fixed role tags.'
     );
     lines.push('');
     lines.push('DATA SHAPE — use ONLY these fields (any other tag renders empty):');
@@ -702,7 +724,9 @@ export function buildAiPrompt(shape, options) {
         '1. Return ONE complete self-contained HTML file (<!DOCTYPE html> ... </html>) with all CSS inline in a single <style> block. No commentary, no markdown fences.'
     );
     lines.push('2. Professional print-ready design within the CSS 2.1 constraints above.');
-    lines.push('3. Use only the merge tags listed in DATA SHAPE (plus {Today}/{RunningUser.*} built-ins).');
+    lines.push(
+        '3. Only bind to field names listed in DATA SHAPE. On top of those you may use any tag from PORTWOOD MERGE TAG SYNTAX above — {RowNumber}, {#GroupBy}/{GroupName}, {#IF}, aggregates, {Chart:...}, {Today}/{Now}, {RunningUser.*} — since those are built into the engine and need no field of their own.'
+    );
     lines.push('');
     lines.push(
         'QUESTIONS? The full Portwood UserGuide covers every merge tag, format suffix, and PDF rendering rule — look it up if anything here is unclear: https://github.com/Portwood-Global-Solutions/Portwood/blob/main/UserGuide.md'

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,23 +1,24 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.50.0 — Renamed to Portwood",
-      "versionNumber": "3.50.0.NEXT",
+      "versionName": "v3.51.0 — Smarter AI template authoring",
+      "versionNumber": "3.51.0.NEXT",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "postInstallScript": "DocGenEmailTemplateInstall",
       "package": "Portwood",
-      "ancestorVersion": "3.49.0",
-      "versionDescription": "Portwood DocGen generates PDFs and Word documents from any Salesforce record. v3.49 puts you in control of document order. Bulk jobs can now be sorted by any field — including a field on a related record, like the Account name — so a combined PDF comes out in the order you expect instead of the order records happened to be created. Table rows can number themselves with a new {RowNumber} tag. And when you generate a document you no longer have to choose between keeping a copy and filing it: a new Save & Download option does both from one generation, with no size limit. 100% native Salesforce — no external services or callouts. Free for all users."
+      "ancestorVersion": "3.50.0",
+      "versionDescription": "Portwood generates PDFs and Word documents from any Salesforce record. v3.51 makes the built-in AI template writer far better at Portwood's own features. Ask it for numbered rows, a separate table for each product family, a chart, or a section that only appears when there is something to put in it, and you get a template that works the first time instead of a near miss — because the AI is now told about all of those capabilities up front rather than left to guess at them. This applies whether you write templates inside Salesforce with Agentforce or copy the prompt out to your own assistant. 100% native Salesforce — no external services or callouts. Free for all users."
     },
     {
-      "versionName": "v1.0.0 — Agentforce template authoring",
-      "versionNumber": "1.0.0.NEXT",
+      "versionName": "v1.1.0 — Free install, no installation key",
+      "versionNumber": "1.1.0.NEXT",
       "path": "agentforce-ext",
       "default": false,
       "package": "Portwood Agentforce Extension",
-      "versionDescription": "Adds AI template authoring to Portwood DocGen. Describe the document you want and it writes the template; ask for a change in plain English and it revises the one you already have. Everything it produces is checked against the PDF engine first, so a template never looks right on screen and wrong in the finished document. Includes a ready-made prompt template — no Prompt Builder setup required. Requires Portwood DocGen 3.46 or later and Einstein/Prompt Builder in your org. 100% native Salesforce — no external services or callouts.",
+      "ancestorVersion": "1.0.0",
+      "versionDescription": "Adds AI template authoring to Portwood. Describe the document you want and it writes the template; ask for a change in plain English and it revises the one you already have. Everything it produces is checked against the PDF engine first, so a template never looks right on screen and wrong in the finished document. Includes a ready-made prompt template — no Prompt Builder setup required, and no installation key: like Portwood itself, it is free for everyone. Requires Portwood 3.46 or later and Einstein/Prompt Builder in your org. 100% native Salesforce — no external services or callouts.",
       "definitionFile": "config/agentforce-ext-def.json",
       "dependencies": [
         {
@@ -235,6 +236,7 @@
     "Portwood Agentforce Extension@1.0.0-2": "04tVx000000s82DIAQ",
     "Portwood@3.48.0-1": "04tVx000000zgS9IAI",
     "Portwood@3.49.0-1": "04tVx000000zvz3IAA",
-    "Portwood@3.50.0-1": "04tVx000000zxCrIAI"
+    "Portwood@3.50.0-1": "04tVx000000zxCrIAI",
+    "Portwood Agentforce Extension@1.1.0-1": "04tVx000000zxUbIAI"
   }
 }


### PR DESCRIPTION
## What

The prompt `buildAiPrompt` assembles — the same text **Copy AI Prompt** hands to an external assistant, and what the **Generate with Agentforce** button sends through ConnectApi — was silent about most of Portwood's merge-tag surface. The model either followed the UserGuide link at the bottom or invented syntax. This spells the tags out inline.

- `{RowNumber}` — including that it restarts per nested loop and per `{#GroupBy}` group
- `{#GroupBy Rel by Field}` — was present but thin; now has a worked example with its own `<table>`/`<thead>` per group, `{GroupName}` header, and per-group subtotal
- `{^Field}` inverse conditionals, and `{#IF}` comparisons with `AND`/`OR`/`NOT`, parentheses, nesting, and the `{#IF Rel.totalSize != 0}` "only if there are rows" idiom
- `{Chart:Rel:Field:style:opts}` — all nine styles and every modifier, framed as the path to use. The prompt previously described **only** the hand-authored `{#ChartBucket}` loop, which is now presented as the fallback it actually is.
- `{%FieldName}` / `{%Image:N}` with the `:WxH` sizing rule (CSS does not size them)
- Rich-text passthrough; `{PageNumber}`/`{TotalPages}` flagged header/footer-only so the model stops putting them in the body; `:Initials`/`:DatePick`/`:inline` signature types and the `{#Signatures}` variable-signer loop

**One correction:** the prompt advertised `code39` barcodes. The engine supports only `code128` and `qr` — anything else renders as nothing, silently.

## Why it is not in the Agentforce Extension

The extension ships a *carrier* `GenAiPromptTemplate` whose whole content is a wrapper plus `{{Input.Instructions}}`; the real prompt is assembled by the Designer in the base package. Keeping it there for two reasons:

1. The carrier is `templateFormat: Jinja`, and `{#` opens a Jinja comment. A tag reference full of `{#Lines}` / `{#GroupBy …}` would be parsed as template syntax rather than passed through. It is safe in `buildAiPrompt` because that text is an input *value*, never parsed.
2. Forking it across two independently versioned packages is exactly the drift `DocGenAiTemplateController`'s header comment was written to prevent.

## Also

- `UserGuide` 5.7.11 no longer tells people to enter an installation key — **Agentforce Extension v1.1.0** (`04tVx000000zxUbIAI`, promoted 2026-08-01, ancestor 1.0.0.2) installs without one.
- `sfdx-project.json` bumped to `3.51.0.NEXT`, ancestor `3.50.0`, with a consumer-facing `versionDescription`.

## Validation

Prompt text only — no Apex, no schema, no runtime behavior change. Release checks run separately before the package build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)