### PR TITLE
Template upload fidelity report — HTML-first slice (#272)

### DIFF
--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -3439,10 +3439,49 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             LIMIT 1
         ];
 
+        // Fidelity report (issue #272): lint the body that was just saved and hand
+        // the findings back with the save result. Warnings only — the save has
+        // already succeeded, and a lint failure must never change that.
+        List<DocGenAiHtmlValidator.Finding> warnings = new List<DocGenAiHtmlValidator.Finding>();
+        try {
+            DocGenFlsGuard.assertAccessible(
+                DocGen_Template__c.sObjectType,
+                new Set<String>{
+                    'Base_Object_API__c',
+                    'Query_Config__c',
+                    'Page_Size__c',
+                    'Page_Orientation__c',
+                    'Page_Margins__c',
+                    'Custom_Margins__c'
+                }
+            );
+            /* code-analyzer-suppress ApexFlsViolation */
+            List<DocGen_Template__c> lintTpls = [
+                SELECT
+                    Base_Object_API__c,
+                    Query_Config__c,
+                    Page_Size__c,
+                    Page_Orientation__c,
+                    Page_Margins__c,
+                    Custom_Margins__c
+                FROM DocGen_Template__c
+                WHERE Id = :templateId
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+            if (!lintTpls.isEmpty()) {
+                warnings = DocGenTemplateLinter.lint(htmlContent, lintTpls[0]);
+            }
+        } catch (Exception lintErr) {
+            String noop = lintErr.getMessage(); // NOPMD — lint is advisory; it must never fail a save
+        }
+
         return new Map<String, Object>{
             'contentVersionId' => cv.Id,
             'contentDocumentId' => reload.ContentDocumentId,
-            'fileName' => fileName
+            'fileName' => fileName,
+            'warnings' => warnings,
+            'warningCount' => warnings.size()
         };
     }
 

