### PR TITLE
v3.53.0 — Excel saves as .xlsx + output format honored from Flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## v3.53.0 — Excel files save as .xlsx + output format honored from Flow
+
+Two document-generation fixes, both surfaced by a customer generating documents
+from a Flow using the **JSON Data** input. Neither is specific to JSON — JSON
+data is simply the only input that is Flow-only, so it was the first path where
+both bugs were visible at once.
+
+**No action required.** No configuration changes, no template changes.
+
+### Fixed — Excel templates generated a file named `.docx`
+
+An Excel template generated anywhere outside the runner UI — the Flow action,
+the save-to-record queueable, bulk generation — produced a valid workbook saved
+under a `.docx` file name, which Word and Excel both refuse to open.
+
+`DocGenService.saveFile` chose the extension from the template type but only
+knew about PowerPoint: everything else fell through to `.docx`. The runner never
+showed the bug because the LWC assembles Office documents in the browser and
+picks its own extension (`docGenRunner.js` already had the full mapping).
+
+Excel now maps to `.xlsx` at both server-side save sites.
+
+### Fixed — a Word template set to PDF still produced a .docx from Flow
+
+A template whose Output Format read **PDF** generated a PDF from the runner but a
+`.docx` from a Flow — same template, same record, two different formats.
+
+The two paths were reading different fields. The runner reads `Output_Format__c`
+off the **template**; every server-side merge reads the **active version
+snapshot** first and only falls back to the template when the snapshot is null
+(the v1.97 change that made a version a true render snapshot). Saving the
+template's details did not carry the new output format onto that snapshot, so a
+template created as Native and later switched to PDF kept answering "Native"
+everywhere except the runner.
+
+Saving a template's details now re-points the active version's output format at
+the saved value. The remaining snapshot fields (page setup, header/footer HTML,
+title format) stay frozen to the version by design.
+
+Existing templates in the divergent state correct themselves the first time the
+template is saved — open it in Template Manager and click **Save**. Generating a
+new version has always fixed it too, because a new version snapshots the current
+value.
+
 ## v3.52.0 — Runner on any page + Save & Download toggle
 
 `04tVx000000zz6bIAA` (build 3.52.0-1, promoted 2026-08-03, ancestor 3.51.0). Build

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -2796,6 +2796,23 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             /* code-analyzer-suppress ApexFlsViolation */
             Database.update(template, AccessLevel.SYSTEM_MODE);
 
