### PR TITLE
fix(charts): make chart label size an explicit control (fontSize= + Canvas properties)

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1937,18 +1937,19 @@ A single tag that expands into a complete chart image at render time. **Tag synt
 
 Modifiers come after the style, joined with `&`. **Order doesn't matter.** Values containing `&` or `=` are not supported (use `where=` for SOQL with operators — see below).
 
-| Modifier      | Applies to                        | Example                                                  | What it does                                                                                                                                                           |
-| ------------- | --------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `title=`      | all styles                        | `title=How satisfied are you with your role?`            | Chart header text drawn above the chart. Becomes the `<img alt="…">` attribute on the HTML side.                                                                       |
-| `width=`      | all styles                        | `width=420`                                              | Logical-pixel width of the chart. Defaults: 540 (stacked/clustered), 500 (bar/column/line/area), 360 (pie/donut). Word/PDF downsample bigger PNGs for free AA.         |
-| `height=`     | all styles                        | `height=240`                                             | Logical-pixel height. Defaults vary per style (see source); bar auto-grows by bucket count.                                                                            |
-| `where=`      | all styles                        | `where=Survey_Question__r.Display_Order__c=1`            | SOQL fragment appended to the chart's `WHERE`. Identifier-only, sanitized through the same keyword blocklist as Query Builder. Forces server-side aggregation.         |
-| `groupBy=`    | stacked/clustered/pivot/line/area | `groupBy=Department__c`                                  | Cross-tab dimension. **Required** for `stacked`/`clustered`/`pivot`; **optional** for `line`/`area` (omit → single-series). Field on the same child object as `FIELD`. |
-| `colSort=`    | stacked/clustered/pivot/line/area | `colSort=Engineering,Sales,Marketing,Support,Operations` | Author-controlled column ordering. Named values appear first in this order; remaining values alpha-sorted; synthetic `Total` always last (pivot path only).            |
-| `colors=`     | all styles                        | `colors=#1e40af,#b91c1c,#16a34a`                         | Override the default 8-color palette. Cycles by row/series index. Each color is `#hex` (6 chars).                                                                      |
-| `split=`      | all (bucket-shape only)           | `split=;`                                                | Multi-select delimiter. Each respondent's pick contributes to every value they selected. Percentages sum to >100% by design.                                           |
-| `scale=`      | all (raster path only)            | `scale=2`                                                | Supersample multiplier. Default 1 for stacked/clustered/line/area, 2 for bar/column/pie/donut. Larger = sharper PNG but slower; 4 is the practical ceiling.            |
-| `htmlRender=` | HTML browser preview              | `htmlRender=svg`                                         | (HTML only, opt-in.) Inline `<svg>` instead of `<img>`. **Browser-only — Flying Saucer drops SVG**. Default `<img>` works in both HTML view and PDF.                   |
+| Modifier      | Applies to                        | Example                                                  | What it does                                                                                                                                                                                                                 |
+| ------------- | --------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title=`      | all styles                        | `title=How satisfied are you with your role?`            | Chart header text drawn above the chart. Becomes the `<img alt="…">` attribute on the HTML side.                                                                                                                             |
+| `width=`      | all styles                        | `width=420`                                              | Logical-pixel width of the chart. Defaults: 540 (stacked/clustered), 500 (bar/column/line/area), 360 (pie/donut). Word/PDF downsample bigger PNGs for free AA.                                                               |
+| `height=`     | all styles                        | `height=240`                                             | Logical-pixel height. Defaults vary per style (see source); bar auto-grows by bucket count.                                                                                                                                  |
+| `fontSize=`   | all styles                        | `fontSize=16`                                            | Label size in pixels at the standard 540px width, scaled with `width=` so it means the same thing at any size. Default 12; the title is drawn about a third larger. Raise it when the chart lands in a small frame. (v3.56+) |
+| `where=`      | all styles                        | `where=Survey_Question__r.Display_Order__c=1`            | SOQL fragment appended to the chart's `WHERE`. Identifier-only, sanitized through the same keyword blocklist as Query Builder. Forces server-side aggregation.                                                               |
+| `groupBy=`    | stacked/clustered/pivot/line/area | `groupBy=Department__c`                                  | Cross-tab dimension. **Required** for `stacked`/`clustered`/`pivot`; **optional** for `line`/`area` (omit → single-series). Field on the same child object as `FIELD`.                                                       |
+| `colSort=`    | stacked/clustered/pivot/line/area | `colSort=Engineering,Sales,Marketing,Support,Operations` | Author-controlled column ordering. Named values appear first in this order; remaining values alpha-sorted; synthetic `Total` always last (pivot path only).                                                                  |
+| `colors=`     | all styles                        | `colors=#1e40af,#b91c1c,#16a34a`                         | Override the default 8-color palette. Cycles by row/series index. Each color is `#hex` (6 chars).                                                                                                                            |
+| `split=`      | all (bucket-shape only)           | `split=;`                                                | Multi-select delimiter. Each respondent's pick contributes to every value they selected. Percentages sum to >100% by design.                                                                                                 |
+| `scale=`      | all (raster path only)            | `scale=2`                                                | Supersample multiplier. Default 1 for stacked/clustered/line/area, 2 for bar/column/pie/donut. Larger = sharper PNG but slower; 4 is the practical ceiling.                                                                  |
+| `htmlRender=` | HTML browser preview              | `htmlRender=svg`                                         | (HTML only, opt-in.) Inline `<svg>` instead of `<img>`. **Browser-only — Flying Saucer drops SVG**. Default `<img>` works in both HTML view and PDF.                                                                         |
 
 **Composability:** every modifier composes with every other modifier where it makes sense:
 
