### PR TITLE
feat: macro-enabled Excel (.xlsm) template support

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -100,7 +100,7 @@ A native Salesforce document generation engine that turns merge-tag templates in
 - **Word (`.docx`)** templates — the most common authoring tool, fully supported.
 - **HTML / Google Docs / Notion / ChatGPT** — any HTML source. Fully supported.
 - **PowerPoint (`.pptx`)** for slide decks. _Alpha — see note below._
-- **Excel (`.xlsx`)** for spreadsheets. _Alpha — see note below._
+- **Excel (`.xlsx` / `.xlsm`)** for spreadsheets, including macro-enabled workbooks. _Alpha — see note below._
 
 **Render to:**
 
@@ -228,7 +228,7 @@ Open the Portwood app → **My Templates** → the **Create New** tab. The wizar
 - **Start from a Design** (recommended) — pick a professional starter (Record Report, Invoice / Line Items, Business Letter, signature-ready Agreement, landscape Certificate / Award). Your object's real merge fields are injected automatically and the template renders on the first click. Starters that need a specific page setup bring it along — the Certificate creates a landscape Letter page with 0.5" margins without you touching anything.
 - **Generate with AI** — a six-step flow, top to bottom on one page: build your query in the full visual builder (fields, parent lookups, related lists with filters), pick your images, describe the document in your own words, copy the assembled prompt (it carries Portwood's full tag syntax and the PDF engine's CSS rules), paste it into Claude / ChatGPT / Copilot, then paste the returned HTML back. The prompt updates live as you build. The result opens in the designer.
 - **Start From Scratch** — a blank page in the visual designer.
-- **I Have an Existing File** — upload **Word** (`.docx`), **HTML** (`.html` / `.htm` / `.zip`), fillable **PDF** (_testing_), **PowerPoint** (`.pptx`, _alpha_), or **Excel** (`.xlsx`, _alpha_) containing `{FieldName}` merge tags.
+- **I Have an Existing File** — upload **Word** (`.docx`), **HTML** (`.html` / `.htm` / `.zip`), fillable **PDF** (_testing_), **PowerPoint** (`.pptx`, _alpha_), or **Excel** (`.xlsx` / `.xlsm`, _alpha_) containing `{FieldName}` merge tags.
 
 Every path also asks for:
 
@@ -244,7 +244,7 @@ Every path also asks for:
 - HTML (`.html` / `.htm` / `.zip`) template → output PDF only (see [§5.7](#57-html-templates-google-docs-notion-any-html-source))
 - PDF (`.pdf`) fillable template → output PDF only (PDF-to-PDF / AcroForm filling is currently in testing)
 - PowerPoint (`.pptx`) template → output PPTX only (PowerPoint→PDF is not supported by the Salesforce platform)
-- Excel (`.xlsx`) template → output XLSX only
+- Excel (`.xlsx` / `.xlsm`) template → output XLSX only (macro-enabled templates output `.xlsm`)
 
 > **One template → one output format.** Templates render in whatever format
 > they were saved with — there's no runtime "Output As" picker. To offer the
@@ -3482,6 +3482,12 @@ Excel (`.xlsx`) templates handle plain field tags, parent lookups, child-record 
 With 3 contacts, rows 2–4 each carry one contact's `FirstName` / `LastName` / `Email` across columns A–C. Keep the loop as the only tagged region in its row — a second loop in the same row falls back to in-cell repetition. If the relationship returns no records, the row is removed.
 
 Not yet supported in Excel output: **images** (`{%…}` tags are removed cleanly), **charts** (`{Chart:…}` renders a text placeholder), **shared assets** (tag removed), and **rich-text fields** (may carry Word-style formatting artifacts). Use Word or HTML templates when you need those.
+
+**Macro-enabled workbooks (`.xlsm`).** Upload a `.xlsm` template and Portwood detects it automatically — no extra configuration. The generated file downloads (and saves to the record) as `.xlsm` with the correct MIME type, and the VBA project, form controls, and VML drawings pass through byte-identical. Notes:
+
+- **Excel blocks macros in downloaded files by default** (Mark of the Web, Microsoft policy since 2022). Recipients must unblock the file (right-click → Properties → Unblock), open it from a Trusted Location, or your org can sign the VBA project. This is a consumer-side Excel setting, not something Portwood can bypass.
+- Macros that reference their workbook by a **hard-coded filename** (`Workbooks("MyTemplate.xlsm")`) fail with "Subscript out of range" after generation, because the generated copy has a different name. Use `ThisWorkbook` instead — it always refers to the workbook the macro lives in.
+- VBA that reads **cell values** is unaffected by the merge. VBA that parses `sharedStrings.xml` directly would break (the merge inlines shared strings), but that is considered pathological.
 
 ---
 

--- a/force-app/main/default/classes/DocGenButtonController.cls
+++ b/force-app/main/default/classes/DocGenButtonController.cls
@@ -412,7 +412,8 @@ public with sharing class DocGenButtonController {
             'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
             'doc' => 'application/msword',
             'pptx' => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-            'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+            'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'xlsm' => 'application/vnd.ms-excel.sheet.macroEnabled.12'
         };
         return m.containsKey(e) ? m.get(e) : 'application/octet-stream';
     }

--- a/force-app/main/default/classes/DocGenButtonControllerTest.cls
+++ b/force-app/main/default/classes/DocGenButtonControllerTest.cls
@@ -30,6 +30,25 @@ private class DocGenButtonControllerTest {
         }
     }
 