+            // 1b. Keep the active version's Output_Format__c in step with the
+            // template on a details-only save.
+            //
+            // The runner LWC reads Output_Format__c off the TEMPLATE record, but
+            // every server-side merge reads the ACTIVE VERSION snapshot first
+            // (generateDocumentData / generateDocumentDataFromCache) and only falls
+            // back to the template when the snapshot is null. A details-only save
+            // (createVersion = false) updated the template and left the snapshot
+            // alone, so the same template answered "PDF" in the runner and "Native"
+            // in the Flow action — a Word→PDF template silently produced a .docx
+            // from Flow. The rest of the v1.97 snapshot fields stay frozen by
+            // design; output format is the one the UI presents as a live
+            // template-level setting, so it has to track.
+            if (createVersion != true && fields.containsKey('Output_Format__c')) {
+                syncActiveVersionOutputFormat(templateId, (String) fields.get('Output_Format__c'));
+            }
+
             // 2. Create Version if requested
             if (createVersion == true) {
                 // Deactivate current active versions. We pull Content_Version_Id__c,
@@ -3065,6 +3082,38 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         /* code-analyzer-suppress ApexFlsViolation */
         Database.insert(cdl, AccessLevel.SYSTEM_MODE);
         return cv.Id;
+    }
+
+    /**
+     * Points the active version snapshot's Output_Format__c at the value just
+     * saved on the template, so the server-side merge (Flow action, queueables,
+     * bulk) resolves the same format the runner UI shows. No-op when there is no
+     * active version or the snapshot already agrees.
+     */
+    private static void syncActiveVersionOutputFormat(Id templateId, String outputFormat) {
+        if (templateId == null || String.isBlank(outputFormat)) {
+            return;
+        }
+        DocGenFlsGuard.assertAccessible(
+            DocGen_Template_Version__c.sObjectType,
+            new Set<String>{ 'Template__c', 'Is_Active__c', 'Output_Format__c' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Template_Version__c> activeVersions = [
+            SELECT Id, Output_Format__c
+            FROM DocGen_Template_Version__c
+            WHERE Template__c = :templateId AND Is_Active__c = TRUE
+            WITH SYSTEM_MODE
+            ORDER BY CreatedDate DESC, Id DESC
+            LIMIT 1
+        ];
+        if (activeVersions.isEmpty() || activeVersions[0].Output_Format__c == outputFormat) {
+            return;
+        }
+        activeVersions[0].Output_Format__c = outputFormat;
+        DocGenFlsGuard.assertUpdateable(activeVersions, new Set<String>{ 'Output_Format__c' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        Database.update(activeVersions, AccessLevel.SYSTEM_MODE);
     }
 
     private static void deleteExistingPdfAcroFormSnapshots(String snapshotTitle) {

--- a/force-app/main/default/classes/DocGenControllerTests.cls
+++ b/force-app/main/default/classes/DocGenControllerTests.cls
@@ -289,6 +289,62 @@ private class DocGenControllerTests {
         }
     }
 
+    // saveTemplate — a details-only save must carry Output_Format__c onto the
+    // active version snapshot.
+    //
+    // The runner LWC reads Output_Format__c off the TEMPLATE; every server-side
+    // merge reads the ACTIVE VERSION snapshot first and only falls back to the
+    // template when the snapshot is null. Leaving the snapshot behind on a
+    // details-only save let one template answer "PDF" in the runner and "Native"
+    // in the Flow action — a Word→PDF template silently emitting .docx from Flow.
+    @IsTest
+    static void testSaveTemplateSyncsOutputFormatOntoActiveVersion() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            TestDataFactory.attachRealDocxToTestTemplate();
+            DocGen_Template__c tpl = TestDataFactory.getTestTemplate();
+            DocGen_Template_Version__c ver = TestDataFactory.getTestTemplateVersion();
+            ver.Output_Format__c = 'Native';
+            Database.update(ver, AccessLevel.SYSTEM_MODE);
+
+            Map<String, Object> fields = new Map<String, Object>{
+                'Id' => tpl.Id,
+                'Name' => tpl.Name,
+                'Type__c' => 'Word',
+                'Base_Object_API__c' => 'Account',
+                'Query_Config__c' => 'Name',
+                'Output_Format__c' => 'PDF'
+            };
+
+            Test.startTest();
+            DocGenController.saveTemplate(fields, false, null); // createVersion = false
+            Test.stopTest();
+
+            DocGen_Template_Version__c after = [
+                SELECT Output_Format__c
+                FROM DocGen_Template_Version__c
+                WHERE Id = :ver.Id
+                LIMIT 1
+            ];
+            System.assertEquals(
+                'PDF',
+                after.Output_Format__c,
+                'A details-only save must re-point the active version snapshot at the saved output format'
+            );
+
+            // And the envelope every server-side merge reads now agrees.
+            Map<String, Object> envelope = DocGenController.generateDocumentDataFromCache(
+                tpl.Id,
+                new Map<String, Object>{ 'Name' => 'Acme' }
+            );
+            System.assertEquals(
+                'PDF',
+                (String) envelope.get('outputFormat'),
+                'Server-side merge must resolve the same format the runner shows'
+            );
+        }
+    }
+
     // -----------------------------------------------------------------------
     // {#GroupBy <Relationship> by <Field>} — Conga-style table grouping: one
     // block per distinct field value, first-seen order, per-group members +

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -282,6 +282,131 @@ private class DocGenMiscTests {
         System.assertNotEquals(null, responses[0].contentVersionId);
     }
 
+    // ─── Excel output must be saved as .xlsx, not .docx ─────────────────────
+    //
+    // saveFile() named every non-PowerPoint result ".docx", so a server-side
+    // Excel render (Flow action / save-to-record queueable / bulk) produced a
+    // valid workbook that no reader would open. The runner never showed this —
+    // it assembles Office files client-side and picks its own extension.
+    @IsTest
+    static void testFlowAction_excelTemplateSavesAsXlsx() {
+        Account acc = TestDataFactory.getTestAccount();
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'Excel JSON Template',
+            Base_Object_API__c = 'FlowJsonData',
+            Type__c = 'Excel',
+            Output_Format__c = 'Native',
+            Query_Config__c = '{"v":4,"source":"flowJsonData"}'
+        );
+        Database.insert(tpl, AccessLevel.SYSTEM_MODE);
+
+        ContentVersion cv = new ContentVersion(
+            Title = 'Excel JSON Template',
+            PathOnClient = 'book.xlsx',
+            VersionData = buildMinimalXlsx(),
+            FirstPublishLocationId = tpl.Id
+        );
+        Database.insert(cv, AccessLevel.SYSTEM_MODE);
+
+        DocGen_Template_Version__c ver = new DocGen_Template_Version__c(
+            Template__c = tpl.Id,
+            Is_Active__c = true,
+            Type__c = 'Excel',
+            Base_Object_API__c = 'FlowJsonData',
+            Query_Config__c = '{"v":4,"source":"flowJsonData"}',
+            Content_Version_Id__c = [SELECT Id FROM ContentVersion WHERE Id = :cv.Id LIMIT 1]
+            .Id
+        );
+        Database.insert(ver, AccessLevel.SYSTEM_MODE);
+
+        DocGenFlowAction.Request req = new DocGenFlowAction.Request();
+        req.templateId = tpl.Id;
+        req.recordId = acc.Id;
+        req.saveToRecord = true;
+        req.jsonData = '{"Name":"Acme"}';
+
+        Test.startTest();
+        List<DocGenFlowAction.Response> responses = DocGenFlowAction.generateDocument(
+            new List<DocGenFlowAction.Request>{ req }
+        );
+        Test.stopTest();
+
+        System.assertEquals(true, responses[0].success, 'Excel render should succeed: ' + responses[0].errorMessage);
+        ContentVersion saved = [
+            SELECT PathOnClient
+            FROM ContentVersion
+            WHERE Id = :responses[0].contentVersionId
+            LIMIT 1
+        ];
+        System.assert(
+            saved.PathOnClient.endsWith('.xlsx'),
+            'Excel template must save as .xlsx, got: ' + saved.PathOnClient
+        );
+    }
+
+    /** Smallest workbook the merge pipeline will accept. */
+    private static Blob buildMinimalXlsx() {
+        Compression.ZipWriter zw = new Compression.ZipWriter();
+        zw.addEntry(
+            '[Content_Types].xml',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+                    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+                    '<Default Extension="xml" ContentType="application/xml"/>' +
+                    '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>' +
+                    '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>' +
+                    '<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>' +
+                    '</Types>'
+            )
+        );
+        zw.addEntry(
+            '_rels/.rels',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+                    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>' +
+                    '</Relationships>'
+            )
+        );
+        zw.addEntry(
+            'xl/_rels/workbook.xml.rels',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+                    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>' +
+                    '<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>' +
+                    '</Relationships>'
+            )
+        );
+        zw.addEntry(
+            'xl/workbook.xml',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" ' +
+                    'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
+                    '<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>'
+            )
+        );
+        zw.addEntry(
+            'xl/sharedStrings.xml',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="1" uniqueCount="1">' +
+                    '<si><t>Hello {Name}</t></si></sst>'
+            )
+        );
+        zw.addEntry(
+            'xl/worksheets/sheet1.xml',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>' +
+                    '<row r="1"><c r="A1" t="s"><v>0</v></c></row></sheetData></worksheet>'
+            )
+        );
+        return zw.getArchive();
+    }
+
     @IsTest
     static void testFlowAction_templateApiName_unknownKeyFailsClearly() {
         DocGenFlowAction.Request req = new DocGenFlowAction.Request();

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -8656,9 +8656,21 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         return null;
     }
 