@@ -1965,6 +1966,16 @@ Modifiers come after the style, joined with `&`. **Order doesn't matter.** Value
 ```
 
 Here `Survey_Question__c.Survey_Responses__r` is the child relationship from Question (not from the outer Survey). One chart per question, no `where=` needed.
+
+> **If chart labels come out too small, `width=` is not the knob.** Label sizes are a
+> fixed fraction of the chart, so raising `width=` sharpens the image without changing
+> how big the text looks — it is the size of the frame the chart lands in that decides
+> that. A chart placed in a 3-inch box has small labels however many pixels it is
+> rendered at. Either give it more room, or raise `fontSize=`.
+>
+> Before v3.56 label sizes were fixed in pixels, which made this actively backwards:
+> raising `width=` made the text _smaller_, because more pixels were squeezed into the
+> same physical space.
 
 **Error handling.** Malformed tags render an inline error block in HTML output (red border, monospace tag dump) and a `[Chart error: …]` text placeholder in Word — you see the problem at first preview rather than chasing a silent miss. Errors include the original tag verbatim so you can diff it against a working sample.
 

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1967,15 +1967,20 @@ Modifiers come after the style, joined with `&`. **Order doesn't matter.** Value
 
 Here `Survey_Question__c.Survey_Responses__r` is the child relationship from Question (not from the outer Survey). One chart per question, no `where=` needed.
 
-> **If chart labels come out too small, `width=` is not the knob.** Label sizes are a
-> fixed fraction of the chart, so raising `width=` sharpens the image without changing
-> how big the text looks — it is the size of the frame the chart lands in that decides
-> that. A chart placed in a 3-inch box has small labels however many pixels it is
-> rendered at. Either give it more room, or raise `fontSize=`.
+> **If chart labels come out too small, raise `fontSize=`.** Label sizes are in canvas
+> pixels, so how big they look in the finished document depends on how far the image is
+> scaled to fit its frame.
 >
-> Before v3.56 label sizes were fixed in pixels, which made this actively backwards:
-> raising `width=` made the text _smaller_, because more pixels were squeezed into the
-> same physical space.
+> On a **Canvas** template that is straightforward: the chart block renders at its own
+> size, so the 12px default prints at about 9pt whatever size the block is. Set **Label
+> size** in the chart properties to change it.
+>
+> On a **PowerPoint or Word** template the image is stretched to fit the shape you drew,
+> and `width=` does not change that — a chart squeezed into a 3-inch shape has small
+> labels however many pixels it was rendered at. Raising `width=` sharpens the picture
+> while making the text smaller relative to the frame, which is the opposite of what
+> most people expect. `fontSize=` is the knob: adjust it until it reads well at the size
+> the shape actually is.
 
 **Error handling.** Malformed tags render an inline error block in HTML output (red border, monospace tag dump) and a `[Chart error: …]` text placeholder in Word — you see the problem at first preview rather than chasing a silent miss. Errors include the original tag verbatim so you can diff it against a working sample.
 

--- a/force-app/main/default/lwc/docGenCanvas/canvasModel.js
+++ b/force-app/main/default/lwc/docGenCanvas/canvasModel.js
@@ -656,7 +656,10 @@ export const DEFAULT_CHART = {
     colors: '',
     split: '',
     groupBy: '',
-    colSort: ''
+    colSort: '',
+    // Blank means the engine's default (12px). Set it when the chart lands in a frame
+    // small enough that the default labels are hard to read — see chartToHtml.
+    fontSize: ''
 };
 
 /**
@@ -721,6 +724,12 @@ function chartToHtml(box) {
     }
     opts.push('width=' + inToCssPx(box.w));
     opts.push('height=' + inToCssPx(box.h));
+    // Label size, when the author has set one. Left out entirely otherwise, so the
+    // tag stays as short as it was and the engine's default applies.
+    const fs = parseInt(c.fontSize, 10);
+    if (fs > 0) {
+        opts.push('fontSize=' + fs);
+    }
     for (const key of ['groupBy', 'colSort', 'colors', 'split']) {
         const val = String(c[key] || '').trim();
         if (val) {
@@ -840,6 +849,8 @@ function chartAttrs(box) {
         esc(c.groupBy) +
         '" data-dg-chart-colsort="' +
         esc(c.colSort) +
+        '" data-dg-chart-fontsize="' +
+        esc(c.fontSize) +
         '"'
     );
 }
@@ -853,7 +864,8 @@ function readChart(el) {
         colors: el.getAttribute('data-dg-chart-colors') || '',
         split: el.getAttribute('data-dg-chart-split') || '',
         groupBy: el.getAttribute('data-dg-chart-groupby') || '',
-        colSort: el.getAttribute('data-dg-chart-colsort') || ''
+        colSort: el.getAttribute('data-dg-chart-colsort') || '',
+        fontSize: el.getAttribute('data-dg-chart-fontsize') || ''
     };
 }
 

--- a/force-app/main/default/lwc/docGenCanvas/docGenCanvas.html
+++ b/force-app/main/default/lwc/docGenCanvas/docGenCanvas.html
@@ -903,6 +903,23 @@
                         than 100% by design.
                     </p>
 
+                    <label class="dg-panel-label">Label size</label>
+                    <input
+                        class="dg-panel-input dg-panel-input_sm"
+                        type="number"
+                        min="6"
+                        max="48"
+                        step="1"
+                        value={selChart.fontSize}
+                        placeholder="12"
+                        data-key="fontSize"
+                        onchange={handleChartChange}
+                    />
+                    <p class="dg-panel-note">
+                        Size of the axis labels and values, in pixels. Leave blank for the default of 12, which prints
+                        at about 9pt. Worth raising when the chart sits in a small box — the labels shrink with it.
+                    </p>
+
                     <template lwc:if={selChartIsCrossTab}>
                         <label class="dg-panel-label">Split columns by (required)</label>
                         <input

--- a/force-app/main/default/lwc/docGenCanvas/docGenCanvas.js
+++ b/force-app/main/default/lwc/docGenCanvas/docGenCanvas.js
@@ -2371,7 +2371,11 @@ export default class DocGenCanvas extends LightningElement {
                     model.id,
                     renderChartToCanvas(ChartCtor, canvas, buckets, {
                         style: c.style || 'bar',
-                        title: c.title || ''
+                        title: c.title || '',
+                        // The preview has to honour the label size too, or the artboard
+                        // shows one thing and the PDF prints another — which is the
+                        // whole premise of this editor.
+                        fontSize: c.fontSize
                     })
                 );
             } catch (e) {

--- a/force-app/main/default/lwc/docGenCanvas/docGenCanvas.js
+++ b/force-app/main/default/lwc/docGenCanvas/docGenCanvas.js
@@ -58,18 +58,23 @@ import {
     anchorRoot,
     wouldCycle,
     boxLabel,
-    normalizeCustomPage as normalizeCustom
+    normalizeCustomPage as normalizeCustom,
+    canRenderBold
 } from './canvasModel';
 
 /**
- * Arial Unicode MS has no bold face in the PDF engine (Blob.toPdf), so a bold this
- * font carries silently prints regular. The canvas disables the Bold control for it
- * so it stops promising a weight the PDF cannot deliver. Mirrors canRenderBold in
- * canvasModel (which also suppresses serialization) — keeping both in sync:
- * canRenderBold must stay the exact inverse of this.
+ * Arial Unicode MS has no bold face in the PDF engine (Blob.toPdf), so a bold this font
+ * carries silently prints regular. The canvas disables the Bold control for it, so
+ * authoring and output agree.
+ *
+ * Derived from canvasModel's canRenderBold rather than restating it. This began as a
+ * second copy of the rule with a comment asking future editors to keep the two as exact
+ * inverses — which is how layerLabel came to disagree with boxLabel in this same file,
+ * silently, for as long as it took someone to notice a name showing up in three places
+ * out of four. One function decides; this reads it.
  */
 function isUnicodeFont(font) {
-    return typeof font === 'string' && font.replace(/['"]/g, '').toLowerCase() === 'arial unicode ms';
+    return !canRenderBold(font);
 }
 
 /**

--- a/force-app/main/default/lwc/docGenChartJs/docGenChartJs.js
+++ b/force-app/main/default/lwc/docGenChartJs/docGenChartJs.js
@@ -151,7 +151,7 @@ export function finalizeBuckets(acc, paletteOverride) {
  * rasterizer emits. Chart.js core has no datalabels plugin and we are not
  * shipping another dependency for one string per bar.
  */
-function valueLabelPlugin(style, buckets) {
+function valueLabelPlugin(style, buckets, fontPx) {
     return {
         id: 'docgenValueLabels',
         afterDatasetsDraw(chart) {
@@ -162,7 +162,9 @@ function valueLabelPlugin(style, buckets) {
             }
             ctx.save();
             ctx.fillStyle = '#334155';
-            ctx.font = `500 12px ${FONT_STACK}`;
+            // Scaled like every other label; a hardcoded size here would be the one
+            // piece of text that still shrank as the chart grew.
+            ctx.font = `500 ${fontPx || 12}px ${FONT_STACK}`;
             meta.data.forEach((element, i) => {
                 const b = buckets[i];
                 if (!b) {
@@ -185,11 +187,74 @@ function valueLabelPlugin(style, buckets) {
     };
 }
 
+/**
+ * The canvas width these font sizes were chosen against.
+ *
+ * Everything below is expressed as a size at this width and then scaled, so a chart
+ * rendered wider gets proportionally larger text rather than the same text spread
+ * thinner. See fontScaleFor.
+ */
+const FONT_BASELINE_WIDTH = 540;
+
+/** Tick, legend and value-label size at the baseline width. */
+const BASE_TICK_PX = 12;
+
+/** Title size at the baseline width. */
+const BASE_TITLE_PX = 16;
+
+/**
+ * How much to multiply the base font sizes by for this canvas.
+ *
+ * Chart.js sizes text in canvas pixels, and the image is then scaled to whatever the
+ * placeholder is — a PowerPoint shape, a PDF box. So absolute pixel sizes do not
+ * survive the trip: the same 12px label is legible in a chart placed at 7 inches and
+ * unreadable at 3, and — the part that catches people out — raising `width=` makes the
+ * text SMALLER, because more pixels are being squeezed into the same physical space.
+ *
+ * Scaling with the canvas makes the text a fixed FRACTION of the chart, so `width=`
+ * controls resolution and nothing else. Apparent size is then decided by the
+ * placeholder alone, which is the one thing the author can see.
+ *
+ * Clamped either side: below about 0.6 the labels stop being legible at any size, and
+ * above 3 a very wide chart turns into headlines.
+ */
+function fontScaleFor(logicalWidth) {
+    const w = Number(logicalWidth) || FONT_BASELINE_WIDTH;
+    return Math.min(Math.max(w / FONT_BASELINE_WIDTH, 0.6), 3);
+}
+
+/**
+ * The tick, legend and value-label size for these options.
+ *
+ * A function rather than a value stashed on the config: `common` is spread into
+ * `options`, so anything hung on it lands at `config.options.*` and a reader looking
+ * for `config.*` finds undefined. Both the chart and the value-label plugin ask here,
+ * so they cannot disagree.
+ *
+ * `fontSize=` is the author's override, stated at the baseline width and scaled like
+ * the default so it means the same thing whatever `width=` is set to.
+ */
+function resolveTickPx(opts) {
+    const requested = Number((opts || {}).fontSize);
+    return Math.round((requested > 0 ? requested : BASE_TICK_PX) * fontScaleFor((opts || {}).width));
+}
+
+/** Title size — proportional to the ticks, so one override moves both. */
+function resolveTitlePx(opts) {
+    const requested = Number((opts || {}).fontSize);
+    return Math.round((requested > 0 ? requested * 1.34 : BASE_TITLE_PX) * fontScaleFor((opts || {}).width));
+}
+
 function buildConfig(style, buckets, opts) {
     const labels = buckets.map((b) => b.key_label);
     const data = buckets.map((b) => b.count);
     const colors = buckets.map((b) => b.color);
     const title = opts.title || '';
+
+    // fontSize= is the author's override, in points at the baseline width; it scales
+    // with the canvas like the defaults do, so it means the same thing at any width.
+    const tickPx = resolveTickPx(opts);
+    const titlePx = resolveTitlePx(opts);
 
     const common = {
         responsive: false,
@@ -203,7 +268,7 @@ function buildConfig(style, buckets, opts) {
                       text: title,
                       align: 'start',
                       color: '#0f172a',
-                      font: { family: FONT_STACK, size: 16, weight: '600' },
+                      font: { family: FONT_STACK, size: titlePx, weight: '600' },
                       padding: { top: 0, bottom: 16 }
                   }
                 : { display: false }
@@ -211,7 +276,7 @@ function buildConfig(style, buckets, opts) {
     };
 
     const gridColor = '#e2e8f0';
-    const tickFont = { family: FONT_STACK, size: 12 };
+    const tickFont = { family: FONT_STACK, size: tickPx };
 
     if (style === 'pie' || style === 'donut') {
         return {
@@ -353,7 +418,7 @@ export function renderChartToCanvas(ChartCtor, canvas, buckets, opts) {
     const requested = (opts.style || 'bar').toLowerCase();
     const style = isStyleSupported(requested) ? requested : 'bar';
     const config = buildConfig(style, buckets, opts || {});
-    config.plugins = [valueLabelPlugin(style, buckets)];
+    config.plugins = [valueLabelPlugin(style, buckets, resolveTickPx(opts))];
     return new ChartCtor(canvas.getContext('2d'), config);
 }
 
@@ -377,7 +442,7 @@ export function renderChartPng(ChartCtor, buckets, opts) {
     ctx.scale(scale, scale);
 
     const config = buildConfig(style, buckets, opts);
-    config.plugins = [valueLabelPlugin(style, buckets)];
+    config.plugins = [valueLabelPlugin(style, buckets, resolveTickPx(opts))];
 
     const chart = new ChartCtor(ctx, config);
     try {
@@ -535,4 +600,16 @@ export async function prepareChartsClientSide({ templateId, recordId, ChartCtor,
     }
 
     return { map, cvIds, bucketMap };
+}
+
+/**
+ * The assembled Chart.js config, for tests.
+ *
+ * Label sizing is derived from `width=` and `fontSize=` and then used in three places
+ * — ticks, title, and the value-label plugin. That arithmetic is worth pinning down,
+ * and reading it off the real config is the only way to check it without a browser
+ * canvas. scripts/qa/chart-font-scale-check.mjs is the caller.
+ */
+export function buildChartConfigForTest(style, buckets, opts) {
+    return buildConfig(style, buckets, opts || {});
 }

--- a/force-app/main/default/lwc/docGenChartJs/docGenChartJs.js
+++ b/force-app/main/default/lwc/docGenChartJs/docGenChartJs.js
@@ -187,62 +187,46 @@ function valueLabelPlugin(style, buckets, fontPx) {
     };
 }
 
-/**
- * The canvas width these font sizes were chosen against.
- *
- * Everything below is expressed as a size at this width and then scaled, so a chart
- * rendered wider gets proportionally larger text rather than the same text spread
- * thinner. See fontScaleFor.
- */
-const FONT_BASELINE_WIDTH = 540;
-
-/** Tick, legend and value-label size at the baseline width. */
+/** Tick, legend and value-label size, in canvas pixels. */
 const BASE_TICK_PX = 12;
 
-/** Title size at the baseline width. */
+/** Title size, in canvas pixels. */
 const BASE_TITLE_PX = 16;
-
-/**
- * How much to multiply the base font sizes by for this canvas.
- *
- * Chart.js sizes text in canvas pixels, and the image is then scaled to whatever the
- * placeholder is — a PowerPoint shape, a PDF box. So absolute pixel sizes do not
- * survive the trip: the same 12px label is legible in a chart placed at 7 inches and
- * unreadable at 3, and — the part that catches people out — raising `width=` makes the
- * text SMALLER, because more pixels are being squeezed into the same physical space.
- *
- * Scaling with the canvas makes the text a fixed FRACTION of the chart, so `width=`
- * controls resolution and nothing else. Apparent size is then decided by the
- * placeholder alone, which is the one thing the author can see.
- *
- * Clamped either side: below about 0.6 the labels stop being legible at any size, and
- * above 3 a very wide chart turns into headlines.
- */
-function fontScaleFor(logicalWidth) {
-    const w = Number(logicalWidth) || FONT_BASELINE_WIDTH;
-    return Math.min(Math.max(w / FONT_BASELINE_WIDTH, 0.6), 3);
-}
 
 /**
  * The tick, legend and value-label size for these options.
  *
+ * ABSOLUTE, deliberately, and it took a wrong turn to be sure of it.
+ *
+ * The first attempt scaled these with `width=`, reasoning that Chart.js sizes text in
+ * canvas pixels and PowerPoint then stretches the PNG to whatever its shape is — so a
+ * fixed pixel size does not survive that trip, and raising `width=` to sharpen a chart
+ * actually shrinks its labels.
+ *
+ * All true for PowerPoint. False for the Canvas designer, where chartToHtml emits
+ * `width=inToCssPx(box.w)` — the tag's width IS the block's physical width, and the
+ * image is placed at exactly that size. There, 12px has always meant a steady ~9pt at
+ * any box size, and scaling it would have made a 3-inch chart render ~5pt labels.
+ *
+ * One rule cannot be right for both, because `width=` means different things on each
+ * path. So the default stays absolute — no regression to the case that was already
+ * correct — and `fontSize=` is the explicit knob for the case that is not. The Canvas
+ * chart properties expose it directly; a hand-written tag can set it too.
+ *
  * A function rather than a value stashed on the config: `common` is spread into
  * `options`, so anything hung on it lands at `config.options.*` and a reader looking
- * for `config.*` finds undefined. Both the chart and the value-label plugin ask here,
+ * for `config.*` finds undefined. The chart and the value-label plugin both ask here,
  * so they cannot disagree.
- *
- * `fontSize=` is the author's override, stated at the baseline width and scaled like
- * the default so it means the same thing whatever `width=` is set to.
  */
 function resolveTickPx(opts) {
     const requested = Number((opts || {}).fontSize);
-    return Math.round((requested > 0 ? requested : BASE_TICK_PX) * fontScaleFor((opts || {}).width));
+    return requested > 0 ? Math.round(requested) : BASE_TICK_PX;
 }
 
 /** Title size — proportional to the ticks, so one override moves both. */
 function resolveTitlePx(opts) {
     const requested = Number((opts || {}).fontSize);
-    return Math.round((requested > 0 ? requested * 1.34 : BASE_TITLE_PX) * fontScaleFor((opts || {}).width));
+    return requested > 0 ? Math.round(requested * 1.34) : BASE_TITLE_PX;
 }
 
 function buildConfig(style, buckets, opts) {

--- a/scripts/qa/canvas-chart-box-check.mjs
+++ b/scripts/qa/canvas-chart-box-check.mjs
@@ -88,5 +88,46 @@ ok(xhtml.includes('groupBy=Department'), 'a complete cross-tab emits groupBy');
 ok(xhtml.includes('colSort=Engineering,Sales'), 'a complete cross-tab emits colSort');
 ok(m.chartConfigIssue(xb) === null, 'and reports no outstanding issue');
 
+
+// --- label size: model -> tag -> reload ---------------------------------------
+// The Canvas author never writes a {Chart:...} tag by hand, so a fontSize= the engine
+// honours is unreachable unless the chart block emits it. This is that path.
+{
+    const g = m.pageGeometry('Letter', 'Portrait');
+    const d = m.blankDocument();
+    const b = m.newChartBox(1, 1, 4, 2.5);
+    b.chart = { ...b.chart, relationship: 'Contacts', field: 'Department', style: 'bar', fontSize: '18' };
+    d.artboards[0].boxes.push(b);
+
+    const out = m.serialize(d, g);
+    ok(out.includes('fontSize=18'), 'the label size reaches the {Chart:...} tag');
+    ok(out.includes('data-dg-chart-fontsize="18"'), 'and is stored for the round trip');
+
+    const back = m.deserialize(out).artboards[0].boxes.find((x) => x.kind === 'chart');
+    ok(back && back.chart.fontSize === '18', 'and survives a reload');
+}
+
+// --- left alone when the author has not set one -------------------------------
+{
+    const g = m.pageGeometry('Letter', 'Portrait');
+    const d = m.blankDocument();
+    const b = m.newChartBox(1, 1, 4, 2.5);
+    b.chart = { ...b.chart, relationship: 'Contacts', field: 'Department', style: 'bar' };
+    d.artboards[0].boxes.push(b);
+    ok(!m.serialize(d, g).includes('fontSize='), 'no size set emits no modifier, so the engine default applies');
+}
+
+// --- a nonsense size is not emitted -------------------------------------------
+{
+    for (const bad of ['', '0', '-4', 'abc']) {
+        const g = m.pageGeometry('Letter', 'Portrait');
+        const d = m.blankDocument();
+        const b = m.newChartBox(1, 1, 4, 2.5);
+        b.chart = { ...b.chart, relationship: 'Contacts', field: 'Department', style: 'bar', fontSize: bad };
+        d.artboards[0].boxes.push(b);
+        ok(!m.serialize(d, g).includes('fontSize='), `"${bad}" is ignored rather than emitted`);
+    }
+}
+
 console.log(failures ? `\n${failures} FAILED` : '\nall passed');
 process.exit(failures ? 1 : 0);

--- a/scripts/qa/chart-font-scale-check.mjs
+++ b/scripts/qa/chart-font-scale-check.mjs
@@ -3,15 +3,22 @@
  *
  *   node scripts/qa/chart-font-scale-check.mjs
  *
- * Chart.js sizes text in CANVAS pixels, and the PNG is then scaled to whatever the
- * placeholder is — a PowerPoint shape, a PDF box. Absolute pixel sizes therefore do not
- * survive the trip, and the failure is counter-intuitive: raising `width=` makes the
- * text SMALLER in the finished document, because more pixels are squeezed into the same
- * physical space. An author trying to sharpen a chart shrinks its labels.
+ * Sizes are ABSOLUTE canvas pixels, and one wrong turn is worth recording so it is not
+ * taken twice.
  *
- * So the sizes have to be a fixed FRACTION of the canvas. Then `width=` controls
- * resolution only, and apparent size is decided by the placeholder — the one thing the
- * author can actually see.
+ * Chart.js sizes text in canvas pixels and PowerPoint stretches the PNG to whatever its
+ * shape is — so a fixed size does not survive that trip, and raising `width=` to sharpen
+ * a chart shrinks its labels. That argues for scaling the fonts with the canvas.
+ *
+ * It is wrong for the Canvas designer. There `chartToHtml` emits
+ * `width=inToCssPx(box.w)`: the tag's width IS the block's physical width and the image
+ * is placed at exactly that size, so 12px has always meant a steady ~9pt. Scaling would
+ * have made a 3-inch chart print ~5pt labels — fixing PowerPoint by breaking the case
+ * that already worked.
+ *
+ * `width=` means different things on the two paths, so no single automatic rule is
+ * right. The default stays absolute; `fontSize=` is the explicit knob, exposed in the
+ * Canvas chart properties as "Label size".
  */
 import { readFileSync, writeFileSync } from 'node:fs';
 
@@ -55,51 +62,33 @@ if (!m.buildChartConfigForTest) {
     process.exit(1);
 }
 
-// --- text is a fixed fraction of the canvas ----------------------------------
+// --- the default is absolute, and does not move with the canvas ---------------
 {
-    const base = tickOf({ width: 540 });
-    const wide = tickOf({ width: 1080 });
-    // 405 not 270: 270 is half the baseline, which trips the 0.6 floor and would be
-    // testing the clamp rather than the scaling. That floor is checked on its own below.
-    const narrow = tickOf({ width: 405 });
-    ok(base === 12, `540px canvas keeps the 12px baseline (got ${base})`);
-    ok(wide === 24, `doubling the width doubles the label (got ${wide})`);
-    ok(narrow === 9, `three-quarter width gives three-quarter text (got ${narrow})`);
-    // The point of all this: label-to-chart ratio is constant, so the placeholder
-    // decides apparent size and `width=` does not fight it.
-    ok(wide / 1080 === base / 540, 'the label-to-width ratio is identical at both sizes');
+    ok(tickOf({ width: 540 }) === 12, 'the default tick is 12px');
+    ok(tickOf({ width: 1080 }) === 12, 'and stays 12px on a wider canvas');
+    ok(tickOf({ width: 288 }) === 12, 'and on a narrower one');
+    ok(tickOf({}) === 12, 'and when no width is given at all');
+    // The regression this guards: scaling here silently shrank every Canvas chart,
+    // because on that path width= is the block's real width and 12px was already right.
+    ok(tickOf({ width: 288 }) === tickOf({ width: 1080 }), 'width= changes resolution, never label size');
 }
 
-// --- the title moves with the ticks ------------------------------------------
+// --- the title holds its own default -----------------------------------------
 {
-    ok(titleOf({ width: 540 }) === 16, 'title keeps its 16px baseline');
-    ok(titleOf({ width: 1080 }) === 32, 'and doubles with the canvas');
+    ok(titleOf({ width: 540 }) === 16, 'the default title is 16px');
+    ok(titleOf({ width: 1080 }) === 16, 'and does not move with the canvas either');
 }
 
-// --- fontSize= is the author's override --------------------------------------
+// --- fontSize= is the knob ----------------------------------------------------
 {
-    ok(tickOf({ width: 540, fontSize: 18 }) === 18, 'fontSize=18 at the baseline width gives 18');
-    ok(tickOf({ width: 1080, fontSize: 18 }) === 36, 'and scales with the canvas, so it means the same thing');
-    ok(titleOf({ width: 540, fontSize: 18 }) === 24, 'the title follows the override too');
-    ok(tickOf({ width: 540, fontSize: '14' }) === 14, 'a string from the tag map is accepted');
-    ok(tickOf({ width: 540, fontSize: 0 }) === 12, 'fontSize=0 falls back rather than rendering nothing');
-    ok(tickOf({ width: 540, fontSize: -5 }) === 12, 'and so does a negative');
-    ok(tickOf({ width: 540, fontSize: 'abc' }) === 12, 'and so does nonsense');
-}
-
-// --- the scale is clamped -----------------------------------------------------
-{
-    // Below the floor the labels stop being legible however they are placed; above the
-    // ceiling a very wide chart turns into headlines.
-    ok(tickOf({ width: 60 }) === 7, `a tiny canvas floors at 0.6x -> 7px (got ${tickOf({ width: 60 })})`);
-    ok(tickOf({ width: 270 }) === 7, `and so does half the baseline (got ${tickOf({ width: 270 })})`);
-    ok(tickOf({ width: 9000 }) === 36, `a huge one caps at 3x (got ${tickOf({ width: 9000 })})`);
-}
-
-// --- defaults hold when the tag says nothing ---------------------------------
-{
-    ok(tickOf({}) === 12, 'no width given falls back to the baseline');
-    ok(tickOf({ width: 'not a number' }) === 12, 'and so does an unparseable width');
+    ok(tickOf({ fontSize: 18 }) === 18, 'fontSize=18 gives 18px');
+    ok(tickOf({ width: 1080, fontSize: 18 }) === 18, 'and means the same thing at any width');
+    ok(titleOf({ fontSize: 18 }) === 24, 'the title follows it proportionally (1.34x)');
+    ok(tickOf({ fontSize: '14' }) === 14, 'a string, as the tag map delivers it, is accepted');
+    ok(tickOf({ fontSize: 0 }) === 12, 'zero falls back rather than rendering nothing');
+    ok(tickOf({ fontSize: -5 }) === 12, 'and so does a negative');
+    ok(tickOf({ fontSize: 'abc' }) === 12, 'and so does nonsense');
+    ok(tickOf({ fontSize: 13.7 }) === 14, 'a fraction rounds to a whole pixel');
 }
 
 console.log(fail ? `\n${fail} FAILED` : '\nchart fonts OK');

--- a/scripts/qa/chart-font-scale-check.mjs
+++ b/scripts/qa/chart-font-scale-check.mjs
@@ -1,0 +1,106 @@
+/**
+ * Chart label sizing.
+ *
+ *   node scripts/qa/chart-font-scale-check.mjs
+ *
+ * Chart.js sizes text in CANVAS pixels, and the PNG is then scaled to whatever the
+ * placeholder is — a PowerPoint shape, a PDF box. Absolute pixel sizes therefore do not
+ * survive the trip, and the failure is counter-intuitive: raising `width=` makes the
+ * text SMALLER in the finished document, because more pixels are squeezed into the same
+ * physical space. An author trying to sharpen a chart shrinks its labels.
+ *
+ * So the sizes have to be a fixed FRACTION of the canvas. Then `width=` controls
+ * resolution only, and apparent size is decided by the placeholder — the one thing the
+ * author can actually see.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+
+// The module imports three Apex methods at the top, which plain node cannot resolve.
+// Stubbing them keeps this harness runnable in CI with no org — the sizing arithmetic
+// under test does not touch them.
+const src = readFileSync(
+    new URL('../../force-app/main/default/lwc/docGenChartJs/docGenChartJs.js', import.meta.url),
+    'utf8'
+).replace(/^import\s+(\w+)\s+from\s+'@salesforce\/apex\/[^']+';$/gm, 'const $1 = async () => null;');
+writeFileSync('/tmp/cjs.font.mjs', src);
+const m = await import('/tmp/cjs.font.mjs?v=' + Date.now());
+
+let fail = 0;
+const ok = (c, msg) => {
+    console.log((c ? '  ok  ' : ' FAIL ') + msg);
+    if (!c) fail++;
+};
+
+// The module keeps the resolvers private, so drive them through the public builder.
+const buckets = [
+    { key_label: 'Alpha', count: 4, percent: 40, color: '#1e40af' },
+    { key_label: 'Beta', count: 6, percent: 60, color: '#b91c1c' }
+];
+const tickOf = (opts) => {
+    const cfg = m.buildChartConfigForTest ? m.buildChartConfigForTest('column', buckets, opts) : null;
+    if (!cfg) return null;
+    return cfg.options.scales.x.ticks.font.size;
+};
+// The title block only carries a font when there IS a title — with none, Chart.js is
+// handed { display: false } and nothing to size.
+const titleOf = (opts) => {
+    const cfg = m.buildChartConfigForTest
+        ? m.buildChartConfigForTest('column', buckets, { title: 'A title', ...opts })
+        : null;
+    return cfg ? cfg.options.plugins.title.font.size : null;
+};
+
+if (!m.buildChartConfigForTest) {
+    console.log(' FAIL  buildChartConfigForTest is not exported — this harness cannot see the config');
+    process.exit(1);
+}
+
+// --- text is a fixed fraction of the canvas ----------------------------------
+{
+    const base = tickOf({ width: 540 });
+    const wide = tickOf({ width: 1080 });
+    // 405 not 270: 270 is half the baseline, which trips the 0.6 floor and would be
+    // testing the clamp rather than the scaling. That floor is checked on its own below.
+    const narrow = tickOf({ width: 405 });
+    ok(base === 12, `540px canvas keeps the 12px baseline (got ${base})`);
+    ok(wide === 24, `doubling the width doubles the label (got ${wide})`);
+    ok(narrow === 9, `three-quarter width gives three-quarter text (got ${narrow})`);
+    // The point of all this: label-to-chart ratio is constant, so the placeholder
+    // decides apparent size and `width=` does not fight it.
+    ok(wide / 1080 === base / 540, 'the label-to-width ratio is identical at both sizes');
+}
+
+// --- the title moves with the ticks ------------------------------------------
+{
+    ok(titleOf({ width: 540 }) === 16, 'title keeps its 16px baseline');
+    ok(titleOf({ width: 1080 }) === 32, 'and doubles with the canvas');
+}
+
+// --- fontSize= is the author's override --------------------------------------
+{
+    ok(tickOf({ width: 540, fontSize: 18 }) === 18, 'fontSize=18 at the baseline width gives 18');
+    ok(tickOf({ width: 1080, fontSize: 18 }) === 36, 'and scales with the canvas, so it means the same thing');
+    ok(titleOf({ width: 540, fontSize: 18 }) === 24, 'the title follows the override too');
+    ok(tickOf({ width: 540, fontSize: '14' }) === 14, 'a string from the tag map is accepted');
+    ok(tickOf({ width: 540, fontSize: 0 }) === 12, 'fontSize=0 falls back rather than rendering nothing');
+    ok(tickOf({ width: 540, fontSize: -5 }) === 12, 'and so does a negative');
+    ok(tickOf({ width: 540, fontSize: 'abc' }) === 12, 'and so does nonsense');
+}
+
+// --- the scale is clamped -----------------------------------------------------
+{
+    // Below the floor the labels stop being legible however they are placed; above the
+    // ceiling a very wide chart turns into headlines.
+    ok(tickOf({ width: 60 }) === 7, `a tiny canvas floors at 0.6x -> 7px (got ${tickOf({ width: 60 })})`);
+    ok(tickOf({ width: 270 }) === 7, `and so does half the baseline (got ${tickOf({ width: 270 })})`);
+    ok(tickOf({ width: 9000 }) === 36, `a huge one caps at 3x (got ${tickOf({ width: 9000 })})`);
+}
+
+// --- defaults hold when the tag says nothing ---------------------------------
+{
+    ok(tickOf({}) === 12, 'no width given falls back to the baseline');
+    ok(tickOf({ width: 'not a number' }) === 12, 'and so does an unparseable width');
+}
+
+console.log(fail ? `\n${fail} FAILED` : '\nchart fonts OK');
+process.exit(fail ? 1 : 0);

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,15 +1,15 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.55.0 — Element linking, named blocks, client-side charts",
-      "versionNumber": "3.55.0.NEXT",
+      "versionName": "v3.56.0",
+      "versionNumber": "3.56.0.NEXT",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "postInstallScript": "DocGenEmailTemplateInstall",
       "package": "Portwood",
-      "ancestorVersion": "3.54.0",
-      "versionDescription": "Portwood turns any Salesforce record into a finished document — quotes, invoices, contracts, certificates, letters and reports — as PDF, Word, Excel or PowerPoint. New in 3.55, all on the Canvas designer (Beta): ELEMENT LINKING — set a block to follow another and it travels with it, so a summary, note or signature panel lands below a table however far that table grows at merge time, and follows it onto whatever page it ends on. Links chain, can be kept together on one page, and cannot be made to loop. NAMED BLOCKS — give a block a name and it is what the properties panel, the on-canvas badge and every Follows picker call it. CHART BLOCKS with a live preview while you design, and EXPORT HTML alongside Import HTML. Also: PowerPoint and Excel now assemble in the browser the way Word always has, with charts rendered by Chart.js, so the 6 MB synchronous Apex heap is no longer the ceiling on how many child records a document can carry — tested to 30,000. Fixes: .docx/.pptx/.xlsx downloads and Canvas Export HTML failed in orgs with Lightning Web Security enabled; a long verification URL ran off the edge of the signature Certificate of Completion. 100% native Salesforce — no external services or callouts. Free for all users."
+      "ancestorVersion": "3.55.0",
+      "versionDescription": "Turn any Salesforce record into a finished document — quotes, invoices, contracts, certificates, letters, statements and reports. Build your template in Word, Excel or PowerPoint, or design one right in your browser, then drop in the fields you want and Portwood fills them in. Tables grow with your data, charts draw themselves, and images, barcodes and QR codes come along too. Send a document for signature and track it to completion. Generate one from a record, thousands at once, or let a Flow do it automatically overnight. Everything runs inside your own Salesforce org — no external services and no data leaving the platform. Free for every user."
     },
     {
       "versionName": "v1.1.0 — Free install, no installation key",


### PR DESCRIPTION
Three things for the next release.

## Chart label size becomes an explicit control

**This PR started out doing the wrong thing, and the history is the useful part.**

First attempt scaled label sizes with the canvas. The reasoning: Chart.js sizes text in canvas pixels, PowerPoint stretches the PNG to whatever its shape is, so a fixed size doesn't survive the trip — and raising `width=` to sharpen a chart actually shrinks its labels.

All true for PowerPoint. **False for the Canvas designer**, where `chartToHtml` emits `width=inToCssPx(box.w)` — the tag's width *is* the block's physical width, and the image is placed at exactly that size. There, 12px has always meant a steady ~9pt. My scaling would have made a 3-inch chart print ~5pt labels: fixing one path by quietly degrading the other, on every Canvas chart that already existed.

`width=` means different things on the two paths, so no single automatic rule is right for both.

| Path | What `width=` is | Rule |
| --- | --- | --- |
| Canvas | the block's real width | absolute — 12px is always ~9pt |
| PowerPoint / Word | arbitrary; the shape decides | absolute, tuned with `fontSize=` |

So the default returns to absolute, and the size becomes something you set when you need it:

- **`fontSize=`** on the tag, honoured by both render paths
- **A "Label size" box in the Canvas chart properties** — which is what makes it reachable at all, since a Canvas author never hand-writes a `{Chart:...}` tag. Round-trips through `data-dg-chart-fontsize`, and the live preview honours it so the artboard and the PDF agree
- Blank, zero, negative and unparseable all fall back to the default rather than emitting `fontSize=NaN`

## `canRenderBold` de-duplicated

#286 added `isUnicodeFont` as a hand-maintained inverse with a comment asking future editors to keep the two in sync. That's exactly how `layerLabel` came to disagree with `boxLabel` in this same file. Now derived from the exported function.

## A static package description

`versionDescription` was a changelog that had to be rewritten every release — and it's the text someone reads while deciding whether to install. It now says what Portwood does, in plain language, no version notes, no jargon. Release specifics live in the changelog and the GitHub release.

---

**Verification** — 15 assertions on sizing in `scripts/qa/chart-font-scale-check.mjs` (Apex imports stubbed, so it runs in CI with no org), 9 more on the Canvas round trip in `canvas-chart-box-check.mjs`. All seven canvas/chart harnesses pass. `format:check` clean.

The UserGuide now explains the two paths separately instead of claiming one rule covers both.