+    /** Mock that saves a macro-enabled workbook, exercising the xlsm MIME branch. */
+    private class MockXlsmGenerator implements DocGenButtonController.Generator {
+        public DocGenButtonController.GenResult generate(DocGenButtonController.GenRequest req) {
+            ContentVersion cv = new ContentVersion(
+                Title = 'Mock Workbook',
+                PathOnClient = 'Mock Workbook.xlsm',
+                VersionData = Blob.valueOf('PK mock xlsm content')
+            );
+            insert cv;
+            cv = [SELECT Id, ContentDocumentId FROM ContentVersion WHERE Id = :cv.Id LIMIT 1];
+
+            DocGenButtonController.GenResult r = new DocGenButtonController.GenResult();
+            r.success = true;
+            r.contentVersionId = cv.Id;
+            r.contentDocumentId = cv.ContentDocumentId;
+            return r;
+        }
+    }
+
     /** Mock that reports a failure (e.g., template locked, merge error). */
     private class FailingGenerator implements DocGenButtonController.Generator {
         public DocGenButtonController.GenResult generate(DocGenButtonController.GenRequest req) {
@@ -92,6 +111,26 @@ private class DocGenButtonControllerTest {
         System.assertNotEquals(null, dto.downloadUrl, 'A servlet download URL is always provided');
         System.assertEquals('application/pdf', dto.mimeType, 'PDF mime expected');
         System.assert(dto.fileName.endsWithIgnoreCase('.pdf'), 'Filename should carry extension');
+    }
+
+    @IsTest
+    static void generate_xlsmFile_returnsMacroEnabledMime() {
+        DocGenButtonController.generator = new MockXlsmGenerator();
+        DocGenButtonController.configOverride = new List<DocGen_Button__mdt>{
+            cfg('WO_XLSM', OBJ, UserInfo.getUserId(), true)
+        };
+
+        Test.startTest();
+        DocGenButtonController.GenerateResultDTO dto = DocGenButtonController.generate(UserInfo.getUserId(), 'WO_XLSM');
+        Test.stopTest();
+
+        System.assertEquals(true, dto.success, 'Expected success');
+        System.assertEquals(
+            'application/vnd.ms-excel.sheet.macroEnabled.12',
+            dto.mimeType,
+            'xlsm must map to the macro-enabled Excel MIME, not octet-stream'
+        );
+        System.assert(dto.fileName.endsWithIgnoreCase('.xlsm'), 'Filename should carry the xlsm extension');
     }
 
     @IsTest

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -561,7 +561,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
      * by URL, then assembles the final DOCX — no server-side ZIP, zero heap for large docs.
      * @param templateId The Portwood template record ID
      * @param recordId The source record ID
-     * @return Map containing allXmlParts, imageBase64Map, imageCvIdMap, title, and templateType
+     * @return Map containing allXmlParts, imageBase64Map, imageCvIdMap, title, templateType, and isMacroEnabled
      */
     @AuraEnabled
     public static Map<String, Object> generateDocumentParts(

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -10802,4 +10802,241 @@ private class DocGenMiscTests {
         );
         System.assert(result.contains('$100.00'), 'Rejoined tag resolves with its format suffix: ' + result);
     }
+
+    // =========================================================================
+    // Macro-enabled Excel (.xlsm) — generateDocumentParts flag + binary routing
+    // =========================================================================
+
+    /**
+     * Minimal workbook for the xlsm tests. With macroEnabled=true the content types
+     * declare the macro-enabled workbook and vbaProjectBin ships as xl/vbaProject.bin —
+     * the two things that distinguish an .xlsm from an .xlsx. extraBinPath/extraBinBytes
+     * add an arbitrary .bin part (e.g. printerSettings) for routing tests.
+     */
+    private static Blob buildTestWorkbook(
+        Boolean macroEnabled,
+        Blob vbaProjectBin,
+        String extraBinPath,
+        Blob extraBinBytes
+    ) {
+        String workbookContentType = macroEnabled
+            ? 'application/vnd.ms-excel.sheet.macroEnabled.main+xml'
+            : 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml';
+        Compression.ZipWriter zw = new Compression.ZipWriter();
+        zw.addEntry(
+            '[Content_Types].xml',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+                    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+                    '<Default Extension="xml" ContentType="application/xml"/>' +
+                    (macroEnabled
+                        ? '<Default Extension="bin" ContentType="application/vnd.ms-office.vbaProject"/>'
+                        : '') +
+                    (extraBinPath != null && !macroEnabled
+                        ? '<Default Extension="bin" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.printerSettings"/>'
+                        : '') +
+                    '<Override PartName="/xl/workbook.xml" ContentType="' +
+                    workbookContentType +
+                    '"/>' +
+                    '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>' +
+                    '<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>' +
+                    '</Types>'
+            )
+        );
+        zw.addEntry(
+            '_rels/.rels',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+                    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>' +
+                    '</Relationships>'
+            )
+        );
+        zw.addEntry(
+            'xl/_rels/workbook.xml.rels',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+                    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>' +
+                    '<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>' +
+                    (macroEnabled
+                        ? '<Relationship Id="rId3" Type="http://schemas.microsoft.com/office/2006/relationships/vbaProject" Target="vbaProject.bin"/>'
+                        : '') +
+                    '</Relationships>'
+            )
+        );
+        zw.addEntry(
+            'xl/workbook.xml',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" ' +
+                    'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
+                    '<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>'
+            )
+        );
+        zw.addEntry(
+            'xl/sharedStrings.xml',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="1" uniqueCount="1">' +
+                    '<si><t>Hello {Name}</t></si></sst>'
+            )
+        );
+        zw.addEntry(
+            'xl/worksheets/sheet1.xml',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>' +
+                    '<row r="1"><c r="A1" t="s"><v>0</v></c></row></sheetData></worksheet>'
+            )
+        );
+        if (macroEnabled && vbaProjectBin != null) {
+            zw.addEntry('xl/vbaProject.bin', vbaProjectBin);
+        }
+        if (extraBinPath != null && extraBinBytes != null) {
+            zw.addEntry(extraBinPath, extraBinBytes);
+        }
+        return zw.getArchive();
+    }
+
+    /** Attaches a workbook to the shared test template as its template file. */
+    private static void linkWorkbookToTemplate(Id tplId, String pathOnClient, Blob archive) {
+        ContentVersion cv = new ContentVersion(
+            Title = pathOnClient.substringBeforeLast('.'),
+            PathOnClient = pathOnClient,
+            VersionData = archive
+        );
+        insert cv;
+        Id conDocId = [SELECT ContentDocumentId FROM ContentVersion WHERE Id = :cv.Id].ContentDocumentId;
+        insert new ContentDocumentLink(LinkedEntityId = tplId, ContentDocumentId = conDocId, ShareType = 'V');
+    }
+
+    @IsTest
+    static void testGenerateDocumentPartsXlsmSetsMacroFlagAndShipsVbaIntact() {
+        DocGen_Template__c tpl = TestDataFactory.getTestTemplate();
+        tpl.Type__c = 'Excel';
+        tpl.Query_Config__c = 'Name';
+        Database.update(tpl, AccessLevel.SYSTEM_MODE);
+
+        // Deliberately NOT valid UTF-8 (0x80, 0xFF bytes) so a string round-trip
+        // corruption could not slip through the byte-identity assertion below.
+        Blob vbaBytes = EncodingUtil.base64Decode('AAECgP8AVkJB');
+        linkWorkbookToTemplate(tpl.Id, 'MacroBook.xlsm', buildTestWorkbook(true, vbaBytes, null, null));
+
+        Account acc = TestDataFactory.getTestAccount();
+
+        Test.startTest();
+        Map<String, Object> result = DocGenService.generateDocumentParts(tpl.Id, acc.Id);
+        Test.stopTest();
+
+        System.assertEquals(true, result.get('isMacroEnabled'), 'macroEnabled workbook content type must set the flag');
+        Map<String, String> binaryParts = (Map<String, String>) result.get('imageBase64Map');
+        System.assert(
+            binaryParts.containsKey('xl/vbaProject.bin'),
+            'VBA project must ship in the binary map, got: ' + binaryParts.keySet()
+        );
+        System.assertEquals(
+            EncodingUtil.base64Encode(vbaBytes),
+            binaryParts.get('xl/vbaProject.bin'),
+            'VBA project bytes must round-trip byte-identical'
+        );
+        Map<String, String> xmlParts = (Map<String, String>) result.get('allXmlParts');
+        System.assert(!xmlParts.containsKey('xl/vbaProject.bin'), 'VBA project must never be treated as XML text');
+    }
+
+    @IsTest
+    static void testGenerateDocumentPartsXlsxNotMacroAndBinRoutesDeterministically() {
+        DocGen_Template__c tpl = TestDataFactory.getTestTemplate();
+        tpl.Type__c = 'Excel';
+        tpl.Query_Config__c = 'Name';
+        Database.update(tpl, AccessLevel.SYSTEM_MODE);
+
+        // A .bin whose bytes ARE valid UTF-8 — the old detect-by-trying split would
+        // have survived .toString() and shipped it re-encoded through the XML map.
+        Blob asciiBin = Blob.valueOf('plain ASCII bytes that decode fine as UTF-8');
+        linkWorkbookToTemplate(
+            tpl.Id,
+            'PlainBook.xlsx',
+            buildTestWorkbook(false, null, 'xl/printerSettings/printerSettings1.bin', asciiBin)
+        );
+
+        Account acc = TestDataFactory.getTestAccount();
+
+        Test.startTest();
+        Map<String, Object> result = DocGenService.generateDocumentParts(tpl.Id, acc.Id);
+        Test.stopTest();
+
+        System.assertEquals(false, result.get('isMacroEnabled'), 'Plain .xlsx must not set the macro flag');
+        Map<String, String> binaryParts = (Map<String, String>) result.get('imageBase64Map');
+        System.assertEquals(
+            EncodingUtil.base64Encode(asciiBin),
+            binaryParts.get('xl/printerSettings/printerSettings1.bin'),
+            'A .bin part must route to the binary map even when its bytes are valid UTF-8'
+        );
+        Map<String, String> xmlParts = (Map<String, String>) result.get('allXmlParts');
+        System.assert(
+            !xmlParts.containsKey('xl/printerSettings/printerSettings1.bin'),
+            '.bin parts must never land in the XML map'
+        );
+    }
+
+    // Server-side render path (Flow action / save-to-record / bulk) must name a
+    // macro-enabled workbook .xlsm — Excel refuses to load VBA from an .xlsx name.
+    @IsTest
+    static void testFlowAction_xlsmTemplateSavesAsXlsm() {
+        Account acc = TestDataFactory.getTestAccount();
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'Xlsm JSON Template',
+            Base_Object_API__c = 'FlowJsonData',
+            Type__c = 'Excel',
+            Output_Format__c = 'Native',
+            Query_Config__c = '{"v":4,"source":"flowJsonData"}'
+        );
+        Database.insert(tpl, AccessLevel.SYSTEM_MODE);
+
+        Blob vbaBytes = EncodingUtil.base64Decode('AAECgP8AVkJB');
+        ContentVersion cv = new ContentVersion(
+            Title = 'Xlsm JSON Template',
+            PathOnClient = 'book.xlsm',
+            VersionData = buildTestWorkbook(true, vbaBytes, null, null),
+            FirstPublishLocationId = tpl.Id
+        );
+        Database.insert(cv, AccessLevel.SYSTEM_MODE);
+
+        DocGen_Template_Version__c ver = new DocGen_Template_Version__c(
+            Template__c = tpl.Id,
+            Is_Active__c = true,
+            Type__c = 'Excel',
+            Base_Object_API__c = 'FlowJsonData',
+            Query_Config__c = '{"v":4,"source":"flowJsonData"}',
+            Content_Version_Id__c = [SELECT Id FROM ContentVersion WHERE Id = :cv.Id LIMIT 1]
+            .Id
+        );
+        Database.insert(ver, AccessLevel.SYSTEM_MODE);
+
+        DocGenFlowAction.Request req = new DocGenFlowAction.Request();
+        req.templateId = tpl.Id;
+        req.recordId = acc.Id;
+        req.saveToRecord = true;
+        req.jsonData = '{"Name":"Acme"}';
+
+        Test.startTest();
+        List<DocGenFlowAction.Response> responses = DocGenFlowAction.generateDocument(
+            new List<DocGenFlowAction.Request>{ req }
+        );
+        Test.stopTest();
+
+        System.assertEquals(true, responses[0].success, 'Xlsm render should succeed: ' + responses[0].errorMessage);
+        ContentVersion saved = [
+            SELECT PathOnClient
+            FROM ContentVersion
+            WHERE Id = :responses[0].contentVersionId
+            LIMIT 1
+        ];
+        System.assert(
+            saved.PathOnClient.endsWith('.xlsm'),
+            'Macro-enabled template must save as .xlsm, got: ' + saved.PathOnClient
+        );
+    }
 }

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -1333,7 +1333,7 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
      * images by URL, then assembles the final DOCX client-side (zero heap for ZIP).
      * @param templateId The DocGen_Template__c record ID
      * @param recordId The source record ID to merge data from
