### PR TITLE
fix(charts): forward every tag modifier to the PNG render

### DIFF
--- a/force-app/main/default/lwc/docGenChartJs/docGenChartJs.js
+++ b/force-app/main/default/lwc/docGenChartJs/docGenChartJs.js
@@ -558,12 +558,14 @@ export async function prepareChartsClientSide({ templateId, recordId, ChartCtor,
             }
 
             try {
+                // Spread the tag's own modifiers rather than naming five of them.
+                // Listing them by hand is how fontSize= reached the artboard preview and
+                // not the rendered PNG: the preview passes the chart config straight
+                // through, this call rebuilt a subset, and a modifier added later was
+                // silently dropped on the way to the only output that matters.
                 const png = renderChartPng(ChartCtor, buckets, {
-                    style: tag.style,
-                    title: opts.title,
-                    width: opts.width,
-                    height: opts.height,
-                    scale: opts.scale
+                    ...opts,
+                    style: tag.style
                 });
                 // eslint-disable-next-line no-await-in-loop
                 const cvId = await uploadChartImage({

--- a/scripts/qa/chart-font-scale-check.mjs
+++ b/scripts/qa/chart-font-scale-check.mjs
@@ -91,5 +91,28 @@ if (!m.buildChartConfigForTest) {
     ok(tickOf({ fontSize: 13.7 }) === 14, 'a fraction rounds to a whole pixel');
 }
 
+// --- every tag modifier reaches the PNG render --------------------------------
+// The bug this pins: prepareChartsClientSide used to hand renderChartPng a fresh
+// object naming five keys — style, title, width, height, scale. fontSize= was not
+// among them, so the artboard preview honoured the label size and the rendered PNG
+// silently ignored it. Reported from a real org: "shows on canvas but once rendered
+// seems to go back to hardcoded".
+//
+// Asserted against the SOURCE rather than by rendering, because the render needs a
+// browser canvas. A named-key rebuild at this call site is the failure mode, so that
+// is what this looks for.
+{
+    const call = /renderChartPng\(ChartCtor,\s*buckets,\s*\{([\s\S]*?)\}\s*\)/.exec(src);
+    ok(!!call, 'the prepareChartsClientSide -> renderChartPng call is findable');
+    if (call) {
+        const args = call[1];
+        ok(/\.\.\.opts/.test(args), 'it spreads the tag options rather than naming a subset');
+        ok(
+            !/width:\s*opts\.width/.test(args),
+            'no hand-listed key set — that is what dropped fontSize on the way to the PNG'
+        );
+    }
+}
+
 console.log(fail ? `\n${fail} FAILED` : '\nchart fonts OK');
 process.exit(fail ? 1 : 0);

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -243,6 +243,7 @@
     "Portwood@3.53.0-1": "04tVx0000010BvlIAE",
     "Portwood@3.54.0-1": "04tVx0000010Y4LIAU",
     "Portwood@3.55.0-1": "04tVx0000010fVdIAI",
-    "Portwood@3.55.0-2": "04tVx0000010fXFIAY"
+    "Portwood@3.55.0-2": "04tVx0000010fXFIAY",
+    "Portwood@3.56.0-1": "04tVx0000010faTIAQ"
   }
 }


### PR DESCRIPTION
Setting **Label size** showed on the artboard and reverted on render. My bug, from #287.

Two paths: the preview calls `renderChartToCanvas` (which I wired for `fontSize`), the render goes `prepareChartsClientSide` → `renderChartPng` — and that rebuilt a fresh options object naming five keys: `style, title, width, height, scale`. `fontSize` wasn't one, so it was dropped before the only output that matters.

The preview disagreeing with the product is precisely what the canvas exists to prevent, and I reintroduced it one call site over.

Now it spreads the tag's modifiers, so anything added later reaches the render without someone remembering this line. Confirmed working in `designer-ns`.

Pinned with a source-level check — a render test needs a browser canvas, but the failure is structural: it fails if that call ever goes back to a named-key subset.