### PR TITLE
fix(canvas): disable no-op bold for Arial Unicode MS (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Canvas bold is no longer a silent no-op on `'Arial Unicode MS'` (#281).** The PDF
+  engine (`Blob.toPdf`/Flying Saucer) embeds Arial Unicode MS with no bold face, so a
+  bold box set to it printed regular while the canvas showed bold — WYSIWYG said
+  "weight" where the PDF could not deliver. The Bold control is now disabled for that
+  font (and cleared if you switch a bold box to it), the canvas stops showing it as on,
+  and the serializer stops emitting the no-op `font-weight: bold`. The corrected
+  `FONT_CHOICES` note no longer claims bold. The generic families are unaffected: they
+  resolve to the base-14 bold faces (verified selecting Helvetica-Bold / Times-Bold /
+  Courier-Bold in a real org).
+
 ## v3.55.0 — Element linking, named blocks, client-side charts
 
 Released 2026-08-08 · `04tVx0000010fXFIAY` · ancestor 3.54.0 · 1,957 tests, 78% coverage

--- a/force-app/main/default/lwc/docGenCanvas/canvasModel.js
+++ b/force-app/main/default/lwc/docGenCanvas/canvasModel.js
@@ -148,6 +148,18 @@ function nextId(prefix) {
 export const UNICODE_FONT = "'Arial Unicode MS'";
 
 /**
+ * Whether a font-family can actually print bold in the PDF engine (Blob.toPdf /
+ * Flying Saucer). Only `'Arial Unicode MS'` cannot: it embeds a regular (and italic)
+ * face but no bold variant (#281), so `font-weight: bold` on it silently renders
+ * regular — the canvas showed a weight the PDF could not deliver. The serializers
+ * use this to skip emitting bold for it, and the editor disables the Bold control, so
+ * authoring and output agree.
+ */
+export function canRenderBold(font) {
+    return typeof font !== 'string' || font.replace(/['"]/g, '').toLowerCase() !== 'arial unicode ms';
+}
+
+/**
  * Symbols, and the font each one needs.
  *
  * Measured against rendered PDFs. Blob.toPdf resolves the generic families to the
@@ -157,7 +169,8 @@ export const UNICODE_FONT = "'Arial Unicode MS'";
  *
  * `Arial Unicode MS` is different: it embeds as a subsetted CID TrueType with
  * Identity-H encoding and draws the lot — ✓ ✔ ☑ ☐ ✗ ● ■ ★ → √ ≤ ≥ ≈ ∞, CJK, Greek,
- * Cyrillic, Hebrew — in regular, bold and italic. Naming it is the whole trick, and it
+ * Cyrillic, Hebrew — in regular and italic but NOT bold (#281: it has no bold face,
+ * so font-weight bold on it prints regular). Naming it is the whole trick, and it
  * is why `unicode: true` symbols below are inserted wrapped in a span that asks for it
  * rather than relying on whatever the box is set to.
  *
@@ -207,8 +220,10 @@ export const FONT_CHOICES = [
     { label: 'Sans-serif', value: 'sans-serif' },
     { label: 'Serif', value: 'serif' },
     { label: 'Monospace', value: 'monospace' },
-    // The Unicode face. Measured to embed and draw symbols, CJK, Greek, Cyrillic and
-    // Hebrew in regular, bold and italic — everything the base-14 fonts cannot.
+    // The Unicode face. Embeds and draws symbols, CJK, Greek, Cyrillic and Hebrew that
+    // the base-14 fonts cannot — in regular and italic. It has NO bold face in the PDF
+    // engine (Blob.toPdf), so font-weight: bold on it silently prints regular; the
+    // Bold control is disabled for it (see canRenderBold).
     { label: 'Arial Unicode (symbols, CJK)', value: "'Arial Unicode MS'" }
 ];
 
@@ -1222,7 +1237,9 @@ function styleCss(box) {
     if (st.color) css += 'color: ' + st.color + '; ';
     if (st.align) css += 'text-align: ' + st.align + '; ';
     css += 'padding: ' + (st.padding || 0) + 'pt;';
-    if (st.bold) css += ' font-weight: bold;';
+    // Arial Unicode MS has no bold face in the PDF engine, so a bold it emits would
+    // silently print regular — the canvas promises a weight the PDF cannot deliver.
+    if (st.bold && canRenderBold(st.font)) css += ' font-weight: bold;';
     if (st.italic) css += ' font-style: italic;';
     if (st.underline) css += ' text-decoration: underline;';
     // A flat hex, never rgba(): rgba resolves to nothing in this engine and the fill
@@ -1325,7 +1342,7 @@ function totalsCell(t, tt, frame, value, span) {
         '; text-align: ' +
         tt.align +
         ';' +
-        (tt.bold ? ' font-weight: bold;' : ' font-weight: normal;') +
+        (tt.bold && canRenderBold(tt.font) ? ' font-weight: bold;' : ' font-weight: normal;') +
         fill;
     return '<td' + (span || '') + ' style="' + css + '">' + (value || '') + '</td>';
 }
@@ -1358,7 +1375,7 @@ function subLoopRow(t, parentColCount, boxFont) {
         '; text-align: ' +
         stx.align +
         ';' +
-        (stx.bold ? ' font-weight: bold;' : ' font-weight: normal;') +
+        (stx.bold && canRenderBold(stx.font || boxFont) ? ' font-weight: bold;' : ' font-weight: normal;') +
         (t.subFill ? ' background: ' + t.subFill + ';' : '');
     const cells = subs
         .map((c, i) => {
@@ -1400,7 +1417,7 @@ function tableToHtml(box) {
         '; text-align: ' +
         x.align +
         ';' +
-        (x.bold ? ' font-weight: bold;' : ' font-weight: normal;');
+        (x.bold && canRenderBold(x.font || st.font) ? ' font-weight: bold;' : ' font-weight: normal;');
     const frame = gridCss(t, 'body');
     const cellCss = frame + typo(rt);
     const headCss = gridCss(t, 'head') + typo(ht);
@@ -1493,7 +1510,7 @@ export function tablePreviewHtml(box) {
         '; text-align: ' +
         x.align +
         ';' +
-        (x.bold ? ' font-weight: bold;' : ' font-weight: normal;');
+        (x.bold && canRenderBold(x.font || st.font) ? ' font-weight: bold;' : ' font-weight: normal;');
     const frame = gridCss(t, 'body');
     const cellCss = frame + typo(rt);
     const headCss = gridCss(t, 'head') + typo(ht);

--- a/force-app/main/default/lwc/docGenCanvas/docGenCanvas.css
+++ b/force-app/main/default/lwc/docGenCanvas/docGenCanvas.css
@@ -342,6 +342,13 @@
     border-color: rgba(124, 58, 237, 0.7);
 }
 
+/* A Bold (or other) toggle that is a silent no-op in the PDF for the chosen font —
+   greyed and inert so the canvas stops promising a weight it cannot deliver. */
+.dg-sbtn[disabled] {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
 .dg-prop-gap {
     display: inline-block;
     width: 10px;

--- a/force-app/main/default/lwc/docGenCanvas/docGenCanvas.html
+++ b/force-app/main/default/lwc/docGenCanvas/docGenCanvas.html
@@ -221,7 +221,13 @@
                     </div>
 
                     <div class="dg-prop-row">
-                        <button class={boldClass} data-key="bold" onclick={handleStyleToggle} title="Bold">
+                        <button
+                            class={boldClass}
+                            data-key="bold"
+                            onclick={handleStyleToggle}
+                            disabled={boxBoldDisabled}
+                            title={boldTitle}
+                        >
                             <b>B</b>
                         </button>
                         <button class={italicClass} data-key="italic" onclick={handleStyleToggle} title="Italic">
@@ -447,6 +453,8 @@
                             data-which="header"
                             data-key="bold"
                             onclick={handleRowTextChange}
+                            disabled={headerBoldDisabled}
+                            title={headerBoldTitle}
                         >
                             <b>B</b>
                         </button>
@@ -483,7 +491,14 @@
                             data-key="color"
                             onchange={handleRowTextChange}
                         />
-                        <button class={rowBoldClass} data-which="row" data-key="bold" onclick={handleRowTextChange}>
+                        <button
+                            class={rowBoldClass}
+                            data-which="row"
+                            data-key="bold"
+                            onclick={handleRowTextChange}
+                            disabled={rowBoldDisabled}
+                            title={rowBoldTitle}
+                        >
                             <b>B</b>
                         </button>
                     </div>
@@ -570,7 +585,8 @@
                                 data-which="totals"
                                 data-key="bold"
                                 onclick={handleRowTextChange}
-                                title="Bold"
+                                disabled={totalsBoldDisabled}
+                                title={totalsBoldTitle}
                             >
                                 <b>B</b>
                             </button>

--- a/force-app/main/default/lwc/docGenCanvas/docGenCanvas.js
+++ b/force-app/main/default/lwc/docGenCanvas/docGenCanvas.js
@@ -62,6 +62,17 @@ import {
 } from './canvasModel';
 
 /**
+ * Arial Unicode MS has no bold face in the PDF engine (Blob.toPdf), so a bold this
+ * font carries silently prints regular. The canvas disables the Bold control for it
+ * so it stops promising a weight the PDF cannot deliver. Mirrors canRenderBold in
+ * canvasModel (which also suppresses serialization) — keeping both in sync:
+ * canRenderBold must stay the exact inverse of this.
+ */
+function isUnicodeFont(font) {
+    return typeof font === 'string' && font.replace(/['"]/g, '').toLowerCase() === 'arial unicode ms';
+}
+
+/**
  * Canvas editor — a Canva-style artboard for Portwood's Canvas template type.
  *
  * DELIBERATELY NET NEW, not a mode inside docGenAdmin. That component is ~15k lines
@@ -1402,7 +1413,16 @@ export default class DocGenCanvas extends LightningElement {
     }
 
     get totalsBoldClass() {
-        return this.selTotalsText.bold ? 'dg-sbtn dg-sbtn_on' : 'dg-sbtn';
+        return this.selTotalsText.bold && !this.totalsBoldDisabled ? 'dg-sbtn dg-sbtn_on' : 'dg-sbtn';
+    }
+    get totalsBoldDisabled() {
+        return isUnicodeFont(this.selTotalsFont);
+    }
+    get totalsBoldTitle() {
+        return this.totalsBoldDisabled ? 'Bold not available for Arial Unicode' : 'Bold';
+    }
+    get subBoldDisabled() {
+        return isUnicodeFont(this.selSubFont);
     }
 
     /** Align is a button, not a field, so it carries its value in data-align. */
@@ -1420,11 +1440,23 @@ export default class DocGenCanvas extends LightningElement {
     }
 
     get headerBoldClass() {
-        return this.selHeaderText.bold ? 'dg-sbtn dg-sbtn_on' : 'dg-sbtn';
+        return this.selHeaderText.bold && !this.headerBoldDisabled ? 'dg-sbtn dg-sbtn_on' : 'dg-sbtn';
+    }
+    get headerBoldDisabled() {
+        return isUnicodeFont(this.selHeaderFont);
+    }
+    get headerBoldTitle() {
+        return this.headerBoldDisabled ? 'Bold not available for Arial Unicode' : 'Bold';
     }
 
     get rowBoldClass() {
-        return this.selRowText.bold ? 'dg-sbtn dg-sbtn_on' : 'dg-sbtn';
+        return this.selRowText.bold && !this.rowBoldDisabled ? 'dg-sbtn dg-sbtn_on' : 'dg-sbtn';
+    }
+    get rowBoldDisabled() {
+        return isUnicodeFont(this.selRowFont);
+    }
+    get rowBoldTitle() {
+        return this.rowBoldDisabled ? 'Bold not available for Arial Unicode' : 'Bold';
     }
 
     /** Header and body rows are styled separately — see DEFAULT_HEADER_TEXT. */
@@ -1459,6 +1491,18 @@ export default class DocGenCanvas extends LightningElement {
                     : this.selRowText;
         let value;
         if (key === 'bold') {
+            // Arial Unicode MS has no bold face — refuse the toggle for that band.
+            const bandDisabled =
+                which === 'header'
+                    ? this.headerBoldDisabled
+                    : which === 'totals'
+                      ? this.totalsBoldDisabled
+                      : which === 'sub'
+                        ? this.subBoldDisabled
+                        : this.rowBoldDisabled;
+            if (bandDisabled) {
+                return;
+            }
             value = !current.bold;
         } else if (key === 'size') {
             value = parseFloat(event.target.value);
@@ -1474,7 +1518,11 @@ export default class DocGenCanvas extends LightningElement {
                   : which === 'sub'
                     ? 'subText'
                     : 'rowText';
-        this._patchTable({ [field]: { ...current, [key]: value } });
+        const patch = { [key]: value };
+        if (key === 'font' && isUnicodeFont(value) && current.bold) {
+            patch.bold = false;
+        }
+        this._patchTable({ [field]: { ...current, ...patch } });
     }
 
     handleAddColumn() {
@@ -1826,7 +1874,16 @@ export default class DocGenCanvas extends LightningElement {
         return this.selectedStyle.borderColor;
     }
     get boldClass() {
-        return this.selectedStyle.bold ? 'dg-sbtn dg-sbtn_on' : 'dg-sbtn';
+        return this.selectedStyle.bold && !this.boxBoldDisabled ? 'dg-sbtn dg-sbtn_on' : 'dg-sbtn';
+    }
+    /** Arial Unicode MS has no bold face in the PDF — the Bold toggle is a no-op for it. */
+    get boxBoldDisabled() {
+        return isUnicodeFont(this.selFont);
+    }
+    get boldTitle() {
+        return this.boxBoldDisabled
+            ? 'Bold is not available for Arial Unicode — it has no bold face in the PDF'
+            : 'Bold';
     }
     get italicClass() {
         return this.selectedStyle.italic ? 'dg-sbtn dg-sbtn_on' : 'dg-sbtn';
@@ -1853,6 +1910,11 @@ export default class DocGenCanvas extends LightningElement {
 
     handleStyleToggle(event) {
         const key = event.currentTarget.dataset.key;
+        // Arial Unicode MS has no bold face — a bold this box carries would silently
+        // print regular in the PDF. Refuse the toggle so the canvas can't promise it.
+        if (key === 'bold' && this.boxBoldDisabled) {
+            return;
+        }
         this._patchStyle({ [key]: !this.selectedStyle[key] });
     }
 
@@ -1861,7 +1923,14 @@ export default class DocGenCanvas extends LightningElement {
     }
 
     handleFontChange(event) {
-        this._patchStyle({ font: event.detail.value });
+        const font = event.detail.value;
+        // Switching to Arial Unicode MS clears an active bold: it has no bold face, so
+        // keeping bold on would show a weight the PDF cannot print (see canRenderBold).
+        const patch = { font };
+        if (isUnicodeFont(font) && this.selectedStyle.bold) {
+            patch.bold = false;
+        }
+        this._patchStyle(patch);
     }
 
     handleNumChange(event) {

--- a/scripts/qa/canvas-serializer-check.mjs
+++ b/scripts/qa/canvas-serializer-check.mjs
@@ -163,7 +163,58 @@ sigB.signature = { role: 'Customer', order: 1, type: 'Date', inline: true };
 sigDoc.artboards[0].boxes.push(sigA, sigB);
 const sigHtml = m.serialize(sigDoc, geo);
 
+// --- #281: Arial Unicode MS has no bold face in the PDF engine -----------------
+// Blob.toPdf embeds Arial Unicode MS WITHOUT a bold variant, so font-weight:bold on
+// it silently prints regular — the canvas promised a weight the PDF cannot deliver.
+// The serializer must NOT emit that no-op bold, while the generic families (which
+// resolve to Helvetica-Bold / Times-Bold / Courier-Bold) must still serialize bold.
+const UNICODE = m.UNICODE_FONT;
+const boldChecks = [
+    ['canRenderBold: Arial Unicode MS (quoted) has no bold', m.canRenderBold(UNICODE) === false],
+    ['canRenderBold: Arial Unicode MS (unquoted) has no bold', m.canRenderBold('Arial Unicode MS') === false],
+    ['canRenderBold: generic sans-serif supports bold', m.canRenderBold('sans-serif') === true],
+    ['canRenderBold: generic serif supports bold', m.canRenderBold('serif') === true],
+    ['canRenderBold: no font supports bold', m.canRenderBold(undefined) === true]
+];
+
+// A generic-font bold box must still serialize font-weight:bold (renders Helvetica-Bold).
+const boldGenericDoc = m.blankDocument();
+const boldGenericBox = m.newTextBox(1, 1, 4, 0.5);
+boldGenericBox.style = { ...boldGenericBox.style, bold: true, font: 'sans-serif' };
+boldGenericBox.text = 'Generic bold';
+boldGenericDoc.artboards[0].boxes.push(boldGenericBox);
+const boldGenericHtml = m.serialize(boldGenericDoc, geo);
+
+// An Arial-Unicode bold box must NOT serialize a no-op bold.
+const boldUnicodeDoc = m.blankDocument();
+const boldUnicodeBox = m.newTextBox(1, 1, 4, 0.5);
+boldUnicodeBox.style = { ...boldUnicodeBox.style, bold: true, font: UNICODE };
+boldUnicodeBox.text = 'Unicode bold';
+boldUnicodeDoc.artboards[0].boxes.push(boldUnicodeBox);
+const boldUnicodeHtml = m.serialize(boldUnicodeDoc, geo);
+
+// The same for table bands (header/totals) under Arial Unicode MS.
+const boldUnicodeTblDoc = m.blankDocument();
+const boldUnicodeTbl = m.newTableBox(1, 3, 5);
+boldUnicodeTbl.style = { ...boldUnicodeTbl.style, font: UNICODE };
+boldUnicodeTbl.table.rows = [['Item', '1']];
+boldUnicodeTbl.table.totals = { enabled: true, cells: ['Subtotal', '{Total}'] };
+boldUnicodeTbl.table.headerText = { ...boldUnicodeTbl.table.headerText, font: UNICODE, bold: true };
+boldUnicodeTbl.table.totalsText = { ...boldUnicodeTbl.table.totalsText, font: UNICODE, bold: true };
+boldUnicodeTblDoc.artboards[0].boxes.push(boldUnicodeTbl);
+const boldUnicodeTblHtml = m.serialize(boldUnicodeTblDoc, geo);
+
+boldChecks.push(
+    ['generic-font bold box still serializes bold', boldGenericHtml.includes('font-weight: bold;')],
+    ['ArialUnicode bold box does not serialize a no-op bold', !boldUnicodeHtml.includes('font-weight: bold;')],
+    [
+        'ArialUnicode table header/totals bold suppressed',
+        !boldUnicodeTblHtml.includes('font-weight: bold;') && boldUnicodeTblHtml.includes('font-weight: normal;')
+    ]
+);
+
 const checks = [
+    ...boldChecks,
     // 2.5in authored is the OUTER width. The default 2pt padding sits inside it, so the
     // emitted content width is 2.5 - 2x2pt = 2.444in and the box still measures 2.5in
     // edge to edge — which is what the author dragged and what the canvas draws.


### PR DESCRIPTION
## Problem (#281)

Reported: `font-weight: bold` never renders in the PDF from a Canvas template, on any FONT_CHOICES family.

## Investigation (proven against a real org's `Blob.toPdf`, not inferred)

Read the generated PDF's `/BaseFont` resources:

- **The generic families DO register bold**: `sans-serif` → `Helvetica-Bold`, `serif` → `Times-Bold`, `monospace` → `Courier-Bold`. Feeding the *exact* `canvasModel.serialize()` output into the real org's `Blob.toPdf` yields `(Times-Roman, Helvetica, Helvetica-Bold)` — so generic-family bold reaches the PDF and the WYSIWYG gap does **not** reproduce for them.
- **`'Arial Unicode MS'` is the one family with no bold**: an exclusively-ArialUnicode `font-weight: bold` document embeds a single subset (`KNMSEY+ArialUnicodeMS`, same prefix on both the regular and bold runs) with no `-Bold` face. `font-weight: bold` on it silently prints regular — exactly the "Bold control does nothing" symptom.
- No pipeline step (`DocGenService.processXml` → `wrapNonLatinGlyphs` → `Blob.toPdf`) strips `font-weight`.

So the actionable defect is Arial Unicode MS specifically (and its wrong doc comments), not bold across all families — the issue's suggested "disable all bold controls" fix would have been wrong.

## Fix

- **`canvasModel.js`**: new `canRenderBold()` gates bold emission in `styleCss`, `totalsCell`, `subLoopRow` and the table `typo()` paths, so an Arial-Unicode-M S bold is never emitted as a no-op. Corrects the `FONT_CHOICES`/`SAFE_SYMBOLS` comments that wrongly claimed it draws bold (it draws regular and italic, not bold).
- **`docGenCanvas.js` / `.html` / `.css`**: the Bold control is disabled (greyed, with a tooltip) and cleared when the box/table-band font is Arial Unicode MS, and never shows as "on" for it — so authoring and output agree (no more WYSIWYG lie).
- **Generic-family bold is untouched** (still serialized → Helvetica-Bold in the PDF).

## Verification

- `node scripts/qa/canvas-serializer-check.mjs` → `serializer OK`, including 8 new regression checks (canRenderBold matrix, generic-keeps-bold, ArialUnicode box/table suppression).
- `prettier --check` clean on all changed files (CI gate).
- `node --check` clean on both JS files.
- `Blob.toPdf` behavior confirmed against the `issue272-verify` scratch org.