-     * @return Map with keys: allXmlParts, imageBase64Map, imageCvIdMap, title, templateType
+     * @return Map with keys: allXmlParts, imageBase64Map, imageCvIdMap, title, templateType, isMacroEnabled
      */
     public static Map<String, Object> generateDocumentParts(Id templateId, Id recordId) {
         // Use PDF output format to skip image blob loading during merge.
@@ -1373,6 +1373,14 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             if (path.startsWith(mr.mediaPath)) {
                 continue; // handled below in the media base64 loop
             }
+            // Known-binary parts (xl/vbaProject.bin, printerSettings*.bin) go straight
+            // to base64 — the detect-by-trying split below is probabilistic, and a
+            // binary whose bytes happen to decode as valid UTF-8 would survive
+            // .toString() and ship re-encoded (corrupt).
+            if (path.endsWithIgnoreCase('.bin')) {
+                imageBase64Map.put(path, EncodingUtil.base64Encode(entryBlob));
+                continue;
+            }
             try {
                 allXmlParts.put(path, entryBlob.toString());
             } catch (StringException stre) {
@@ -1411,13 +1419,19 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             }
         }
 
+        // Macro-enabled Excel (.xlsm) is detected at generation time from data already
+        // in memory — no template schema change. The client derives the download
+        // extension (.xlsm) and MIME from this flag.
+        Boolean isMacroEnabled = isMacroEnabledWorkbook(mr);
+
         return new Map<String, Object>{
             'allXmlParts' => allXmlParts,
             'imageBase64Map' => imageBase64Map,
             'imageCvIdMap' => imageCvIdMap,
             'imageUrlMap' => imageUrlMap,
             'title' => mr.docTitle,
-            'templateType' => mr.templateType
+            'templateType' => mr.templateType,
+            'isMacroEnabled' => isMacroEnabled
         };
     }
 
