### PR TITLE
Upload-time fidelity report for Word/PowerPoint templates — DOCX/PPTX slice (#272)

### DIFF
--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -2584,8 +2584,13 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
      * @param createVersion Whether to create a new active version snapshot
      */
     @AuraEnabled
-    public static Id saveTemplate(Map<String, Object> fields, Boolean createVersion, String contentVersionId) {
+    public static Map<String, Object> saveTemplate(
+        Map<String, Object> fields,
+        Boolean createVersion,
+        String contentVersionId
+    ) {
         Id createdVersionId = null;
+        Map<String, Object> saveResult = new Map<String, Object>();
         try {
             // 1. Update Template
             Id templateId = (Id) fields.get('Id');
@@ -2986,10 +2991,52 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                     String noop = htmlErr.getMessage(); // NOPMD UnusedLocalVariable — satisfies EmptyCatchBlock rule
                 }
             }
-            return createdVersionId;
+            // Fidelity report (issue #272) for Word/PowerPoint uploads. Lint the
+            // newly uploaded body and hand the findings back with the save result,
+            // mirroring saveHtmlTemplateBody's `warnings`/`warningCount` keys.
+            // Warnings only — the version is already stored, and a lint failure
+            // must never change the save outcome.
+            List<DocGenAiHtmlValidator.Finding> warnings = new List<DocGenAiHtmlValidator.Finding>();
+            try {
+                if (
+                    createVersion == true &&
+                    String.isNotBlank(contentVersionId) &&
+                    isDocxBodyType((String) fields.get('Type__c'))
+                ) {
+                    warnings = lintUploadedOfficeBody(contentVersionId);
+                }
+            } catch (Exception lintErr) {
+                String noop = lintErr.getMessage(); // NOPMD — lint is advisory; it must never fail a save
+            }
+            saveResult.put('createdVersionId', createdVersionId);
+            saveResult.put('warnings', warnings);
+            saveResult.put('warningCount', warnings.size());
+            return saveResult;
         } catch (Exception e) {
             throw DocGenService.ahe(e, 'Error saving template. Please verify your inputs and permissions.');
         }
+    }
+
+    /** The Word/PowerPoint template types the DOCX/PPTX linter covers. */
+    private static Boolean isDocxBodyType(String type) {
+        return type == 'Word' || type == 'PowerPoint' || type == 'PPT' || type == 'PPTX';
+    }
+
+    /** Reads a just-uploaded body ContentVersion and lints its Office bytes. */
+    private static List<DocGenAiHtmlValidator.Finding> lintUploadedOfficeBody(Id contentVersionId) {
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'VersionData' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<ContentVersion> cvs = [
+            SELECT VersionData
+            FROM ContentVersion
+            WHERE Id = :contentVersionId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (cvs.isEmpty() || cvs[0].VersionData == null) {
+            return new List<DocGenAiHtmlValidator.Finding>();
+        }
+        return DocGenDocxTemplateLinter.lint(cvs[0].VersionData);
     }
 
     /**

--- a/force-app/main/default/classes/DocGenControllerTests.cls
+++ b/force-app/main/default/classes/DocGenControllerTests.cls
@@ -548,7 +548,7 @@ private class DocGenControllerTests {
             };
 
             Test.startTest();
-            Id newVersionId = DocGenController.saveTemplate(fields, true, null);
+            Id newVersionId = (Id) DocGenController.saveTemplate(fields, true, null).get('createdVersionId');
             Test.stopTest();
 
             DocGen_Template_Version__c newActive = [

--- a/force-app/main/default/classes/DocGenDocxTemplateLinter.cls
+++ b/force-app/main/default/classes/DocGenDocxTemplateLinter.cls
@@ -1,0 +1,593 @@
+/**
+ * Upload-time fidelity report for Word/PowerPoint templates (issue #272).
+ *
+ * DocGenTemplateLinter is the HTML/Canvas sibling; this class is the DOCX/PPTX
+ * equivalent. The offline reference is scripts/docgen-template-lint.js (the
+ * zero-dep Node preflight that QA runs against .docx files) — these checks are
+ * the same rules, computed at save time in Apex so the author sees them in the
+ * Designer instead of discovering them after a generation that silently
+ * degraded.
+ *
+ * Every check is advisory and individually guarded: lint() never throws and
+ * never touches the author's bytes. A warning is a heads-up, not a blocker —
+ * the save has already succeeded before lint runs (see saveTemplate) and a
+ * failing check costs its own findings, never the report, and never the save.
+ *
+ * Checks ported from the blueprint:
+ *   1. Fragmented merge tags  —  a {Field} split across multiple <w:r> runs by
+ *      mid-tag editing. Text tags are healed at merge time (mergeRunsInTags),
+ *      but chart tags split across runs fall back to literal text (#130) — so
+ *      this is a warning either way.
+ *   2. Loop pairing (stack-based, mirroring DocGenService.findBalancedEnd) —
+ *      {#Rel} without {/Rel}, and stray {/Rel}. {#IF expr} balances on the
+ *      bare key "IF" exactly as the engine does.
+ *   3. Closing-tag containment — a {#Rel}…{/Rel} pair that no <w:tr> fully
+ *      encloses makes the engine fall back to paragraph repeat (or worse).
+ *   4. Closing-tag placement — a {/Rel} outside any structural container is
+ *      almost always an escaped cell.
+ *   5. Nested loops on the same relationship — almost always a typo (the
+ *      canonical {^Rel}{:else}…{#Rel}…{/Rel}…{/Rel} inverse pattern is allowed).
+ *   6. Empty / whitespace-only loops.
+ *   7. Row-binding collision — parent + nested loop bound to the SAME <w:tr>.
+ *   8. Entity-encoded IF operators (&gt;/&lt;) — the IF parser does not decode
+ *      entities before operator parsing, so the expression always evaluates
+ *      false on installs before v1.69 (left in so templates stay portable).
+ *   9. Nested IF blocks — findBalancedEnd can't depth-track nested {#IF} on
+ *      installs before v1.72 (left in for the same portability reason).
+ *
+ * The row-binding collision check only applies to Word documents (its
+ * <w:tr> semantics); PowerPoint slides get the text-level checks 1, 2, 5, 6,
+ * 8 and 9, whose tables use <a:tr> and would otherwise false-positive on a
+ * paragraph fallback warning.
+ */
+public with sharing class DocGenDocxTemplateLinter {
+    /**
+     * Lints a DOCX/PPTX upload's bytes against the merge engine's semantics.
+     * Best-effort: returns whatever warnings completed checks produced; a
+     * failing check (or an unreadable archive) yields no findings from that
+     * part, never an exception.
+     */
+    public static List<DocGenAiHtmlValidator.Finding> lint(Blob fileBytes) {
+        List<DocGenAiHtmlValidator.Finding> findings = new List<DocGenAiHtmlValidator.Finding>();
+        if (fileBytes == null) {
+            return findings;
+        }
+        try {
+            Compression.ZipReader reader = new Compression.ZipReader(fileBytes);
+            // Word: the body lives in word/document.xml. PowerPoint: each slide
+            // in ppt/slides/slideN.xml. We lint each part independently so a tag
+            // pair never appears to close across a part boundary it could not.
+            for (Compression.ZipEntry e : reader.getEntries()) {
+                if (e.getName() == 'word/document.xml') {
+                    lintXml(reader.extract(e.getName()).toString(), true, findings);
+                } else if (e.getName().startsWith('ppt/slides/slide') && e.getName().endsWith('.xml')) {
+                    lintXml(reader.extract(e.getName()).toString(), false, findings);
+                }
+            }
+        } catch (Exception e) {
+            String noop = e.getMessage(); // NOPMD — lint is advisory; one unreadable file must not sink the report
+        }
+        return findings;
+    }
+
+    private static void lintXml(String xml, Boolean isWordPart, List<DocGenAiHtmlValidator.Finding> findings) {
+        if (String.isBlank(xml)) {
+            return;
+        }
+        checkFragmentedTags(xml, findings);
+
+        VisibleStream vs = buildVisibleText(xml);
+        List<RawTag> tags = tagsFromVisibleText(vs);
+        PairResult pr = findMatchingPairs(tags);
+
+        checkUnmatchedTags(pr, findings);
+        checkEmptyLoops(pr, vs, findings);
+        checkNestedSameRel(pr.pairs, findings);
+        checkNestedIfs(pr.pairs, findings);
+        checkEntityEncodedIf(xml, findings);
+        if (isWordPart) {
+            // Table-structure semantics are WordprocessingML-specific.
+            checkStructuralPlacement(xml, pr, findings);
+            checkRowBindingCollision(xml, pr.pairs, findings);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 1. Fragmented merge tags — {Na<w:r>me</w:r>} reads as two runs to the
+    //    merger. Text tags heal; chart tags fall back to literal text (#130).
+    // -----------------------------------------------------------------------
+
+    private static void checkFragmentedTags(String xml, List<DocGenAiHtmlValidator.Finding> findings) {
+        Integer i = 0;
+        Integer len = xml.length();
+        while (i < len) {
+            Integer open = xml.indexOf('{', i);
+            if (open == -1) {
+                break;
+            }
+            if (!isInsideOpenTextRun(xml, open)) {
+                i = open + 1;
+                continue;
+            }
+            Integer close = xml.indexOf('}', open);
+            if (close == -1) {
+                break;
+            }
+            String between = xml.substring(open + 1, close);
+            if (between.indexOf('<') != -1 || between.indexOf('>') != -1) {
+                String visible = between.replaceAll('<[^>]+>', '');
+                String reconstructed = '{' + visible + '}';
+                addFinding(
+                    findings,
+                    'Merge tag split across runs',
+                    'Merge tag is split across multiple Word runs: ' +
+                        reconstructed +
+                        '. Text tags heal at merge time, but chart tags split across runs can fall back to literal text. Cleanest fix: delete the whole tag in Word and retype it in one continuous burst, without backspacing or formatting changes mid-tag.',
+                    1
+                );
+            }
+            i = close + 1;
+        }
+    }
+
+    /** Is this '{' inside a <w:t>/<a:t> text run? Approximate, like the blueprint. */
+    private static Boolean isInsideOpenTextRun(String xml, Integer pos) {
+        Integer fromIdx = Math.max(0, pos - 200);
+        String recent = xml.substring(fromIdx, pos);
+        Integer lastWtOpen = recent.lastIndexOf('<w:t');
+        Integer lastWtClose = recent.lastIndexOf('</w:t>');
+        Integer lastAtOpen = recent.lastIndexOf('<a:t');
+        Integer lastAtClose = recent.lastIndexOf('</a:t>');
+        Boolean inWt = lastWtOpen != -1 && (lastWtClose == -1 || lastWtClose < lastWtOpen);
+        Boolean inAt = lastAtOpen != -1 && (lastAtClose == -1 || lastAtClose < lastAtOpen);
+        return inWt || inAt;
+    }
+
+    // -----------------------------------------------------------------------
+    // Visible-text stream — concatenate every text run, mapping each character
+    // back to its XML offset so hits in clean text can be located structurally.
+    // -----------------------------------------------------------------------
+
+    private static VisibleStream buildVisibleText(String xml) {
+        VisibleStream vs = new VisibleStream();
+        Matcher m = Pattern.compile('<[wa]:t(?:\\s[^>]*)?>([^<]*)</[wa]:t>').matcher(xml);
+        List<String> buf = new List<String>();
+        while (m.find()) {
+            String text = m.group(1);
+            Integer contentStart = xml.indexOf('>', m.start()) + 1;
+            for (Integer k = 0; k < text.length(); k++) {
+                buf.add(text.substring(k, k + 1));
+                vs.mapping.add(contentStart + k);
+            }
+        }
+        vs.text = String.join(buf, '');
+        return vs;
+    }
+
+    private static List<RawTag> tagsFromVisibleText(VisibleStream vs) {
+        List<RawTag> tags = new List<RawTag>();
+        Matcher m = Pattern.compile('\\{[^{}]+\\}').matcher(vs.text);
+        while (m.find()) {
+            RawTag t = new RawTag();
+            t.raw = m.group(0);
+            t.visStart = m.start();
+            t.visEnd = m.end();
+            t.xmlStart = vs.mapping[m.start()];
+            t.xmlEnd = vs.mapping[m.end() - 1] + 1;
+            tags.add(t);
+        }
+        return tags;
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Loop pairing. Both {#Rel} and {^Rel} are openers (findBalancedEnd
+    //    treats '#' and '^' as equivalent depth-up); {/Rel} closes. {#IF expr}
+    //    balances on the bare key "IF", mirroring the engine.
+    // -----------------------------------------------------------------------
+
+    private static PairResult findMatchingPairs(List<RawTag> tags) {
+        List<Opener> opens = new List<Opener>();
+        PairResult r = new PairResult();
+        for (RawTag t : tags) {
+            if (t.raw.startsWith('{#')) {
+                opens.add(makeOpener(t, '#'));
+            } else if (t.raw.startsWith('{^')) {
+                opens.add(makeOpener(t, '^'));
+            } else if (t.raw.startsWith('{/')) {
+                String rel = t.raw.substring(2, t.raw.length() - 1);
+                String key = balanceKey(rel);
+                Integer found = -1;
+                for (Integer j = opens.size() - 1; j >= 0; j--) {
+                    if (opens[j].key == key) {
+                        found = j;
+                        break;
+                    }
+                }
+                if (found >= 0) {
+                    Pair p = new Pair();
+                    p.open = opens[found];
+                    p.close = t;
+                    p.rel = opens[found].rel;
+                    r.pairs.add(p);
+                    opens.remove(found);
+                } else {
+                    r.unmatchedCloses.add(t);
+                }
+            }
+        }
+        r.unmatchedOpens = opens;
+        return r;
+    }
+
+    private static Opener makeOpener(RawTag t, String variant) {
+        Opener o = new Opener();
+        o.tag = t;
+        o.variant = variant;
+        o.rel = t.raw.substring(2, t.raw.length() - 1);
+        o.key = balanceKey(o.rel);
+        return o;
+    }
+
+    /** The balance key DocGenService.findBalancedEnd pairs on. */
+    private static String balanceKey(String rel) {
+        String trimmed = rel.trim();
+        String upper = trimmed.toUpperCase();
+        if (upper == 'IF' || upper.startsWith('IF ')) {
+            return 'IF';
+        }
+        return trimmed;
+    }
+
+    private static void checkUnmatchedTags(PairResult pr, List<DocGenAiHtmlValidator.Finding> findings) {
+        for (Opener o : pr.unmatchedOpens) {
+            addFinding(
+                findings,
+                'Loop opener with no closer',
+                'Loop opener {#' +
+                    o.rel +
+                    '} has no matching closing tag {/' +
+                    o.rel +
+                    '}. Generation fails the whole merge with a malformed-loop error — add the closing tag, or delete the opener if it was leftover.',
+                1
+            );
+        }
+        for (RawTag c : pr.unmatchedCloses) {
+            String rel = c.raw.substring(2, c.raw.length() - 1);
+            addFinding(
+                findings,
+                'Loop closer with no opener',
+                'Loop closer {/' +
+                    rel +
+                    '} has no matching opener {#' +
+                    rel +
+                    '} (possible duplicate). Check the relationship name spelling and that the {#…} opener was not lost to formatting or a stray copy/paste.',
+                1
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 3 + 4. Structural placement: the enclosing <w:tr> and where the closing
+    //    tag sits. Word-only.
+    // -----------------------------------------------------------------------
+
+    private static void checkStructuralPlacement(
+        String xml,
+        PairResult pr,
+        List<DocGenAiHtmlValidator.Finding> findings
+    ) {
+        for (Pair pair : pr.pairs) {
+            Integer[] enclosingRow = findEnclosingRow(xml, pair.open.tag.xmlStart, pair.close.xmlEnd);
+            if (enclosingRow != null) {
+                continue;
+            }
+            String closeContainer = isInsideAnyContainer(xml, pair.close.xmlStart);
+            if (closeContainer == null) {
+                addFinding(
+                    findings,
+                    'Closing tag outside a container',
+                    'Closing tag {/' +
+                        pair.rel +
+                        '} is not inside any structural container (table row, cell, or paragraph). The closing tag has escaped its intended cell — cut it and paste it back inside the same cell as the opening tag, or inside the cell that contains the related sub-table.',
+                    1
+                );
+            } else {
+                addFinding(
+                    findings,
+                    'Loop not inside a single table row',
+                    'No table row encloses both {#' +
+                        pair.open.variant +
+                        pair.rel +
+                        '} and {/' +
+                        pair.rel +
+                        '}. The merge engine falls back to paragraph-level repeat — usually fine for non-table loops, but unexpected for table-based templates. If you want a table row to repeat, both loop tags must live inside cells of the same row (or inside a single cell that contains the entire repeat block).',
+                    1
+                );
+            }
+        }
+    }
+
+    /** Nearest <w:tr> that fully encloses both tags, or null. Mirrors extractLoopBody. */
+    private static Integer[] findEnclosingRow(String xml, Integer openOffset, Integer closeEnd) {
+        List<Integer[]> ranges = new List<Integer[]>();
+        List<Integer> stack = new List<Integer>();
+        Matcher m = Pattern.compile('<(/)?(w:tr|a:tr)(?=[\\s>])').matcher(xml);
+        while (m.find()) {
+            if (m.group(1) == null) {
+                stack.add(m.start());
+            } else if (!stack.isEmpty()) {
+                Integer start = stack.remove(stack.size() - 1);
+                Integer endIdx = m.start() + ('</' + m.group(2) + '>').length();
+                ranges.add(new List<Integer>{ start, endIdx });
+            }
+        }
+        Integer[] best = null;
+        for (Integer[] r : ranges) {
+            if (r[0] < openOffset && r[1] >= closeEnd) {
+                if (best == null || (r[1] - r[0]) < (best[1] - best[0])) {
+                    best = r;
+                }
+            }
+        }
+        return best;
+    }
+
+    /** The kind of WordprocessingML container this offset sits inside, or null. */
+    private static String isInsideAnyContainer(String xml, Integer offset) {
+        String before = xml.substring(0, offset);
+        if (countOpenMinusClose(before, 'w:tc') > 0) {
+            return 'cell';
+        }
+        if (countOpenMinusClose(before, 'w:tr') > 0) {
+            return 'row';
+        }
+        if (countOpenMinusClose(before, 'w:p') > 0) {
+            Integer lastPOpen = Math.max(xml.lastIndexOf('<w:p>', offset), xml.lastIndexOf('<w:p ', offset));
+            Integer lastPClose = xml.lastIndexOf('</w:p>', offset);
+            if (lastPOpen > lastPClose && xml.substring(lastPOpen, offset).contains('<w:numPr')) {
+                return 'numbered paragraph';
+            }
+            return 'paragraph';
+        }
+        return null;
+    }
+
+    private static Integer countOpenMinusClose(String s, String tag) {
+        Integer open = countMatches(s, Pattern.compile('<' + tag + '(?=[\\s>])'));
+        Integer close = countMatches(s, Pattern.compile('</' + tag + '>'));
+        return open - close;
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Nested loops on the same relationship. The canonical inverse-loop
+    //    conditional {^Rel}{:else}…{#Rel}…{/Rel}…{/Rel} is allowed.
+    // -----------------------------------------------------------------------
+
+    private static void checkNestedSameRel(List<Pair> pairs, List<DocGenAiHtmlValidator.Finding> findings) {
+        for (Integer i = 0; i < pairs.size(); i++) {
+            for (Integer j = 0; j < pairs.size(); j++) {
+                if (i == j) {
+                    continue;
+                }
+                Pair a = pairs[i];
+                Pair b = pairs[j];
+                if (a.rel != b.rel) {
+                    continue;
+                }
+                if (a.open.tag.xmlStart < b.open.tag.xmlStart && a.close.xmlEnd > b.close.xmlEnd) {
+                    if (a.open.variant == '^' && b.open.variant == '#') {
+                        continue;
+                    }
+                    addFinding(
+                        findings,
+                        'Nested loops on the same relationship',
+                        'Two loops over "' +
+                            a.rel +
+                            '" are nested inside each other. This is almost always a typo — did you mean to nest a different relationship inside? (The canonical inverse-loop conditional {^Rel}{:else}…{#Rel}…{/Rel}…{/Rel} is allowed.)',
+                        1
+                    );
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 6. Empty loops.
+    // -----------------------------------------------------------------------
+
+    private static void checkEmptyLoops(PairResult pr, VisibleStream vs, List<DocGenAiHtmlValidator.Finding> findings) {
+        for (Pair p : pr.pairs) {
+            String innerVis = vs.text.substring(p.open.tag.visEnd, p.close.visStart).trim();
+            if (innerVis.length() == 0) {
+                addFinding(
+                    findings,
+                    'Empty loop',
+                    'Loop {#' +
+                        p.rel +
+                        '} … {/' +
+                        p.rel +
+                        '} has no content between the tags. It will iterate but produce no output — probably leftover from a deleted cell.',
+                    1
+                );
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 7. Row-binding collision — parent + nested loop bound to the same <w:tr>
+    //    fight over the same container. Word-only.
+    // -----------------------------------------------------------------------
+
+    private static void checkRowBindingCollision(
+        String xml,
+        List<Pair> pairs,
+        List<DocGenAiHtmlValidator.Finding> findings
+    ) {
+        List<PairRow> withRows = new List<PairRow>();
+        for (Pair p : pairs) {
+            Integer[] row = findEnclosingRow(xml, p.open.tag.xmlStart, p.close.xmlEnd);
+            if (row != null) {
+                withRows.add(new PairRow(p, row));
+            }
+        }
+        for (Integer i = 0; i < withRows.size(); i++) {
+            for (Integer j = 0; j < withRows.size(); j++) {
+                if (i == j) {
+                    continue;
+                }
+                PairRow outerRow = withRows[i];
+                PairRow innerRow = withRows[j];
+                if (
+                    outerRow.p.open.tag.xmlStart < innerRow.p.open.tag.xmlStart &&
+                    outerRow.p.close.xmlEnd > innerRow.p.close.xmlEnd
+                ) {
+                    if (outerRow.row[0] == innerRow.row[0] && outerRow.row[1] == innerRow.row[1]) {
+                        addFinding(
+                            findings,
+                            'Row-binding collision',
+                            '{#' +
+                                innerRow.p.rel +
+                                '} is nested inside {#' +
+                                outerRow.p.rel +
+                                '} but both bind to the same table row. Wrap the inner tag and its content in a borderless single-cell mini-table so it binds to the mini-table row instead of fighting the outer loop for the same container.',
+                            1
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 8. Entity-encoded IF operators — &gt;/&lt; are not decoded before the
+    //    IF parser matches operators, so the expression always evaluates false
+    //    on installs before v1.69.
+    // -----------------------------------------------------------------------
+
+    private static void checkEntityEncodedIf(String xml, List<DocGenAiHtmlValidator.Finding> findings) {
+        Matcher m = Pattern.compile('\\{#[Ii][Ff]\\s+[^}]*?(&gt;|&lt;)[^}]*?\\}').matcher(xml);
+        while (m.find()) {
+            String entity = m.group(1);
+            String decoded = entity == '&gt;' ? '>' : '<';
+            addFinding(
+                findings,
+                'HTML-encoded IF operator',
+                'IF expression uses \'' +
+                    decoded +
+                    '\' which is HTML-encoded as \'' +
+                    entity +
+                    '\' in the file — the IF parser does not decode entities before parsing operators, so this expression will always evaluate false: ' +
+                    m.group(0) +
+                    '. Rewrite the condition using \'!=\' or \'=\' (which are not HTML-encoded). Example: instead of {#IF Field > 0}, use {#IF Field != 0}.',
+                1
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 9. Nested IF blocks — findBalancedEnd cannot depth-track nested {#IF} on
+    //    installs before v1.72.
+    // -----------------------------------------------------------------------
+
+    private static void checkNestedIfs(List<Pair> pairs, List<DocGenAiHtmlValidator.Finding> findings) {
+        List<Pair> ifPairs = new List<Pair>();
+        for (Pair p : pairs) {
+            String rel = p.rel.trim().toUpperCase();
+            if (rel == 'IF' || rel.startsWith('IF ')) {
+                ifPairs.add(p);
+            }
+        }
+        for (Integer i = 0; i < ifPairs.size(); i++) {
+            for (Integer j = 0; j < ifPairs.size(); j++) {
+                if (i == j) {
+                    continue;
+                }
+                Pair ifOuter = ifPairs[i];
+                Pair ifInner = ifPairs[j];
+                if (
+                    ifOuter.open.tag.xmlStart < ifInner.open.tag.xmlStart &&
+                    ifOuter.close.xmlEnd > ifInner.close.xmlEnd
+                ) {
+                    addFinding(
+                        findings,
+                        'Nested IF blocks',
+                        'IF block {#' +
+                            ifInner.rel +
+                            '} is nested inside IF block {#' +
+                            ifOuter.rel +
+                            '} — package versions before v1.72 cannot disambiguate nested IFs and will pair the inner {/IF} with the outer {#IF}, corrupting the parser state. Upgrade to v1.72+ to use nested IFs natively; for older installs, restructure to avoid nesting.',
+                        1
+                    );
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static void addFinding(
+        List<DocGenAiHtmlValidator.Finding> findings,
+        String rule,
+        String detail,
+        Integer occurrences
+    ) {
+        findings.add(new DocGenAiHtmlValidator.Finding('warning', rule, occurrences, detail));
+    }
+
+    private static Integer countMatches(String s, Pattern p) {
+        Integer n = 0;
+        Matcher m = p.matcher(s);
+        while (m.find()) {
+            n++;
+        }
+        return n;
+    }
+
+    // -----------------------------------------------------------------------
+    // Inner records
+    // -----------------------------------------------------------------------
+
+    private class RawTag {
+        String raw;
+        Integer visStart;
+        Integer visEnd;
+        Integer xmlStart;
+        Integer xmlEnd;
+    }
+
+    private class Opener {
+        RawTag tag;
+        String rel;
+        String key;
+        String variant;
+    }
+
+    private class Pair {
+        Opener open;
+        RawTag close;
+        String rel;
+    }
+
+    private class PairRow {
+        Pair p;
+        Integer[] row;
+
+        PairRow(Pair p, Integer[] row) {
+            this.p = p;
+            this.row = row;
+        }
+    }
+
+    private class PairResult {
+        List<Pair> pairs = new List<Pair>();
+        List<Opener> unmatchedOpens = new List<Opener>();
+        List<RawTag> unmatchedCloses = new List<RawTag>();
+    }
+
+    private class VisibleStream {
+        String text;
+        List<Integer> mapping = new List<Integer>();
+    }
+}

--- a/force-app/main/default/classes/DocGenDocxTemplateLinter.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenDocxTemplateLinter.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenDocxTemplateLinterTest.cls
+++ b/force-app/main/default/classes/DocGenDocxTemplateLinterTest.cls
@@ -1,0 +1,450 @@
+/**
+ * Coverage for DocGenDocxTemplateLinter — the Word/PowerPoint slice of the
+ * upload-time fidelity report (issue #272).
+ *
+ * The reference semantics live in scripts/docgen-template-lint.js (the offline
+ * Node preflight); what is asserted here is the Apex port: each of the nine
+ * checks fires on the fixture that trips it, stays quiet when it shouldn't,
+ * every finding is a warning (never a blocker), and the saveTemplate hook hands
+ * the report back without changing the save outcome.
+ *
+ * Fixtures are minimal Office packages built with Compression.ZipWriter — the
+ * same construction the rest of the suite uses (DocGenControllerTests ~904).
+ */
+@isTest
+private class DocGenDocxTemplateLinterTest {
+    private static final String XML_HEAD =
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">';
+
+    private static DocGenAiHtmlValidator.Finding findRule(List<DocGenAiHtmlValidator.Finding> findings, String rule) {
+        for (DocGenAiHtmlValidator.Finding f : findings) {
+            if (f.rule == rule) {
+                return f;
+            }
+        }
+        return null;
+    }
+
+    private static List<String> ruleNames(List<DocGenAiHtmlValidator.Finding> findings) {
+        List<String> names = new List<String>();
+        for (DocGenAiHtmlValidator.Finding f : findings) {
+            names.add(f.rule);
+        }
+        return names;
+    }
+
+    // -----------------------------------------------------------------------
+    // Fixture builders — minimal valid Office packages, after TestDataFactory.
+    // -----------------------------------------------------------------------
+
+    /** A ZIP carrying the supplied document.xml body as a .docx. */
+    private static Blob buildDocx(String documentXml) {
+        Compression.ZipWriter zw = new Compression.ZipWriter();
+        zw.addEntry(
+            '[Content_Types].xml',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+                    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+                    '<Default Extension="xml" ContentType="application/xml"/>' +
+                    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+                    '</Types>'
+            )
+        );
+        zw.addEntry(
+            '_rels/.rels',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+                    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+                    '</Relationships>'
+            )
+        );
+        zw.addEntry(
+            'word/_rels/document.xml.rels',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>'
+            )
+        );
+        zw.addEntry('word/document.xml', Blob.valueOf(documentXml));
+        return zw.getArchive();
+    }
+
+    /** A paragraph of WordprocessingML text. */
+    private static String p(String text) {
+        return '<w:p><w:r><w:t>' + text + '</w:t></w:r></w:p>';
+    }
+
+    /** A single-row WordprocessingML table whose one cell carries the row text. */
+    private static String tableRow(String cellText) {
+        return '<w:tbl><w:tr><w:tc><w:p><w:r><w:t>' + cellText + '</w:t></w:r></w:p></w:tc></w:tr></w:tbl>';
+    }
+
+    /** A ZIP with the supplied slides as a .pptx (one slide per string). */
+    private static Blob buildPptx(List<String> slidesXml) {
+        Compression.ZipWriter zw = new Compression.ZipWriter();
+        zw.addEntry('[Content_Types].xml', Blob.valueOf('<?xml version="1.0"?><Types/>'));
+        for (Integer i = 0; i < slidesXml.size(); i++) {
+            zw.addEntry('ppt/slides/slide' + (i + 1) + '.xml', Blob.valueOf(slidesXml[i]));
+        }
+        return zw.getArchive();
+    }
+
+    private static String slide(String text) {
+        return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+            '<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" ' +
+            'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">' +
+            '<p:cSld><p:spTree><p:sp><p:txBody><a:p><a:r><a:t>' +
+            text +
+            '</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld></p:sld>';
+    }
+
+    // -----------------------------------------------------------------------
+    // The nine checks
+    // -----------------------------------------------------------------------
+
+    @isTest
+    static void cleanDocxProducesZeroFindings() {
+        String xml = XML_HEAD + '<w:body>' + p('Hello {Name}, {Industry}.') + '</w:body></w:document>';
+        Test.startTest();
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(buildDocx(xml));
+        Test.stopTest();
+        System.assertEquals(0, findings.size(), 'A clean single-run template must report nothing: ' + findings);
+    }
+
+    @isTest
+    static void fragmentedTagIsReported() {
+        // Word splits the tag across two runs when formatting changes mid-tag.
+        String xml =
+            XML_HEAD + '<w:body><w:p><w:r><w:t>{Na</w:t></w:r><w:r><w:t>me}</w:t></w:r></w:p></w:body></w:document>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(buildDocx(xml));
+        DocGenAiHtmlValidator.Finding f = findRule(findings, 'Merge tag split across runs');
+        System.assertNotEquals(null, f, 'the tag spans two runs — warn: ' + findings);
+        System.assert(f.detail.contains('{Name}'), 'the warning must name the reconstructed tag: ' + f.detail);
+    }
+
+    @isTest
+    static void unmatchedLoopOpenIsReported() {
+        String xml = XML_HEAD + '<w:body>' + p('{#Lines}{Name}') + '</w:body></w:document>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(buildDocx(xml));
+        DocGenAiHtmlValidator.Finding f = findRule(findings, 'Loop opener with no closer');
+        System.assertNotEquals(null, f, 'an opener with no closer fails the merge at generation time');
+        System.assert(f.detail.contains('{#Lines}'), 'the warning must name the tag: ' + f.detail);
+    }
+
+    @isTest
+    static void unmatchedLoopCloseIsReported() {
+        String xml = XML_HEAD + '<w:body>' + p('{Name}{/Lines}') + '</w:body></w:document>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(buildDocx(xml));
+        DocGenAiHtmlValidator.Finding f = findRule(findings, 'Loop closer with no opener');
+        System.assertNotEquals(null, f, 'a closer with no opener must be flagged');
+        System.assert(f.detail.contains('{/Lines}'), 'the warning must name the tag: ' + f.detail);
+    }
+
+    @isTest
+    static void balancedLoopWithElseIsClean() {
+        String xml = XML_HEAD + '<w:body>' + tableRow('{#Lines}{Name}{:else}none{/Lines}') + '</w:body></w:document>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(buildDocx(xml));
+        System.assertEquals(null, findRule(findings, 'Loop opener with no closer'), 'balanced loop: ' + findings);
+        System.assertEquals(null, findRule(findings, 'Loop closer with no opener'), 'balanced loop: ' + findings);
+        System.assertEquals(null, findRule(findings, 'Empty loop'), 'the {:else} counts as content: ' + findings);
+    }
+
+    @isTest
+    static void loopInsideOneTableRowIsClean() {
+        // Both tags inside cells of the SAME row — the canonical table-loop shape.
+        String xml =
+            XML_HEAD +
+            '<w:body><w:tbl><w:tr><w:tc>' +
+            '<w:p><w:r><w:t>{#Lines}</w:t></w:r></w:p>' +
+            '<w:p><w:r><w:t>{Name}</w:t></w:r></w:p>' +
+            '<w:p><w:r><w:t>{/Lines}</w:t></w:r></w:p>' +
+            '</w:tc></w:tr></w:tbl></w:body></w:document>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(buildDocx(xml));
+        System.assertEquals(
+            null,
+            findRule(findings, 'Loop not inside a single table row'),
+            'row encloses both: ' + findings
+        );
+        System.assertEquals(null, findRule(findings, 'Row-binding collision'), 'only one loop: ' + findings);
+    }
+
+    @isTest
+    static void loopWithoutEnclosingRowWarnsAboutTheFallback() {
+        // Both tags live in plain paragraphs — no <w:tr> encloses them, so the
+        // engine falls back to paragraph-level repeat.
+        String xml = XML_HEAD + '<w:body>' + p('{#Lines}') + p('{Name}') + p('{/Lines}') + '</w:body></w:document>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(buildDocx(xml));
+        System.assertNotEquals(
+            null,
+            findRule(findings, 'Loop not inside a single table row'),
+            'no row encloses the pair — warn about the fallback: ' + findings
+        );
+    }
+
+    @isTest
+    static void closingTagOutsideAnyContainerIsReported() {
+        // The closer escaped to the body root, outside every paragraph.
+        String xml =
+            XML_HEAD +
+            '<w:body>' +
+            p('{#Lines}{Name}') +
+            '<w:r><w:t>{/Lines}</w:t></w:r>' +
+            '</w:body></w:document>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(buildDocx(xml));
+        System.assertNotEquals(
+            null,
+            findRule(findings, 'Closing tag outside a container'),
+            'the closer escaped its cell: ' + findings
+        );
+    }
+
+    @isTest
+    static void nestedSameRelLoopIsReported() {
+        String xml =
+            XML_HEAD +
+            '<w:body>' +
+            tableRow('{#Lines}{Name}{#Lines}{Number}{/Lines}{/Lines}') +
+            '</w:body></w:document>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(buildDocx(xml));
+        DocGenAiHtmlValidator.Finding f = findRule(findings, 'Nested loops on the same relationship');
+        System.assertNotEquals(null, f, 'two forward loops over Lines — almost always a typo: ' + findings);
+        System.assert(f.detail.contains('Lines'), 'the warning must name the relationship: ' + f.detail);
+    }
+
+    @isTest
+    static void nestedSameRelInversePatternIsAllowed() {
+        // {^Lines}{:else}…{#Lines}…{/Lines}…{/Lines} — the canonical inverse-loop
+        // conditional. Not a typo, so no warning.
+        String xml =
+            XML_HEAD +
+            '<w:body>' +
+            tableRow('{^Lines}{:else}{#Lines}{Name}{/Lines}{/Lines}') +
+            '</w:body></w:document>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(buildDocx(xml));
+        System.assertEquals(
+            null,
+            findRule(findings, 'Nested loops on the same relationship'),
+            'the inverse-loop conditional is deliberate: ' + findings
+        );
+    }
+
+    @isTest
+    static void emptyLoopIsReported() {
+        String xml = XML_HEAD + '<w:body>' + p('{#Lines}{/Lines}') + '</w:body></w:document>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(buildDocx(xml));
+        DocGenAiHtmlValidator.Finding f = findRule(findings, 'Empty loop');
+        System.assertNotEquals(null, f, 'an empty loop iterates to nothing: ' + findings);
+        System.assert(f.detail.contains('{#Lines}'), 'the warning must name the loop: ' + f.detail);
+    }
+
+    @isTest
+    static void rowBindingCollisionIsReported() {
+        // {#Lines} and {#Opportunities} both bind to the SAME row.
+        String xml =
+            XML_HEAD +
+            '<w:body><w:tbl><w:tr><w:tc>' +
+            '<w:p><w:r><w:t>{#Lines}{#Opportunities}</w:t></w:r></w:p>' +
+            '<w:p><w:r><w:t>{Name}</w:t></w:r></w:p>' +
+            '<w:p><w:r><w:t>{/Opportunities}{/Lines}</w:t></w:r></w:p>' +
+            '</w:tc></w:tr></w:tbl></w:body></w:document>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(buildDocx(xml));
+        System.assertNotEquals(
+            null,
+            findRule(findings, 'Row-binding collision'),
+            'both loops fight for the row: ' + findings
+        );
+    }
+
+    @isTest
+    static void entityEncodedIfOperatorIsReported() {
+        // Word stores '>' as &gt; in OOXML; the IF parser does not decode it, so
+        // the expression always evaluates false on installs before v1.69.
+        String xml = XML_HEAD + '<w:body>' + p('{#IF Amount &gt; 0}positive{/IF}') + '</w:body></w:document>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(buildDocx(xml));
+        DocGenAiHtmlValidator.Finding f = findRule(findings, 'HTML-encoded IF operator');
+        System.assertNotEquals(null, f, 'the expression can never be true: ' + findings);
+        System.assert(f.detail.contains('&gt;'), 'the warning must name the encoded operator: ' + f.detail);
+        System.assert(f.detail.contains('!='), 'and suggest the safe rewrite: ' + f.detail);
+    }
+
+    @isTest
+    static void nestedIfBlocksAreReported() {
+        String xml = XML_HEAD + '<w:body>' + p('{#IF A != 0}{#IF B != 0}x{/IF}{/IF}') + '</w:body></w:document>';
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(buildDocx(xml));
+        DocGenAiHtmlValidator.Finding f = findRule(findings, 'Nested IF blocks');
+        System.assertNotEquals(null, f, 'nested IFs corrupt the parser on older installs: ' + findings);
+    }
+
+    // -----------------------------------------------------------------------
+    // PowerPoint: text-level checks run; table-structure checks are skipped.
+    // -----------------------------------------------------------------------
+
+    @isTest
+    static void pptxBalancedLoopIsCleanOfStructuralWarnings() {
+        Blob pptx = buildPptx(new List<String>{ slide('{#Lines}{Name}{/Lines}') });
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(pptx);
+        System.assertEquals(
+            null,
+            findRule(findings, 'Loop not inside a single table row'),
+            'PPTX has no <w:tr> — the paragraph-fallback warning would be noise: ' + findings
+        );
+        System.assertEquals(null, findRule(findings, 'Loop opener with no closer'), 'balanced slide: ' + findings);
+    }
+
+    @isTest
+    static void pptxUnmatchedLoopIsReported() {
+        Blob pptx = buildPptx(new List<String>{ slide('{#Lines}{Name}') });
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(pptx);
+        System.assertNotEquals(
+            null,
+            findRule(findings, 'Loop opener with no closer'),
+            '<a:t> runs must be read like <w:t>: ' + findings
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Never throws, never blocks.
+    // -----------------------------------------------------------------------
+
+    @isTest
+    static void lintNeverThrowsOnGarbage() {
+        Test.startTest();
+        List<DocGenAiHtmlValidator.Finding> nullBlob = DocGenDocxTemplateLinter.lint(null);
+        List<DocGenAiHtmlValidator.Finding> notAZip = DocGenDocxTemplateLinter.lint(
+            Blob.valueOf('this is definitely not a zip archive')
+        );
+        List<DocGenAiHtmlValidator.Finding> emptyZip = DocGenDocxTemplateLinter.lint(
+            buildDocx('<?xml version="1.0"?><w:document/>')
+        );
+        Test.stopTest();
+        System.assertEquals(0, nullBlob.size(), 'null input is an empty report, not an exception');
+        System.assertEquals(0, notAZip.size(), 'an unreadable archive must not throw');
+        System.assertEquals(0, emptyZip.size(), 'a document with no runs reports nothing: ' + emptyZip);
+    }
+
+    // -----------------------------------------------------------------------
+    // The hook: saveTemplate returns the warnings with the save result.
+    // -----------------------------------------------------------------------
+
+    private static DocGen_Template__c newWordTemplate() {
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'Docx Lint Hook ' + System.now().getTime(),
+            Base_Object_API__c = 'Account',
+            Type__c = 'Word',
+            Output_Format__c = 'PDF',
+            Query_Config__c = 'Name'
+        );
+        Database.insert(tpl, AccessLevel.SYSTEM_MODE);
+        return tpl;
+    }
+
+    @isTest
+    static void saveReturnsWarningsKeysWithoutBlocking() {
+        DocGen_Template__c tpl = newWordTemplate();
+        String badBody = XML_HEAD + '<w:body>' + p('{#Lines}{Name}') + '</w:body></w:document>';
+        ContentVersion cv = new ContentVersion(
+            Title = 'DocxLintBody',
+            PathOnClient = 'DocxLintBody.docx',
+            VersionData = buildDocx(badBody)
+        );
+        insert cv;
+
+        Map<String, Object> fields = new Map<String, Object>{
+            'Id' => tpl.Id,
+            'Name' => tpl.Name,
+            'Type__c' => 'Word',
+            'Base_Object_API__c' => 'Account',
+            'Output_Format__c' => 'PDF',
+            'Query_Config__c' => 'Name',
+            'Test_Record_Id__c' => null,
+            'Document_Title_Format__c' => null
+        };
+        Test.startTest();
+        Map<String, Object> res = DocGenController.saveTemplate(fields, true, cv.Id);
+        Test.stopTest();
+
+        System.assertNotEquals(null, res.get('createdVersionId'), 'warnings never block the save');
+        System.assert(res.containsKey('warnings'), 'the save result must carry the fidelity report');
+        System.assert(res.containsKey('warningCount'), 'and its count');
+        List<DocGenAiHtmlValidator.Finding> warnings = (List<DocGenAiHtmlValidator.Finding>) res.get('warnings');
+        System.assertNotEquals(
+            null,
+            findRule(warnings, 'Loop opener with no closer'),
+            'an unmatched loop in the uploaded DOCX must warn: ' + warnings
+        );
+        System.assertEquals(warnings.size(), (Integer) res.get('warningCount'), 'count must match the list');
+        for (DocGenAiHtmlValidator.Finding f : warnings) {
+            System.assertEquals('warning', f.action, 'lint never repairs or removes — every finding is a warning');
+        }
+    }
+
+    @isTest
+    static void saveReturnsCleanWarningsForACleanDocx() {
+        DocGen_Template__c tpl = newWordTemplate();
+        String cleanBody = XML_HEAD + '<w:body>' + p('Hello {Name}.') + '</w:body></w:document>';
+        ContentVersion cv = new ContentVersion(
+            Title = 'DocxLintBodyClean',
+            PathOnClient = 'DocxLintBodyClean.docx',
+            VersionData = buildDocx(cleanBody)
+        );
+        insert cv;
+
+        Map<String, Object> fields = new Map<String, Object>{
+            'Id' => tpl.Id,
+            'Name' => tpl.Name,
+            'Type__c' => 'Word',
+            'Base_Object_API__c' => 'Account',
+            'Output_Format__c' => 'PDF',
+            'Query_Config__c' => 'Name',
+            'Test_Record_Id__c' => null,
+            'Document_Title_Format__c' => null
+        };
+        Test.startTest();
+        Map<String, Object> res = DocGenController.saveTemplate(fields, true, cv.Id);
+        Test.stopTest();
+
+        System.assertNotEquals(null, res.get('createdVersionId'), 'the save still succeeds');
+        System.assertEquals(
+            0,
+            (Integer) res.get('warningCount'),
+            'a clean DOCX body warns about nothing: ' + res.get('warnings')
+        );
+    }
+
+    @isTest
+    static void saveDoesNotLintNonOfficeTypes() {
+        // The HTML path has its own linter; saveTemplate must not run the DOCX
+        // one for HTML bodies (a text blob would just fail the ZIP read anyway).
+        DocGen_Template__c tpl = newWordTemplate();
+        ContentVersion cv = new ContentVersion(
+            Title = 'HtmlBody',
+            PathOnClient = 'Body.html',
+            VersionData = Blob.valueOf('<html><body><p>{#Lines}</p></body></html>')
+        );
+        insert cv;
+
+        Map<String, Object> fields = new Map<String, Object>{
+            'Id' => tpl.Id,
+            'Name' => tpl.Name,
+            'Type__c' => 'HTML',
+            'Base_Object_API__c' => 'Account',
+            'Output_Format__c' => 'PDF',
+            'Query_Config__c' => 'Name',
+            'Test_Record_Id__c' => null,
+            'Document_Title_Format__c' => null
+        };
+        Test.startTest();
+        Map<String, Object> res = DocGenController.saveTemplate(fields, true, cv.Id);
+        Test.stopTest();
+
+        System.assertNotEquals(null, res.get('createdVersionId'), 'the save still succeeds');
+        System.assertEquals(
+            0,
+            (Integer) res.get('warningCount'),
+            'non-Office uploads are outside this linter: ' + res.get('warnings')
+        );
+    }
+}

--- a/force-app/main/default/classes/DocGenDocxTemplateLinterTest.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenDocxTemplateLinterTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -5943,7 +5943,7 @@ private class DocGenMiscTests {
             FirstPublishLocationId = tpl.Id
         );
         insert htmlCv;
-        Id newVerId = DocGenController.saveTemplate(fields, true, htmlCv.Id);
+        Id newVerId = (Id) DocGenController.saveTemplate(fields, true, htmlCv.Id).get('createdVersionId');
         Test.stopTest();
 
         System.assert(blocked, 'Details-only save must not change the template format without a new body');

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -5770,11 +5770,22 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             const savedPdfSnapshotJson = this.uploadedPdfAcroFormSnapshotJson;
             const templateBodyContentVersionId = this.uploadedContentVersionId;
             // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
-            const versionId = await saveTemplate({
+            const saveResult = await saveTemplate({
                 fields: fields,
                 createVersion: true,
                 contentVersionId: templateBodyContentVersionId
             });
+            const versionId = saveResult && saveResult.createdVersionId ? saveResult.createdVersionId : null;
+            // #272 fidelity report for Word/PowerPoint uploads: the linter's
+            // warnings ride the saveTemplate response (same contract as the HTML
+            // path's saveHtmlTemplateBody). Advisory only — the version is already
+            // stored, nothing was blocked. Render into the SAME panel the HTML
+            // report uses.
+            this.lintFindings = [];
+            if (saveResult && Array.isArray(saveResult.warnings) && saveResult.warnings.length > 0) {
+                this.lintFindings = this._mapLintFindings(saveResult.warnings);
+                this._toastLintFindings();
+            }
             if (versionId && savedPdfSnapshotJson) {
                 await savePdfAcroFormSnapshot({
                     templateId: this.editTemplateId,


### PR DESCRIPTION
## What

Implements the Word/PowerPoint slice of #272: a DOCX/PPTX upload stops being a black box. Every "Save as New Version" of a Word/PowerPoint template now lints the uploaded body and hands the findings back with the save result — **warnings, never blockers**.

The checks are the Apex port of `scripts/docgen-template-lint.js` (the offline Node preflight QA runs against .docx files), all 9 rules, mirroring the merge engine's actual semantics:

1. **Merge tag split across runs** — the #130 class: text tags heal at merge time, chart tags fall back to literal text. Advises retyping the tag in one burst.
2. **Loop pairing** — `{#Rel}` without `{/Rel}` and stray `{/Rel}`, paired with `findBalancedEnd`'s stack semantics (`{^Rel}` is an opener, `{#IF expr}` balances on the bare key `IF`).
3. **Loop not inside a single table row** — the engine falls back to paragraph-level repeat.
4. **Closing tag outside a container** — an escaped cell.
5. **Nested loops on the same relationship** — the canonical `{^Rel}{:else}…{#Rel}…{/Rel}…{/Rel}` inverse pattern is allowed.
6. **Empty loops**.
7. **Row-binding collision** — parent + nested loop fighting over the same `<w:tr>` (Word only).
8. **HTML-encoded IF operators** (`&gt;`/`&lt;`) — always evaluates false on installs before v1.69.
9. **Nested IF blocks** — incorrectly paired on installs before v1.72.

PowerPoint slides get the text-level checks (1, 2, 5, 6, 8, 9); the `<w:tr>`-based structural checks are Word-specific and skipped there so slide loops don't false-positive on a paragraph-fallback warning.

## How

- New `DocGenDocxTemplateLinter.lint(Blob fileBytes)` — reads `word/document.xml` / `ppt/slides/slideN.xml` via `Compression.ZipReader`, every check individually guarded, never throws, never mutates. Findings reuse the `DocGenAiHtmlValidator.Finding` DTO with `action = 'warning'` so the existing panel renders them unchanged.
- `DocGenController.saveTemplate` now mirrors the `saveHtmlTemplateBody` contract: it returns a `Map` with `createdVersionId` (same value as the old `Id` return), plus `warnings` / `warningCount`, computed after the version is saved — a lint failure can never change the save outcome. Only for `Type__c` Word/PowerPoint/PPT/PPTX; the HTML path is untouched.
- `docGenAdmin.handleSaveAndClose` maps the returned warnings into the existing `lintFindings` panel ("Template warnings — this will still render") and shows the sticky toast, exactly like the HTML report.
- `DocGenControllerTests` / `DocGenMiscTests` callers of the new return shape updated (2 lines).

## Verification

- `aer test --filter DocGenDocxTemplateLinterTest`: 20/20 pass; the four classes touching `saveTemplate` pass except the known pre-existing aer failure (`testTemplatePickerTmpVarErrorResolvesToSharingGuidance`).
- Prettier clean (husky pre-commit gate); `sf code-analyzer --rule-selector Security --rule-selector AppExchange`: 0 violations on all changed files.
- Scratch org (`--no-namespace`): deploy succeeds (only the two known Einstein-only failures), full suite **1977 tests, 100% pass, 79% coverage** (linter class 98%); all release-checklist e2e scripts print `PASS: N FAIL: 0`.

## Scope note — does NOT close #272

This is the Word/PowerPoint slice. #272 remains open for the remaining checklist items, including chart tags in a .docx steering authors to HTML (simple bars only), the Excel/XLSX slice, and any DOCX-side field-reference validation. Follow-up, not completion.