--- a/force-app/main/default/classes/DocGenTemplateLinter.cls
+++ b/force-app/main/default/classes/DocGenTemplateLinter.cls
@@ -1,0 +1,602 @@
+/**
+ * Upload-time fidelity report for HTML/Canvas templates (issue #272).
+ *
+ * DocGenAiHtmlValidator is built for the Agentforce flow: it REPAIRS the HTML
+ * and reports what it changed. An author uploading or saving a body in the
+ * Designer gets no such visibility — flex silently stacks, rgba() silently
+ * renders invisible, a `table > tbody > tr > td` selector silently matches
+ * nothing, and an unbalanced {#Lines} only surfaces as a generation-time
+ * exception.
+ *
+ * This linter is the read-only counterpart. It runs the validator in report
+ * mode (the rewritten HTML is discarded, the findings kept and reworded so
+ * nothing implies the file was modified) and adds the checks the validator
+ * does not have: @page-in-HTML vs the template's page-setup fields (the
+ * #60/#71 conflict class — precedence is explicit-override per #243), tbody
+ * selectors, loop pairing per DocGenService.findBalancedEnd, merge tags split
+ * across formatting, and field references validated against the template's
+ * Base_Object_API__c describe and Query_Config__c.
+ *
+ * Every check is advisory and individually guarded: lint() never throws and
+ * never touches the author's bytes. A warning is a heads-up, not a blocker.
+ */
+public with sharing class DocGenTemplateLinter {
+    // Tags that resolve without a field on the base object. GROUPNAME only
+    // exists inside a {#GroupBy} block; skipping it globally is harmless
+    // because it never describes-validates anyway.
+    private static final Set<String> BUILTIN_TAGS = new Set<String>{
+        'TODAY',
+        'NOW',
+        'PAGENUMBER',
+        'TOTALPAGES',
+        'ROWNUMBER',
+        'GROUPNAME'
+    };
+    private static final Set<String> AGGREGATE_TAGS = new Set<String>{ 'SUM', 'COUNT', 'AVG', 'MIN', 'MAX' };
+
+    // {Field}, {Parent.Field}, {Field:format} — the GiantQueryAssembler tag shape.
+    private static final Pattern FIELD_TAG = Pattern.compile(
+        '^([A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*)(?::(.+))?$'
+    );
+
+    /**
+     * Lints an HTML/Canvas body against its template. Best-effort: returns
+     * whatever warnings completed checks produced; a failing check costs its
+     * own findings, never the whole report, and never the save.
+     */
+    public static List<DocGenAiHtmlValidator.Finding> lint(String html, DocGen_Template__c tmpl) {
+        List<DocGenAiHtmlValidator.Finding> findings = new List<DocGenAiHtmlValidator.Finding>();
+        if (String.isBlank(html)) {
+            return findings;
+        }
+        runRendererCompatibilityCheck(html, findings);
+        runPageSetupConflictCheck(html, tmpl, findings);
+        runTbodySelectorCheck(html, findings);
+        runMergeTagChecks(html, tmpl, findings);
+        return findings;
+    }
+
+    // -----------------------------------------------------------------------
+    // 1. Renderer compatibility, report mode. The validator's rule set is
+    //    MEASURED against the Flying Saucer build we ship (see its header), so
+    //    reuse it wholesale — but discard the rewritten HTML and reword every
+    //    finding so nothing tells the author their file was changed. It wasn't.
+    // -----------------------------------------------------------------------
+
+    private static void runRendererCompatibilityCheck(String html, List<DocGenAiHtmlValidator.Finding> findings) {
+        try {
+            DocGenAiHtmlValidator.Result res = DocGenAiHtmlValidator.sanitize(html);
+            for (DocGenAiHtmlValidator.Finding f : res.findings) {
+                findings.add(
+                    new DocGenAiHtmlValidator.Finding(
+                        'warning',
+                        f.rule,
+                        f.occurrences,
+                        'The PDF engine ignores this at render time — your file was not modified. ' + f.detail
+                    )
+                );
+            }
+        } catch (Exception e) {
+            String noop = e.getMessage(); // NOPMD — lint is advisory; one dead check must not sink the report
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. @page in the HTML vs page setup on the template record.
+    //
+    //    Render-time precedence (DocGenService #243): a DELIBERATE template
+    //    choice wins and the author's competing @page declaration is stripped —
+    //    Landscape, Legal, A4, or a margins preset other than Default/FromSource
+    //    can only have been picked on purpose. Letter/Portrait/Default cannot be
+    //    told apart from "never touched", so they do NOT conflict.
+    // -----------------------------------------------------------------------
+
+    private static void runPageSetupConflictCheck(
+        String html,
+        DocGen_Template__c tmpl,
+        List<DocGenAiHtmlValidator.Finding> findings
+    ) {
+        try {
+            if (tmpl == null || !html.containsIgnoreCase('@page')) {
+                return;
+            }
+            List<String> overrides = new List<String>();
+            if ('Landscape'.equalsIgnoreCase(tmpl.Page_Orientation__c)) {
+                overrides.add('Page Orientation = Landscape');
+            }
+            if ('Legal'.equalsIgnoreCase(tmpl.Page_Size__c) || 'A4'.equalsIgnoreCase(tmpl.Page_Size__c)) {
+                overrides.add('Page Size = ' + tmpl.Page_Size__c);
+            }
+            if (
+                String.isNotBlank(tmpl.Page_Margins__c) &&
+                !'Default'.equalsIgnoreCase(tmpl.Page_Margins__c) &&
+                !'FromSource'.equalsIgnoreCase(tmpl.Page_Margins__c)
+            ) {
+                overrides.add('Page Margins = ' + tmpl.Page_Margins__c);
+            }
+            if (overrides.isEmpty()) {
+                return;
+            }
+            findings.add(
+                new DocGenAiHtmlValidator.Finding(
+                    'warning',
+                    '@page conflicts with template page setup',
+                    1,
+                    'This HTML declares @page, but the template record also sets ' +
+                        String.join(overrides, ', ') +
+                        '. The template wins: at render time those declarations are stripped from your @page rule, so the page you get is not the one the CSS asks for. Remove @page from the body, or set the template fields back to their defaults.'
+                )
+            );
+        } catch (Exception e) {
+            String noop = e.getMessage(); // NOPMD — advisory
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. The tbody selector trap. The engine's HTML parser does not synthesize
+    //    a <tbody> element, so a selector written the way browsers teach it —
+    //    table > tbody > tr > td — silently matches nothing. <tbody> in the
+    //    MARKUP is fine; only selectors are the trap, so only <style> blocks
+    //    are scanned.
+    // -----------------------------------------------------------------------
+
+    private static void runTbodySelectorCheck(String html, List<DocGenAiHtmlValidator.Finding> findings) {
+        try {
+            Matcher styles = Pattern.compile('(?is)<style\\b[^>]*>(.*?)</style\\s*>').matcher(html);
+            Integer n = 0;
+            String example = null;
+            while (styles.find()) {
+                Matcher rules = Pattern.compile('([^{}]+)\\{').matcher(styles.group(1));
+                while (rules.find()) {
+                    String selector = rules.group(1).trim();
+                    if (Pattern.compile('(?i)\\btbody\\b').matcher(selector).find()) {
+                        n++;
+                        if (example == null) {
+                            example = selector;
+                        }
+                    }
+                }
+            }
+            if (n > 0) {
+                findings.add(
+                    new DocGenAiHtmlValidator.Finding(
+                        'warning',
+                        'tbody in a CSS selector',
+                        n,
+                        'The PDF engine does not match <tbody> in selectors, so "' +
+                            example +
+                            '" silently selects nothing. Target the cells directly instead, e.g. table tr td.'
+                    )
+                );
+            }
+        } catch (Exception e) {
+            String noop = e.getMessage(); // NOPMD — advisory
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. Merge-tag lint: pairing, split runs, and field resolution.
+    // -----------------------------------------------------------------------
+
+    private static void runMergeTagChecks(
+        String html,
+        DocGen_Template__c tmpl,
+        List<DocGenAiHtmlValidator.Finding> findings
+    ) {
+        try {
+            // <style>/<script> bodies carry braces that are not merge tags, and
+            // comments can carry commented-out tags. Both are stripped so the
+            // tokenizer below only sees authored tags.
+            String stripped = html.replaceAll('(?is)<(style|script)\\b[^>]*>.*?</\\1\\s*>', ' ')
+                .replaceAll('(?s)<!--.*?-->', ' ');
+
+            checkSplitRuns(stripped, findings);
+            List<MergeToken> tokens = tokenize(stripped);
+            checkLoopPairing(tokens, findings);
+            checkFieldReferences(tokens, tmpl, findings);
+        } catch (Exception e) {
+            String noop = e.getMessage(); // NOPMD — advisory
+        }
+    }
+
+    private class MergeToken {
+        String raw; // full "{...}" text
+        String content; // inner text, trimmed
+        Boolean isOpen; // {#X} / {^X}
+        Boolean isClose; // {/X}
+        String key; // balance key per DocGenService.findBalancedEnd
+    }
+
+    /** Extracts well-formed {…} candidates in document order. */
+    private static List<MergeToken> tokenize(String stripped) {
+        List<MergeToken> tokens = new List<MergeToken>();
+        Matcher m = Pattern.compile('\\{([^{}]*)\\}').matcher(stripped);
+        while (m.find()) {
+            String content = m.group(1).trim();
+            if (String.isBlank(content) || content == ':else') {
+                continue; // {:else} belongs to the enclosing block, not the balance count
+            }
+            MergeToken t = new MergeToken();
+            t.raw = m.group(0);
+            t.content = content;
+            if (content.startsWith('#') || content.startsWith('^')) {
+                t.isOpen = true;
+                t.key = balanceKey(content.substring(1).trim());
+            } else if (content.startsWith('/')) {
+                t.isClose = true;
+                t.key = content.substring(1).trim();
+            }
+            tokens.add(t);
+        }
+        return tokens;
+    }
+
+    /**
+     * The balance key DocGenService.findBalancedEnd pairs on: {#IF expr} and
+     * {#GroupBy rel by field} carry a spec but close on the bare keyword;
+     * {#ChartBucket:…} is the same shape. Everything else pairs on its own name.
+     */
+    private static String balanceKey(String openerName) {
+        String upper = openerName.toUpperCase();
+        if (upper == 'IF' || upper.startsWith('IF ')) {
+            return 'IF';
+        }
+        if (upper == 'GROUPBY' || upper.startsWith('GROUPBY ')) {
+            return 'GroupBy';
+        }
+        if (upper == 'CHARTBUCKET' || upper.startsWith('CHARTBUCKET:')) {
+            return 'ChartBucket';
+        }
+        return openerName;
+    }
+
+    /** Openers that rebind the field context — {Name} inside one is the CHILD's Name. */
+    private static Boolean isRelationshipLoop(String key) {
+        return key != 'IF' && key != 'GroupBy' && key != 'ChartBucket';
+    }
+
+    /**
+     * Stack-based pairing mirroring findBalancedEnd semantics: an opener with no
+     * matching close fails the whole merge at generation time; a stray closer is
+     * dead text today and a parse error tomorrow.
+     */
+    private static void checkLoopPairing(List<MergeToken> tokens, List<DocGenAiHtmlValidator.Finding> findings) {
+        List<MergeToken> stack = new List<MergeToken>();
+        List<String> strayClosers = new List<String>();
+        for (MergeToken t : tokens) {
+            if (t.isOpen == true) {
+                stack.add(t);
+            } else if (t.isClose == true) {
+                // Case-SENSITIVE equals, mirroring findBalancedEnd — {/lines}
+                // does not close {#Lines} at generation time either.
+                if (!stack.isEmpty() && stack[stack.size() - 1].key.equals(t.key)) {
+                    stack.remove(stack.size() - 1);
+                } else {
+                    strayClosers.add(t.raw);
+                }
+            }
+        }
+        if (!stack.isEmpty()) {
+            List<String> unclosed = new List<String>();
+            for (Integer i = 0; i < stack.size() && i < 3; i++) {
+                unclosed.add(stack[i].raw);
+            }
+            findings.add(
+                new DocGenAiHtmlValidator.Finding(
+                    'warning',
+                    'Unclosed loop tag',
+                    stack.size(),
+                    'Opened but never closed: ' +
+                        String.join(unclosed, ', ') +
+                        '. Generation fails the whole merge with "Malformed loop tag" — add the matching {/…} for each.'
+                )
+            );
+        }
+        if (!strayClosers.isEmpty()) {
+            List<String> shown = new List<String>();
+            for (Integer i = 0; i < strayClosers.size() && i < 3; i++) {
+                shown.add(strayClosers[i]);
+            }
+            findings.add(
+                new DocGenAiHtmlValidator.Finding(
+                    'warning',
+                    'Unmatched closing tag',
+                    strayClosers.size(),
+                    'Closes nothing that is open: ' +
+                        String.join(shown, ', ') +
+                        '. Check the relationship name spelling and that the {#…} opener was not lost to formatting.'
+                )
+            );
+        }
+    }
+
+    /**
+     * A merge tag broken across an HTML tag boundary — {Na<b>me}</b> — reads as
+     * one tag to a human and as two runs to the merger. Text tags are healed at
+     * merge time; chart tags fall back to literal text (#130). Either way the
+     * author should know the formatting split the tag.
+     */
+    private static void checkSplitRuns(String stripped, List<DocGenAiHtmlValidator.Finding> findings) {
+        Matcher m = Pattern.compile('\\{[^{}]*<[^>]+>[^{}]*\\}').matcher(stripped);
+        Integer n = 0;
+        String example = null;
+        while (m.find()) {
+            n++;
+            if (example == null) {
+                example = m.group(0).replaceAll('<[^>]+>', '…');
+            }
+        }
+        if (n > 0) {
+            findings.add(
+                new DocGenAiHtmlValidator.Finding(
+                    'warning',
+                    'Merge tag split by formatting',
+                    n,
+                    'A tag is broken across an HTML formatting boundary ("' +
+                        example +
+                        '"). Keep the whole tag in a single run of text — bold only part of it and the merger may not see it.'
+                )
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 4c. Field resolution. Simple {Field} / {Parent.Field} tags OUTSIDE loop
+    //     bodies are validated against the Base_Object_API__c describe (the
+    //     DocGenGiantQueryAssembler pattern); tags inside a {#Rel} loop belong
+    //     to the child object and are skipped. A described-valid field that is
+    //     absent from Query_Config__c still merges — blank — so that is a
+    //     separate, softer warning. Query Config parse failure skips silently.
+    // -----------------------------------------------------------------------
+
+    private static void checkFieldReferences(
+        List<MergeToken> tokens,
+        DocGen_Template__c tmpl,
+        List<DocGenAiHtmlValidator.Finding> findings
+    ) {
+        String baseObj = tmpl?.Base_Object_API__c;
+        if (String.isBlank(baseObj)) {
+            return; // nothing to validate against — single-object templates without a base skip silently
+        }
+        Map<String, Schema.SObjectField> fieldMap = Schema.getGlobalDescribe()
+            .get(baseObj)
+            ?.getDescribe()
+            ?.fields
+            ?.getMap();
+        if (fieldMap == null) {
+            return;
+        }
+        Set<String> relNames = relationshipNames(fieldMap);
+        Set<String> queryFields = queryConfigFields(tmpl?.Query_Config__c);
+        // Aliased loops: a V3 Query Config node can rename a relationship, and the
+        // template loops on the ALIAS. Describe alone would condemn a valid tag.
+        Set<String> loopNames = childRelationshipNames(baseObj);
+        loopNames.addAll(queryConfigRelationshipNames(tmpl?.Query_Config__c));
+
+        Set<String> unknownReported = new Set<String>();
+        Set<String> notQueriedReported = new Set<String>();
+        Set<String> loopReported = new Set<String>();
+        Integer loopDepth = 0;
+        List<MergeToken> stack = new List<MergeToken>();
+        for (MergeToken t : tokens) {
+            if (t.isOpen == true) {
+                stack.add(t);
+                if (isRelationshipLoop(t.key)) {
+                    // Only the OUTERMOST loop resolves against the base object —
+                    // a nested {#Rel} belongs to the child and is skipped.
+                    if (loopDepth == 0 && !loopNames.contains(t.key.toLowerCase()) && !loopReported.contains(t.key)) {
+                        loopReported.add(t.key);
+                        findings.add(
+                            new DocGenAiHtmlValidator.Finding(
+                                'warning',
+                                'Loop relationship not found',
+                                1,
+                                '{#' +
+                                    t.key +
+                                    '} — ' +
+                                    t.key +
+                                    ' is not a child relationship of ' +
+                                    baseObj +
+                                    ' and no Query Config node defines it. The loop will render nothing. Check the relationship name (e.g. OpportunityLineItems).'
+                            )
+                        );
+                    }
+                    loopDepth++;
+                }
+                continue;
+            }
+            if (t.isClose == true) {
+                if (!stack.isEmpty() && stack[stack.size() - 1].key.equals(t.key)) {
+                    MergeToken popped = stack.remove(stack.size() - 1);
+                    if (isRelationshipLoop(popped.key)) {
+                        loopDepth--;
+                    }
+                }
+                continue;
+            }
+            if (loopDepth > 0) {
+                continue;
+            }
+            Matcher fm = FIELD_TAG.matcher(t.content);
+            if (!fm.matches()) {
+                continue; // {%image}, {*}barcode, {@signature}, {?form} and friends — not field refs
+            }
+            String path = fm.group(1);
+            String upper = path.toUpperCase();
+            if (
+                BUILTIN_TAGS.contains(upper) ||
+                AGGREGATE_TAGS.contains(upper) ||
+                upper.startsWith('RUNNINGUSER.') ||
+                upper == 'CHART'
+            ) {
+                continue;
+            }
+            if (path.contains('.')) {
+                // Same contract as GiantQueryAssembler: the relationship name
+                // must exist on the base object; the far-side field is trusted.
+                if (relNames.contains(path.substringBefore('.').toLowerCase())) {
+                    noteNotQueried(path, queryFields, notQueriedReported, findings);
+                } else if (!unknownReported.contains(path)) {
+                    unknownReported.add(path);
+                    findings.add(
+                        new DocGenAiHtmlValidator.Finding(
+                            'warning',
+                            'Merge tag does not resolve',
+                            1,
+                            '{' +
+                                path +
+                                '} — ' +
+                                path.substringBefore('.') +
+                                ' is not a relationship on ' +
+                                baseObj +
+                                '. This tag will merge blank.'
+                        )
+                    );
+                }
+            } else if (fieldMap.containsKey(path.toLowerCase())) {
+                noteNotQueried(path, queryFields, notQueriedReported, findings);
+            } else if (!unknownReported.contains(path)) {
+                unknownReported.add(path);
+                findings.add(
+                    new DocGenAiHtmlValidator.Finding(
+                        'warning',
+                        'Merge tag does not resolve',
+                        1,
+                        '{' + path + '} does not exist on ' + baseObj + ' — it will merge blank. Check the API name.'
+                    )
+                );
+            }
+        }
+    }
+
+    /** The field is real but the template's query will not return it — so it merges blank. */
+    private static void noteNotQueried(
+        String path,
+        Set<String> queryFields,
+        Set<String> reported,
+        List<DocGenAiHtmlValidator.Finding> findings
+    ) {
+        if (queryFields == null || queryFields.contains(path.toLowerCase()) || reported.contains(path.toLowerCase())) {
+            return;
+        }
+        reported.add(path.toLowerCase());
+        findings.add(
+            new DocGenAiHtmlValidator.Finding(
+                'warning',
+                'Field not in Query Config',
+                1,
+                '{' +
+                    path +
+                    '} exists on the object but is not in this template\'s Query Config, so the merge has no value for it — it will render blank. Add it to the Query Config.'
+            )
+        );
+    }
+
+    /** Lowercased relationship names of every lookup/master-detail on the object. */
+    private static Set<String> relationshipNames(Map<String, Schema.SObjectField> fieldMap) {
+        Set<String> names = new Set<String>();
+        for (Schema.SObjectField sof : fieldMap.values()) {
+            String rel = sof.getDescribe().getRelationshipName();
+            if (rel != null) {
+                names.add(rel.toLowerCase());
+            }
+        }
+        return names;
+    }
+
+    /** Lowercased CHILD relationship names on the object — what {#Rel} loops pair with. */
+    private static Set<String> childRelationshipNames(String baseObj) {
+        Set<String> names = new Set<String>();
+        Schema.SObjectType t = Schema.getGlobalDescribe().get(baseObj);
+        if (t == null) {
+            return names;
+        }
+        for (Schema.ChildRelationship cr : t.getDescribe().getChildRelationships()) {
+            if (cr.getRelationshipName() != null) {
+                names.add(cr.getRelationshipName().toLowerCase());
+            }
+        }
+        return names;
+    }
+
+    /**
+     * Relationship names and aliases declared by a V3 JSON Query Config — a node
+     * can rename its relationship, and templates loop on the alias. Anything that
+     * is not a parseable JSON graph yields an empty set, not an error.
+     */
+    private static Set<String> queryConfigRelationshipNames(String queryConfig) {
+        Set<String> names = new Set<String>();
+        if (String.isBlank(queryConfig) || !queryConfig.trim().startsWith('{')) {
+            return names;
+        }
+        try {
+            Map<String, Object> cfg = (Map<String, Object>) JSON.deserializeUntyped(queryConfig.trim());
+            Object nodes = cfg.get('nodes');
+            if (nodes instanceof List<Object>) {
+                for (Object nodeObj : (List<Object>) nodes) {
+                    if (nodeObj instanceof Map<String, Object>) {
+                        Map<String, Object> node = (Map<String, Object>) nodeObj;
+                        for (String key : new List<String>{ 'alias', 'relationshipName' }) {
+                            Object v = node.get(key);
+                            if (v instanceof String && String.isNotBlank((String) v)) {
+                                names.add(((String) v).trim().toLowerCase());
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            String noop = e.getMessage(); // NOPMD — unparseable config just means no aliases
+        }
+        return names;
+    }
+
+    /**
+     * Lowercased field paths out of Query_Config__c, or null when it cannot be
+     * read as a field list. Two shapes exist in the wild: the V1 flat string
+     * ("Name, Industry") and the V3 JSON graph ({"nodes":[{"fields":[…]}]}).
+     * Anything else — parse failure, empty — returns null and the cross-check
+     * is skipped rather than guessed at.
+     */
+    private static Set<String> queryConfigFields(String queryConfig) {
+        if (String.isBlank(queryConfig)) {
+            return null;
+        }
+        String trimmed = queryConfig.trim();
+        Set<String> fields = new Set<String>();
+        try {
+            if (trimmed.startsWith('{')) {
+                Map<String, Object> cfg = (Map<String, Object>) JSON.deserializeUntyped(trimmed);
+                collectJsonFields(cfg.get('fields'), fields);
+                Object nodes = cfg.get('nodes');
+                if (nodes instanceof List<Object>) {
+                    for (Object nodeObj : (List<Object>) nodes) {
+                        if (nodeObj instanceof Map<String, Object>) {
+                            collectJsonFields(((Map<String, Object>) nodeObj).get('fields'), fields);
+                        }
+                    }
+                }
+            } else {
+                for (String piece : trimmed.split(',')) {
+                    if (String.isNotBlank(piece)) {
+                        fields.add(piece.trim().toLowerCase());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            return null; // unparseable config — skip the cross-check silently
+        }
+        return fields.isEmpty() ? null : fields;
+    }
+
+    private static void collectJsonFields(Object raw, Set<String> fields) {
+        if (!(raw instanceof List<Object>)) {
+            return;
+        }
+        for (Object f : (List<Object>) raw) {
+            if (f instanceof String && String.isNotBlank((String) f)) {
+                fields.add(((String) f).trim().toLowerCase());
+            }
+        }
+    }
+}

--- a/force-app/main/default/classes/DocGenTemplateLinter.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenTemplateLinter.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenTemplateLinterTest.cls
+++ b/force-app/main/default/classes/DocGenTemplateLinterTest.cls
@@ -1,0 +1,328 @@
+/**
+ * Coverage for DocGenTemplateLinter — the upload-time fidelity report (issue #272).
+ *
+ * The renderer-compatibility findings come from DocGenAiHtmlValidator's MEASURED
+ * rule set (see that class's tests for the per-rule proof); what is asserted here
+ * is the lint layer on top: findings are reworded so nothing implies the file was
+ * modified, the input bytes are never touched, and the checks the validator does
+ * not have (@page conflicts, tbody selectors, loop pairing, split runs, field
+ * resolution against Base_Object_API__c / Query_Config__c) each fire — and each
+ * stays quiet when it should.
+ */
+@isTest
+private class DocGenTemplateLinterTest {
+    private static DocGenAiHtmlValidator.Finding findRule(List<DocGenAiHtmlValidator.Finding> findings, String rule) {
+        for (DocGenAiHtmlValidator.Finding f : findings) {
+            if (f.rule == rule) {
+                return f;
+            }
+        }
+        return null;
+    }
+
+    /** A template record for lint — in-memory is enough, lint never queries it. */
+    private static DocGen_Template__c accountTemplate(String queryConfig) {
+        return new DocGen_Template__c(
+            Name = 'Lint Tpl',
+            Type__c = 'HTML',
+            Base_Object_API__c = 'Account',
+            Output_Format__c = 'PDF',
+            Query_Config__c = queryConfig
+        );
+    }
+
+    @isTest
+    static void cleanCss21TemplateProducesZeroFindings() {
+        String html =
+            '<html><head><style>body{font-family:Helvetica,Arial,sans-serif;font-size:11pt;color:#333;}' +
+            'table{width:100%;border-collapse:collapse;}td{padding:4pt;border:0.5pt solid #ccc;}' +
+            'tr:nth-child(even){background:#f5f7fa;}</style></head><body>' +
+            '<table><tr><td>{Name}</td><td>{Industry}</td></tr></table></body></html>';
+        Test.startTest();
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(
+            html,
+            accountTemplate('Name, Industry')
+        );
+        Test.stopTest();
+        System.assertEquals(0, findings.size(), 'A CSS 2.1-clean template must report nothing: ' + findings);
+    }
+
+    @isTest
+    static void modernCssWarnsAndTheInputIsNotMutated() {
+        String html =
+            '<style>.h{display:flex;gap:8pt;} .b{background:linear-gradient(90deg,#0b3d91,#63b3ed);}' +
+            '.w{width:calc(100% - 40pt);}</style><div class="h">x</div>';
+        String before = html;
+        Test.startTest();
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(html, accountTemplate(null));
+        Test.stopTest();
+
+        System.assertEquals(before, html, 'lint must never touch the author\'s bytes');
+        System.assertNotEquals(null, findRule(findings, 'display:flex / display:grid'), 'flex must be reported');
+        System.assertNotEquals(null, findRule(findings, 'Gradient'), 'gradients must be reported');
+        System.assertNotEquals(null, findRule(findings, 'calc()'), 'calc() must be reported');
+        for (DocGenAiHtmlValidator.Finding f : findings) {
+            System.assertEquals('warning', f.action, 'lint never repairs or removes — every finding is a warning');
+            System.assert(
+                f.detail.contains('your file was not modified'),
+                'reworded detail must say the file was not modified: ' + f.detail
+            );
+        }
+    }
+
+    @isTest
+    static void pageRuleConflictsWithExplicitTemplatePageSetup() {
+        String html = '<html><head><style>@page{size:Letter portrait;margin:1in;}</style></head><body><p>x</p></body></html>';
+
+        DocGen_Template__c overridden = accountTemplate(null);
+        overridden.Page_Margins__c = 'Wide';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(html, overridden);
+        DocGenAiHtmlValidator.Finding f = findRule(findings, '@page conflicts with template page setup');
+        System.assertNotEquals(null, f, 'an explicit margins preset overrides the author\'s @page — say so');
+        System.assert(f.detail.contains('Wide'), 'the warning must name the competing setting: ' + f.detail);
+    }
+
+    @isTest
+    static void pageRuleAloneWithUntouchedFieldsIsNotAConflict() {
+        // Letter/Portrait/Default cannot be told apart from "never touched" (#243),
+        // so an @page rule with only defaults on the record is the author being in
+        // charge — no warning.
+        String html = '<html><head><style>@page{size:A4 landscape;margin:2cm;}</style></head><body><p>x</p></body></html>';
+        DocGen_Template__c tpl = accountTemplate(null);
+        tpl.Page_Margins__c = 'Default';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(html, tpl);
+        System.assertEquals(null, findRule(findings, '@page conflicts with template page setup'));
+    }
+
+    @isTest
+    static void tbodySelectorIsFlagged() {
+        String html =
+            '<html><head><style>table > tbody > tr > td{border:0.5pt solid #ccc;}</style></head>' +
+            '<body><table><tr><td>x</td></tr></table></body></html>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(html, accountTemplate(null));
+        DocGenAiHtmlValidator.Finding f = findRule(findings, 'tbody in a CSS selector');
+        System.assertNotEquals(null, f, 'the engine does not match tbody — the selector silently selects nothing');
+        System.assertEquals(1, f.occurrences);
+    }
+
+    @isTest
+    static void tbodyInMarkupWithoutASelectorIsFine() {
+        // <tbody> in the markup is harmless — only selectors are the trap.
+        String html = '<html><body><table><tbody><tr><td>x</td></tr></tbody></table></body></html>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(html, accountTemplate(null));
+        System.assertEquals(null, findRule(findings, 'tbody in a CSS selector'));
+    }
+
+    @isTest
+    static void unclosedLoopTagIsReported() {
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(
+            '<p>{#Lines}</p><p>{Name}</p>',
+            accountTemplate('Name')
+        );
+        DocGenAiHtmlValidator.Finding f = findRule(findings, 'Unclosed loop tag');
+        System.assertNotEquals(null, f, 'generation would fail with "Malformed loop tag" — warn at save time');
+        System.assert(f.detail.contains('{#Lines}'), 'the warning must name the tag: ' + f.detail);
+    }
+
+    @isTest
+    static void strayClosingTagIsReported() {
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(
+            '<p>{Name}</p><p>{/Lines}</p>',
+            accountTemplate('Name')
+        );
+        DocGenAiHtmlValidator.Finding f = findRule(findings, 'Unmatched closing tag');
+        System.assertNotEquals(null, f, 'a closer with no opener must be flagged');
+        System.assert(f.detail.contains('{/Lines}'), 'the warning must name the tag: ' + f.detail);
+    }
+
+    @isTest
+    static void balancedLoopWithElseIsClean() {
+        String html = '<html><body><table><tr><td>{#OpportunityLineItems}{Name}{:else}none{/OpportunityLineItems}</td></tr></table></body></html>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(html, accountTemplate('Name'));
+        System.assertEquals(null, findRule(findings, 'Unclosed loop tag'));
+        System.assertEquals(null, findRule(findings, 'Unmatched closing tag'));
+    }
+
+    @isTest
+    static void splitRunTagIsReported() {
+        // Bold half a merge tag in the editor and it arrives like this.
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(
+            '<p>{Na<b>me}</b></p>',
+            accountTemplate('Name')
+        );
+        System.assertNotEquals(null, findRule(findings, 'Merge tag split by formatting'), 'formatting split the tag');
+    }
+
+    @isTest
+    static void unknownFieldIsReported() {
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(
+            '<p>{NotAField__c}</p>',
+            accountTemplate('Name')
+        );
+        DocGenAiHtmlValidator.Finding f = findRule(findings, 'Merge tag does not resolve');
+        System.assertNotEquals(null, f, 'a field that does not exist on Account merges blank — warn');
+        System.assert(f.detail.contains('NotAField__c'), 'the warning must name the field: ' + f.detail);
+        System.assert(f.detail.contains('Account'), 'and the object: ' + f.detail);
+    }
+
+    @isTest
+    static void validBuiltInAndSpecialTagsAreNotFieldWarnings() {
+        String html =
+            '<p>{Name}</p><p>{Parent.Name}</p><p>{Today}</p>' +
+            '<p>{SUM:Lines.Amount}</p><p>{Chart:Lines:Amount:bar}</p>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(
+            html,
+            accountTemplate('Name, Parent.Name')
+        );
+        System.assertEquals(
+            null,
+            findRule(findings, 'Merge tag does not resolve'),
+            'valid fields, built-ins, aggregates and chart tags must not be flagged: ' + findings
+        );
+        System.assertEquals(null, findRule(findings, 'Field not in Query Config'));
+    }
+
+    @isTest
+    static void fieldMissingFromQueryConfigIsReported() {
+        // Industry exists on Account but the template only queries Name — the tag
+        // merges blank and nothing at generation time says why.
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(
+            '<p>{Name}</p><p>{Industry}</p>',
+            accountTemplate('Name')
+        );
+        DocGenAiHtmlValidator.Finding f = findRule(findings, 'Field not in Query Config');
+        System.assertNotEquals(null, f);
+        System.assert(f.detail.contains('Industry'), 'the warning must name the field: ' + f.detail);
+    }
+
+    @isTest
+    static void fieldInsideALoopBodyIsNotValidatedAgainstTheBaseObject() {
+        // {Name} inside {#OpportunityLineItems} is the CHILD's Name — validating it
+        // against Account would be wrong either way, so it is skipped.
+        String html = '<html><body><table><tr><td>{#OpportunityLineItems}{Widget_Name__c}{/OpportunityLineItems}</td></tr></table></body></html>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(html, accountTemplate('Name'));
+        System.assertEquals(
+            null,
+            findRule(findings, 'Merge tag does not resolve'),
+            'loop-body fields belong to the child object: ' + findings
+        );
+    }
+
+    @isTest
+    static void unknownLoopRelationshipIsReported() {
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(
+            '<p>{#NotARel}</p><p>{Name}</p><p>{/NotARel}</p>',
+            accountTemplate('Name')
+        );
+        DocGenAiHtmlValidator.Finding f = findRule(findings, 'Loop relationship not found');
+        System.assertNotEquals(null, f, 'a loop on a relationship the base object does not have renders nothing');
+        System.assert(f.detail.contains('NotARel'), 'the warning must name the relationship: ' + f.detail);
+        System.assert(f.detail.contains('Account'), 'and the object: ' + f.detail);
+    }
+
+    @isTest
+    static void aliasedLoopFromQueryConfigIsAccepted() {
+        // A V3 Query Config node can rename its relationship — templates loop on
+        // the ALIAS, so describe alone must not condemn it.
+        DocGen_Template__c tpl = accountTemplate(
+            '{"nodes":[{"object":"OpportunityLineItem","relationshipName":"OpportunityLineItems","lookupField":"OpportunityId","alias":"Lines","fields":["UnitPrice"]}]}'
+        );
+        String html = '<html><body><table><tr><td>{#Lines}{UnitPrice}{/Lines}</td></tr></table></body></html>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(html, tpl);
+        System.assertEquals(
+            null,
+            findRule(findings, 'Loop relationship not found'),
+            'the alias is defined by the Query Config: ' + findings
+        );
+    }
+
+    @isTest
+    static void lintNeverThrowsOnGarbage() {
+        Test.startTest();
+        List<DocGenAiHtmlValidator.Finding> blank = DocGenTemplateLinter.lint(null, null);
+        List<DocGenAiHtmlValidator.Finding> garbage = DocGenTemplateLinter.lint('{{{ not html at all', null);
+        List<DocGenAiHtmlValidator.Finding> noTemplate = DocGenTemplateLinter.lint(
+            '<p>{Name}</p>',
+            new DocGen_Template__c()
+        );
+        Test.stopTest();
+        System.assertEquals(0, blank.size(), 'blank input is an empty report, not an exception');
+        System.assertNotEquals(null, garbage);
+        System.assertNotEquals(null, noTemplate);
+    }
+
+    // -----------------------------------------------------------------------
+    // The hook: every HTML body write funnels through saveHtmlTemplateBody, so
+    // the warnings ride back with the save result.
+    // -----------------------------------------------------------------------
+
+    private static DocGen_Template__c newHtmlTemplate() {
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'Lint Hook ' + System.now().getTime(),
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF',
+            Query_Config__c = 'Name'
+        );
+        Database.insert(tpl, AccessLevel.SYSTEM_MODE);
+        return tpl;
+    }
+
+    @isTest
+    static void saveReturnsTheWarningsKeys() {
+        DocGen_Template__c tpl = newHtmlTemplate();
+        Test.startTest();
+        Map<String, Object> res = DocGenController.saveHtmlTemplateBody(
+            tpl.Id,
+            'body.html',
+            '<html><body><p>Hello {Name}</p></body></html>'
+        );
+        Test.stopTest();
+
+        System.assert(res.containsKey('warnings'), 'the save result must carry the fidelity report');
+        System.assert(res.containsKey('warningCount'), 'and its count');
+        List<DocGenAiHtmlValidator.Finding> warnings = (List<DocGenAiHtmlValidator.Finding>) res.get('warnings');
+        System.assertEquals(0, warnings.size(), 'a clean body warns about nothing: ' + warnings);
+        System.assertEquals(0, (Integer) res.get('warningCount'));
+    }
+
+    @isTest
+    static void saveReportsWarningsWithoutBlocking() {
+        DocGen_Template__c tpl = newHtmlTemplate();
+        Test.startTest();
+        Map<String, Object> res = DocGenController.saveHtmlTemplateBody(
+            tpl.Id,
+            'body.html',
+            '<html><head><style>.h{display:flex;}</style></head><body><p>Hello {Name}</p></body></html>'
+        );
+        Test.stopTest();
+
+        System.assertNotEquals(null, res.get('contentVersionId'), 'warnings never block the save');
+        List<DocGenAiHtmlValidator.Finding> warnings = (List<DocGenAiHtmlValidator.Finding>) res.get('warnings');
+        System.assert(!warnings.isEmpty(), 'flex in the body must produce a warning');
+        System.assertEquals(warnings.size(), (Integer) res.get('warningCount'), 'count must match the list');
+    }
+
+    @isTest
+    static void saveAndPublishPropagatesTheWarnings() {
+        DocGen_Template__c tpl = newHtmlTemplate();
+        Test.startTest();
+        Map<String, Object> res = DocGenController.saveAndPublishHtmlBody(
+            tpl.Id,
+            'body.html',
+            '<html><head><style>.h{display:flex;}</style></head><body><p>Hello {Name}</p></body></html>',
+            false
+        );
+        Test.stopTest();
+
+        System.assert(res.containsKey('warnings'), 'the canvas path returns the same report');
+        System.assert(
+            !((List<DocGenAiHtmlValidator.Finding>) res.get('warnings')).isEmpty(),
+            'warnings must survive the publish wrapper'
+        );
+        System.assertEquals(
+            ((List<DocGenAiHtmlValidator.Finding>) res.get('warnings')).size(),
+            (Integer) res.get('warningCount')
+        );
+    }
+}

--- a/force-app/main/default/classes/DocGenTemplateLinterTest.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenTemplateLinterTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1704,6 +1704,7 @@
                             sample-record-id={editTemplateTestRecordId}
                             onedittemplate={handleEditTemplateFromDesigner}
                             onqueryupdated={handleCanvasQueryUpdated}
+                            onsaved={handleCanvasSaved}
                             onback={handleCanvasBack}
                         ></c-doc-gen-canvas>
                     </template>
@@ -2295,6 +2296,7 @@
                                         template-id={editTemplateId}
                                         page-size={editTemplatePageSize}
                                         orientation={editTemplatePageOrientation}
+                                        onsaved={handleCanvasSaved}
                                         onback={handleCanvasBack}
                                     ></c-doc-gen-canvas>
                                 </template>
@@ -5271,6 +5273,37 @@
                                                     variant="inverse"
                                                 ></lightning-icon>
                                                 <strong>Ready to Save:</strong> {uploadedFileName}
+                                            </div>
+                                        </template>
+
+                                        <!-- #272 fidelity report. Warnings, never blockers: the body
+                                             was already stored when these were produced, so the heading
+                                             says what will happen, not what failed. -->
+                                        <template if:true={hasLintFindings}>
+                                            <div class="slds-box slds-var-m-top_medium">
+                                                <h3 class="slds-text-heading_small slds-var-m-bottom_x-small">
+                                                    Template warnings — this will still render
+                                                </h3>
+                                                <p
+                                                    class="slds-text-body_small slds-text-color_weak slds-var-m-bottom_small"
+                                                >
+                                                    Nothing was blocked and your file was saved as-is. The PDF engine is
+                                                    CSS 2.1, so at render time it handles the items below differently
+                                                    than a browser would — here's what changes.
+                                                </p>
+                                                <template for:each={lintFindings} for:item="f">
+                                                    <div key={f.key} class="slds-var-m-bottom_x-small">
+                                                        <lightning-badge label={f.badge} class={f.badgeClass}>
+                                                        </lightning-badge>
+                                                        <strong class="slds-var-m-left_x-small">{f.rule}</strong>
+                                                        <span class="slds-text-body_small slds-text-color_weak">
+                                                            &times;{f.occurrences}</span
+                                                        >
+                                                        <p class="slds-text-body_small slds-var-m-left_medium">
+                                                            {f.detail}
+                                                        </p>
+                                                    </div>
+                                                </template>
                                             </div>
                                         </template>
 

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -563,6 +563,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     @track isWizardAgentforceGenerating = false;
     @track wizardAgentforceSummary = '';
     @track wizardAgentforceFindings = [];
+    // Upload-time fidelity report (#272): DocGenTemplateLinter warnings riding
+    // the saveHtmlTemplateBody / saveAndPublishHtmlBody response. Advisory
+    // only — the body is already stored when these show, nothing was blocked.
+    @track lintFindings = [];
     // Live PDF preview: draft HTML → real Blob.toPdf render → blob: iframe.
     @track pdfPreviewUrl = null;
     @track isPdfPreviewLoading = false;
@@ -5114,6 +5118,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         try {
             this._editContext = true;
             this.editTemplateId = row.Id;
+            // Findings belong to the body that was linted — a different template
+            // must never see the previous one's report.
+            this.lintFindings = [];
             this.editTemplateName = row.Name;
             this.editTemplateCategory = row[F.Category];
             this.editTemplateType = row[F.Type];
@@ -6518,6 +6525,49 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         return htmlText.toLowerCase().indexOf('@page') !== -1;
     }
 
+    get hasLintFindings() {
+        return this.lintFindings && this.lintFindings.length > 0;
+    }
+
+    /**
+     * Fidelity report (#272): server Finding DTOs → badge rows, the same shape
+     * the Agentforce report renders. Lint actions are always 'warning'.
+     */
+    _mapLintFindings(warnings) {
+        return (warnings || []).map((f, i) => ({
+            key: `lint-${i}`,
+            rule: f.rule,
+            detail: f.detail,
+            occurrences: f.occurrences,
+            badge: f.action === 'repaired' ? 'Repaired' : f.action === 'removed' ? 'Removed' : 'Check this',
+            badgeClass:
+                f.action === 'warning' ? 'slds-theme_warning' : f.action === 'repaired' ? 'slds-theme_success' : ''
+        }));
+    }
+
+    // Sticky so the author can read it while scrolling to the report; the save
+    // itself already got its own success toast.
+    _toastLintFindings() {
+        const n = this.lintFindings.length;
+        this.showToast(
+            'Saved — ' + n + ' template warning' + (n === 1 ? '' : 's'),
+            'This will still render. The fidelity report in the edit view lists what the PDF engine handles differently — nothing was blocked.',
+            'warning',
+            'sticky'
+        );
+    }
+
+    // Canvas saves bypass _processAndSaveHtmlBody (docGenCanvas calls
+    // saveAndPublishHtmlBody itself), so the warnings arrive on the 'saved'
+    // event instead of a save response this component holds.
+    handleCanvasSaved(event) {
+        const warnings = event && event.detail ? event.detail.warnings : null;
+        this.lintFindings = this._mapLintFindings(warnings);
+        if (this.lintFindings.length > 0) {
+            this._toastLintFindings();
+        }
+    }
+
     triggerHtmlFilePicker() {
         const input = this.template.querySelector('.docgen-html-file-input');
         if (input) {
@@ -6583,6 +6633,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
      * state. Throws on failure — callers own the error toast.
      */
     async _processAndSaveHtmlBody(templateId, htmlText, fileName, zipImages, source) {
+        // A new save invalidates whatever the last fidelity report said — never
+        // leave stale findings showing for a body they were not run against.
+        this.lintFindings = [];
         // REGIONS: this is the single choke point every body reaches on its way to a
         // ContentVersion — editor save, file upload, AI paste-back, switch-to-HTML.
         // Adopting here means an author can upload an HTML file that carries
@@ -6695,11 +6748,17 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         const pageMsg = this.editHtmlBodyOwnsPageRule
             ? ' Your HTML defines its own @page CSS — template page-layout fields cleared.'
             : '';
+        // #272 fidelity report — the linter's warnings ride the save response.
+        // Advisory only: the body above is already stored.
+        this.lintFindings = this._mapLintFindings(bodyResult.warnings);
         this.showToast(
             source === 'editor' ? 'Editor HTML staged' : 'Uploaded',
             fileName + imgMsg + '.' + pageMsg + ' Click "Save as New Version" to activate.',
             'success'
         );
+        if (this.lintFindings.length > 0) {
+            this._toastLintFindings();
+        }
         return rewritten;
     }
 

--- a/force-app/main/default/lwc/docGenCanvas/docGenCanvas.js
+++ b/force-app/main/default/lwc/docGenCanvas/docGenCanvas.js
@@ -3163,7 +3163,10 @@ export default class DocGenCanvas extends LightningElement {
             if (res && res.versionId) {
                 this.activeVersionId = res.versionId;
             }
-            this.dispatchEvent(new CustomEvent('saved', { detail: { html } }));
+            // #272 — the linter's warnings ride the save response; hand them to
+            // the host so its fidelity report can show them. Extra detail keys
+            // are additive — existing 'saved' listeners only read detail.html.
+            this.dispatchEvent(new CustomEvent('saved', { detail: { html, warnings: (res && res.warnings) || [] } }));
         } catch (e) {
             // Surfaced as a banner, not a status line: a save that silently did not
             // happen is the single worst thing this editor can do.


### PR DESCRIPTION
## What

Implements the HTML-first slice of #272: template upload/save stops being a black box. Every HTML body write now runs a fidelity report and hands the findings back with the save result — **warnings, never blockers**.

**Renderer compatibility**
- Every CSS 3 construct Flying Saucer drops, flagged at save time. Reuses `DocGenAiHtmlValidator`'s *measured* rule set (flex/grid/gap, gradients, `calc()`, CSS custom properties, rgba(), @media…) in report mode: the rewritten HTML is discarded and every finding is reworded so nothing implies the file was modified.
- `@page` declared in the HTML **and** competing page setup on the template record (the #60/#71 conflict class). Mirrors the render-time explicit-override precedence from #243 — Letter/Portrait/Default can't be told apart from "never touched" and don't false-positive.
- `table > tbody > tr > td`-style selectors — the engine doesn't match `tbody`, so the selector silently selects nothing.

**Merge-tag lint**
- Unbalanced `{#Rel}`/`{/Rel}` pairing with `findBalancedEnd`'s exact semantics (bare `IF`/`GroupBy`/`ChartBucket` balance keys, `{:else}` at depth zero, case-sensitive matching) — catches at save what currently only surfaces as the generation-time "Malformed loop tag" exception.
- Tags split across formatting runs (the #130 text-fallback cause).
- Field references validated against the template's `Base_Object_API__c` describe; loop names against child relationships **and** V3 Query Config aliases; a softer warning when a described-valid field isn't in the Query Config (merges blank).

## How

- New `DocGenTemplateLinter.lint(html, template)` — non-mutating, individually guarded per check; it never throws and never touches the author's bytes.
- `saveHtmlTemplateBody` / `saveAndPublishHtmlBody` return `warnings` + `warningCount` keys. The lint runs after the save succeeds, wrapped so a lint failure can never change the save outcome. No signature changes; existing callers see identical behavior when clean.
- `docGenAdmin` edit view: "Template warnings — this will still render" panel (same badge style as the Agentforce findings) + sticky summary toast. Findings clear on template switch / new save. Canvas saves surface warnings through the `saved` event.

## Verification

- **RunLocalTests: 1936/1936 passed, 78% org-wide coverage** on a fresh no-namespace scratch org (deploy skipped only the two pre-existing Einstein-only components — `GenAiPromptTemplate` + `DocGenEinsteinProvider` — which require org features the scratch def doesn't enable).
- **All 14 e2e scripts PASS / FAIL 0** (e2e-01…08 incl. syntax1–5).
- **`sf code-analyzer` (Security + AppExchange): 0 violations.**
- 20 new tests in `DocGenTemplateLinterTest` cover every check, the non-mutation guarantee, and the save-hook propagation.

## Deliberately out of scope (follow-ups)

- DOCX/PPTX upload lint — port `scripts/docgen-template-lint.js` to Apex (`Compression.ZipReader` precedent exists at `DocGenController.cls:1067`) and the chart-tags-in-docx steering warning.
- The two wizard create paths (starter body, AI paste-back) call the save methods directly and don't yet render the panel.
- Auto-repair at upload — the issue asks for warnings, not a wall.