@@ -2981,7 +2995,14 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
 
         // Native DOCX/PPTX path
         Blob resultBlob = assembleZip(mr);
-        return saveFile(resultBlob, mr.docTitle, attachmentRecordId, mr.outputFormat, mr.templateType);
+        return saveFile(
+            resultBlob,
+            mr.docTitle,
+            attachmentRecordId,
+            mr.outputFormat,
+            mr.templateType,
+            isMacroEnabledWorkbook(mr)
+        );
     }
 
     /**
@@ -8657,19 +8678,47 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
     }
 
     /**
+     * True when the merged workbook is macro-enabled (.xlsm). Detected from data
+     * already in memory — the macroEnabled workbook content type is the primary
+     * signal, the vbaProject.bin part the belt-and-braces backup — so templates
+     * uploaded before this feature existed are recognized without a schema change.
+     */
+    private static Boolean isMacroEnabledWorkbook(MergeResult mr) {
+        if (mr == null) {
+            return false;
+        }
+        if (
+            mr.contentTypesXml != null &&
+            mr.contentTypesXml.contains('application/vnd.ms-excel.sheet.macroEnabled.main+xml')
+        ) {
+            return true;
+        }
+        return mr.passthroughEntries != null && mr.passthroughEntries.containsKey('xl/vbaProject.bin');
+    }
+
+    /**
      * Names the saved file after the TEMPLATE type, not the merge path. Excel was
      * missing from this map, so a server-side XLSX generation (Flow action, save-
      * to-record queueable, bulk) wrote a valid workbook under a .docx name and
      * every reader rejected it. The runner never showed this because the LWC
      * assembles Office files client-side and picks its own extension.
+     * Macro-enabled workbooks must save as .xlsm — Excel refuses to load a VBA
+     * project from a file named .xlsx.
      */