+    /**
+     * Names the saved file after the TEMPLATE type, not the merge path. Excel was
+     * missing from this map, so a server-side XLSX generation (Flow action, save-
+     * to-record queueable, bulk) wrote a valid workbook under a .docx name and
+     * every reader rejected it. The runner never showed this because the LWC
+     * assembles Office files client-side and picks its own extension.
+     */
     private static Id saveFile(Blob fileBlob, String title, Id recordId, String format, String type) {
         String baseName = title != null ? title : 'Generated_Document';
-        String ext = (type == 'PowerPoint') ? '.pptx' : '.docx';
+        String ext = '.docx';
+        if (type == 'PowerPoint') {
+            ext = '.pptx';
+        } else if (type == 'Excel') {
+            ext = '.xlsx';
+        }
         return saveContentVersion(fileBlob, baseName, baseName + ext, recordId);
     }
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.52.0 — Runner on any page + Save & Download toggle",
-      "versionNumber": "3.52.0.NEXT",
+      "versionName": "v3.53.0 — Excel files save as .xlsx + output format honored from Flow",
+      "versionNumber": "3.53.0.NEXT",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "postInstallScript": "DocGenEmailTemplateInstall",
       "package": "Portwood",
-      "ancestorVersion": "3.51.0",
+      "ancestorVersion": "3.52.0",
       "versionDescription": "Portwood turns any Salesforce record into a finished document — quotes, invoices, contracts, certificates, letters and reports — as PDF, Word, Excel or PowerPoint. Build templates in a drag-and-drop visual editor, upload a Word file you already have, or describe what you want and let the built-in AI write it for you. Templates pull fields from the record and its related lists, and handle repeating tables, running totals, conditional sections, charts, images, watermarks and page setup. Users create documents in one click from a record page, a Lightning app page, a screen flow, or in bulk from a list view, then download them or save them straight back to the record. Send documents out for e-signature with automatic reminders, a full audit trail and a certificate of completion. Available in 10 languages. 100% native Salesforce — no external services or callouts. Free for all users."
     },
     {


### PR DESCRIPTION
Two document-generation fixes reported by a customer generating documents from a Flow with **JSON Data**. Neither is JSON-specific — JSON data is simply the only Flow-only input, so it was the first path where both bugs were visible at once.

## Excel templates saved as `.docx`

`DocGenService.saveFile` picked the extension from the template type but only knew about PowerPoint; everything else fell through to `.docx`. A valid workbook came out under a name neither Word nor Excel will open.

The runner never showed this — the LWC assembles Office files in the browser and picks its own extension (`docGenRunner.js` already had the full mapping). Only server-side generation hits `saveFile`: the Flow action, the save-to-record queueable, bulk.

Excel now maps to `.xlsx`, covering both server-side save sites.

## A Word template set to PDF still produced `.docx` from Flow

Same template, same record, two different formats depending on the entry point — because the two paths read different fields:

- runner → `DocGen_Template__c.Output_Format__c`
- every server-side merge → the **active version snapshot's** `Output_Format__c`, falling back to the template only when null (the v1.97 change that made a version a true render snapshot)

A details-only save (`createVersion: false`) updated the template and left the snapshot behind, so a template created as Native and later switched to PDF kept answering "Native" everywhere except the runner.

Saving a template's details now re-points the active version's output format at the saved value. The remaining snapshot fields (page setup, header/footer HTML, title format) stay frozen to the version by design.

Templates already in the divergent state correct themselves the first time the template is saved.

## Validation

- e2e-01..08 + 07-syntax1..5 — all `PASS: N  FAIL: 0`
- `sf code-analyzer` — 0 violations, full workspace and both changed classes
- New regression tests: `DocGenMiscTests.testFlowAction_excelTemplateSavesAsXlsx`, `DocGenControllerTests.testSaveTemplateSyncsOutputFormatOntoActiveVersion`
- Both fixes reproduced before the change and confirmed after, end-to-end through `DocGenFlowAction` in a no-namespace scratch org, then click-verified in the admin UI + Flow Builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)