-    private static Id saveFile(Blob fileBlob, String title, Id recordId, String format, String type) {
+    private static Id saveFile(
+        Blob fileBlob,
+        String title,
+        Id recordId,
+        String format,
+        String type,
+        Boolean isMacroEnabled
+    ) {
         String baseName = title != null ? title : 'Generated_Document';
         String ext = '.docx';
         if (type == 'PowerPoint') {
             ext = '.pptx';
         } else if (type == 'Excel') {
-            ext = '.xlsx';
+            ext = isMacroEnabled == true ? '.xlsm' : '.xlsx';
         }
         return saveContentVersion(fileBlob, baseName, baseName + ext, recordId);
     }
@@ -9500,7 +9549,7 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         }
 
         Blob resultBlob = assembleZip(mr);
-        return saveFile(resultBlob, mr.docTitle, recordId, outputFormat, templateType);
+        return saveFile(resultBlob, mr.docTitle, recordId, outputFormat, templateType, isMacroEnabledWorkbook(mr));
     }
 
     /**

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -4415,7 +4415,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     get outputFormatOptions() {
         const type = this.isCreating ? this.newTemplateType : this.editTemplateType;
         if (type === 'Excel') {
-            return [{ label: 'Native (.xlsx)', value: 'Native' }];
+            return [{ label: 'Native (.xlsx / .xlsm)', value: 'Native' }];
         }
         if (type === 'HTML' || type === 'PDF') {
             return [{ label: 'PDF', value: 'PDF' }];
@@ -4429,7 +4429,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     get acceptedFormats() {
         const type = this.isCreating ? this.newTemplateType : this.editTemplateType;
         if (type === 'PowerPoint') return ['.pptx'];
-        if (type === 'Excel') return ['.xlsx'];
+        if (type === 'Excel') return ['.xlsx', '.xlsm'];
         if (type === 'HTML') return ['.html', '.htm', '.zip'];
         if (type === 'PDF') return ['.pdf'];
         return ['.docx'];
@@ -5386,7 +5386,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                     throw new Error('Document generation returned empty result.');
                 }
                 const docTitle = 'Preview_' + this.previewVersion.VersionNumber + '_' + (result.title || 'Document');
-                const ext = this._officeExtensionForType(previewTemplateType);
+                const ext = this._officeExtensionForType(previewTemplateType, result.isMacroEnabled);
                 this.downloadBase64(result.base64, docTitle + ext, 'application/octet-stream');
                 this.showToast(
                     'Success',
@@ -5714,7 +5714,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 }
 
                 const docTitle = 'Sample_' + (result.title || 'Document');
-                const ext = this._officeExtensionForType(this.editTemplateType);
+                const ext = this._officeExtensionForType(this.editTemplateType, result.isMacroEnabled);
                 this.downloadBase64(result.base64, docTitle + ext, 'application/octet-stream');
                 this.showToast('Success', 'Sample Document Downloaded', 'success');
             } else {
@@ -5929,12 +5929,14 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
     }
 
-    _officeExtensionForType(templateType) {
+    _officeExtensionForType(templateType, isMacroEnabled) {
         if (['PowerPoint', 'PPT', 'PPTX'].includes(templateType)) {
             return '.pptx';
         }
         if (templateType === 'Excel') {
-            return '.xlsx';
+            // Macro-enabled workbooks must download as .xlsm or Excel strips the
+            // VBA project. The flag comes back with the generateDocumentParts payload.
+            return isMacroEnabled ? '.xlsm' : '.xlsx';
         }
         if (templateType === 'PDF') {
             return '.pdf';
@@ -6000,7 +6002,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         const fileBytes = buildDocx(parts.allXmlParts, allImages);
         return {
             base64: this._uint8ArrayToBase64(fileBytes),
-            title: parts.title || 'Document'
+            title: parts.title || 'Document',
+            isMacroEnabled: parts.isMacroEnabled === true
         };
     }
 

--- a/force-app/main/default/lwc/docGenRunner/docGenRunner.js
+++ b/force-app/main/default/lwc/docGenRunner/docGenRunner.js
@@ -54,6 +54,16 @@ import LBL_SELECT_RECORD from '@salesforce/label/c.DocGenRunner_SelectRecord';
 import LBL_SEARCH_RECORDS from '@salesforce/label/c.DocGenRunner_SearchRecords';
 import LBL_CHOOSE_RECORD_PROMPT from '@salesforce/label/c.DocGenRunner_ChooseRecordPrompt';
 
+// Proper MIME per Office extension for browser downloads. xlsm is resolved
+// after the parts call — the server detects macro-enabled workbooks and the
+// runner upgrades xlsx → xlsm from the parts payload's isMacroEnabled flag.
+const OFFICE_MIME_BY_EXT = {
+    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    xlsm: 'application/vnd.ms-excel.sheet.macroEnabled.12'
+};
+
 export default class DocGenRunner extends NavigationMixin(LightningElement) {
     // Exposed to the template as {label.X}. Custom Labels resolve to the
     // running user's language at runtime (#95).
@@ -992,9 +1002,11 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
                 // Word DOCX / Excel XLSX / PowerPoint PPTX — client-side assembly.
                 // PowerPoint uses the same browser ZIP writer so generated PPTX
                 // packages avoid Apex Compression.ZipWriter container quirks.
+                // Excel may still upgrade to .xlsm inside _generateOfficeClientSideInner —
+                // macro-enabled detection needs the parts payload from the server.
                 const ext = isPPT ? 'pptx' : isExcel ? 'xlsx' : 'docx';
                 this.showToast('Info', 'Generating document...', 'info');
-                await this._generateOfficeClientSide(ext, 'application/octet-stream');
+                await this._generateOfficeClientSide(ext, OFFICE_MIME_BY_EXT[ext]);
             }
         } catch (e) {
             this.error = 'Generation Error: ' + (e.body ? e.body.message : e.message || 'Unknown error');
@@ -1384,6 +1396,16 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
         }
         const docTitle = parts.title || 'Document';
 
+        // Macro-enabled workbook: the server flags it from the template's content
+        // types / vbaProject.bin part. Upgrade the extension so Excel opens the
+        // file without stripping the VBA project.
+        let resolvedExtension = extension;
+        let resolvedMimeType = mimeType;
+        if (extension === 'xlsx' && parts.isMacroEnabled) {
+            resolvedExtension = 'xlsm';
+            resolvedMimeType = OFFICE_MIME_BY_EXT.xlsm;
+        }
+
         const allImages = { ...(parts.imageBase64Map || {}) };
         if (parts.imageCvIdMap) {
             const uniqueCvIds = new Map();
@@ -1443,10 +1465,10 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
         await this._deliverGeneratedDocument({
             base64: fileBase64,
             fileName: docTitle,
-            extension: extension,
-            mimeType: mimeType,
+            extension: resolvedExtension,
+            mimeType: resolvedMimeType,
             byteLength: fileBytes.length,
-            label: extension.toUpperCase()
+            label: resolvedExtension.toUpperCase()
         });
     }
 


### PR DESCRIPTION
**Summary**

Accept macro-enabled Excel (`.xlsm`) templates and emit valid `.xlsm` output — the VBA project, form controls, and VML drawings survive byte-identical, and the file downloads/saves with the correct extension and MIME type so Excel opens it without a repair prompt and without stripping macros. No schema changes: macro-enabled is detected at generation time from the template's own content types, with `xl/vbaProject.bin` presence as a fallback, so templates uploaded before this feature are recognized too.

**Changes**

- `docGenAdmin.js` — upload allowlist accepts `.xlsm`; sample/preview downloads pick `.xlsm` from the parts payload; output-format label updated.
- `DocGenService.cls` — `generateDocumentParts` returns `isMacroEnabled` (new shared `isMacroEnabledWorkbook()` helper); server-side `saveFile` names Excel output `.xlsm` when flagged (extends the v3.53.0 Flow-action save path); **hardening:** passthrough paths ending `.bin` now route deterministically to the binary map instead of the probabilistic `.toString()`-and-catch split — a binary whose bytes happen to decode as valid UTF-8 would previously ship re-encoded (corrupt).
- `docGenRunner.js` — resolves `xlsx → xlsm` after the parts call; proper per-extension MIME for all Office downloads (previously `application/octet-stream`).
- `DocGenButtonController.cls` — `mimeFor` maps `xlsm` → `application/vnd.ms-excel.sheet.macroEnabled.12` for serving previously saved documents.
- `UserGuide.md` — macro-enabled section: auto-detection, Mark-of-the-Web macro blocking, the hard-coded-filename VBA pitfall (`Workbooks("name.xlsm")` → `ThisWorkbook`), sharedStrings-inlining caveat.
Deliberately untouched: `xl/calcChain.xml` passthrough — dropping it was considered and rejected, since dangling content-type/rel references are exactly the strict-reader repair pattern the empty-sharedStrings-table workaround in `mergeTemplate` exists to avoid.

**Testing**

- [ ] Ran E2E tests (`sf apex run --target-org <org> -f scripts/e2e-test.apex`) — all passing
- [x] Ran Apex unit tests (`sf apex run test --synchronous --code-coverage`) — all passing
- [x] Tested manually in a scratch org
- [x] Added/updated E2E test assertions for new behavior

Notes on the unchecked box: the `e2e-*.apex` scripts have no Excel path today, so there was nothing for this change to break or assert there; happy to add an `e2e` Excel script as a follow-up if you'd like one. What was run instead:

- **Full Apex unit suite: 1,896/1,896 pass (100%), zero regressions** (scratch org, this branch deployed).
- **Code Analyzer** per `code-analyzer.yml` (Security + AppExchange selectors): 0 violations.
- **4 new Apex tests** (in-memory `Compression.ZipWriter` fixtures, matching existing conventions): macro flag detection + byte-identical VBA round-trip through the parts payload (fixture bytes deliberately invalid UTF-8 so corruption can't hide); plain-`.xlsx` regression + valid-UTF-8 `.bin` routing; server-side save names `.xlsm`; served-file MIME mapping.
- **Manual E2E, synthetic fixture** (attached to #278): uploaded via admin UI, generated via the runner in a sandbox — downloads as `.xlsm`, opens with no repair prompt, tags merge, defined-name formulas resolve, embedded `FixtureCheck` macro executes.
- **Manual E2E, real template**: a production Nintex-exported order checklist (190+ package parts — 137 form-control `ctrlProps`, 4 VML drawings, external links, printerSettings binaries, customXml, 416 defined names) — post-generation package structurally identical, `vbaProject.bin` byte-identical, all 75 merge tags resolved, checkboxes and drawings intact.

**Related Issues**

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)