### PR TITLE
fix(charts): scale every chart label, and stop emitting invalid CSS sizes

### DIFF
--- a/force-app/main/default/classes/DocGenChartTagExpander.cls
+++ b/force-app/main/default/classes/DocGenChartTagExpander.cls
@@ -456,23 +456,59 @@ public with sharing class DocGenChartTagExpander {
      * Not applied to the 1px rules: those give a zero-height bar its line box and are
      * layout, not text. Scaling them would push every bar out of shape.
      */
+    /**
+     * A `font-size:` declaration for a cell that normally inherits the document font —
+     * emitted ONLY when the tag asked for a size.
+     *
+     * The category-label cells never carried a size; they took the document's. So
+     * fontSize= moved the value labels and left the categories behind, which measured as
+     * "3 (50.0%)" growing from 7.8pt to 23.4pt while "Sales" stayed at 10.3.
+     *
+     * Conditional rather than always-on, deliberately. Giving these cells a fixed base
+     * would change how every existing chart looks in templates that set their own body
+     * font — a silent restyle of documents nobody asked to change. With no fontSize= the
+     * output is byte-for-byte what it was.
+     */
+    /**
+     * A Decimal as a CSS length, which rules out scientific notation.
+     *
+     * `stripTrailingZeros()` renders any multiple of ten as `1E+1`, `2E+1`, `4E+1`. That
+     * is not a valid CSS length: the engine discards the declaration and the element
+     * silently falls back to the inherited size. It bites unevenly — at fontSize=12 the
+     * 10pt cell broke, at fontSize=30 the 16pt title broke, and at 24 nothing did, which
+     * is exactly the value the first tests happened to use.
+     *
+     * Trailing ".0" is trimmed by hand instead, so 10.0 prints as "10" and 10.5 stays
+     * "10.5".
+     */
+    private static String css(Decimal v) {
+        String out = String.valueOf(v.setScale(1, System.RoundingMode.HALF_UP));
+        return out.endsWith('.0') ? out.removeEnd('.0') : out;
+    }
+
+    private static String fsPtIfSet(Decimal basePt, Map<String, String> opts) {
+        if (opts == null || String.isBlank(opts.get('fontSize'))) {
+            return '';
+        }
+        return ' font-size:' + fsPt(basePt, opts) + 'pt;';
+    }
+
     private static String fsPt(Decimal basePt, Map<String, String> opts) {
         if (opts == null || String.isBlank(opts.get('fontSize'))) {
-            return String.valueOf(basePt.setScale(1).stripTrailingZeros());
+            return css(basePt);
         }
         Decimal requestedPx;
         try {
             requestedPx = Decimal.valueOf(opts.get('fontSize').trim());
         } catch (Exception e) {
-            return String.valueOf(basePt.setScale(1).stripTrailingZeros());
+            return css(basePt);
         }
         if (requestedPx <= 0) {
-            return String.valueOf(basePt.setScale(1).stripTrailingZeros());
+            return css(basePt);
         }
         // Clamped to the same 6-48px the Canvas control offers.
         Decimal clamped = Math.min(Math.max(requestedPx, 6), 48);
-        Decimal scaled = basePt * clamped / LABEL_BASE_PX;
-        return String.valueOf(scaled.setScale(1, System.RoundingMode.HALF_UP).stripTrailingZeros());
+        return css(basePt * clamped / LABEL_BASE_PX);
     }
 
     /** The pixel size `fontSize=` names. 12px is the 9pt this path already drew. */
@@ -512,7 +548,9 @@ public with sharing class DocGenChartTagExpander {
             '<table style="width:100%; border-collapse:collapse; margin:6px 0 18px 0;">' +
             chartBucketTag +
             '<tr>' +
-            '<td style="padding:7px 6px; vertical-align:middle; border-bottom:1px solid #e5e7eb; font-weight:bold; color:#1f2937; padding-right:14px; width:28%;">{key_label}</td>' +
+            '<td style="padding:7px 6px; vertical-align:middle; border-bottom:1px solid #e5e7eb; font-weight:bold; color:#1f2937; padding-right:14px; width:28%;' +
+            fsPtIfSet(10, opts) +
+            '">{key_label}</td>' +
             '<td style="padding:7px 6px; vertical-align:middle; border-bottom:1px solid #e5e7eb; width:55%;">' +
             '<div style="width:100%; background-color:#f3f4f6; height:18px; border:1px solid #e5e7eb;">' +
             '<div style="height:18px; line-height:18px; font-size:1px; width:{percent}%; background-color:{color};">&nbsp;</div>' +
@@ -565,7 +603,9 @@ public with sharing class DocGenChartTagExpander {
             '</div>' +
             chartBucketTag +
             '<div style="display:table-row;">' +
-            '<div style="display:table-cell; padding:7px 10px; border-bottom:1px solid #e5e7eb; font-weight:bold; color:#1e3a8a;">{key_label}</div>' +
+            '<div style="display:table-cell; padding:7px 10px; border-bottom:1px solid #e5e7eb; font-weight:bold; color:#1e3a8a;' +
+            fsPtIfSet(9, opts) +
+            '">{key_label}</div>' +
             '{#cols}' +
             '<div style="display:table-cell; padding:7px 10px; border-bottom:1px solid #e5e7eb; text-align:right; color:#1f2937;">{percent}%</div>' +
             '{/cols}' +
@@ -667,7 +707,9 @@ public with sharing class DocGenChartTagExpander {
             '<div style="display:table; width:100%; border-collapse:collapse; margin:0 0 18px 0;">' +
             chartBucketTag +
             '<div style="display:table-row;">' +
-            '<div style="display:table-cell; padding:9px 8px; vertical-align:middle; border-bottom:1px solid #e5e7eb; width:30%; font-weight:bold; color:#1f2937;">{key_label}</div>' +
+            '<div style="display:table-cell; padding:9px 8px; vertical-align:middle; border-bottom:1px solid #e5e7eb; width:30%; font-weight:bold; color:#1f2937;' +
+            fsPtIfSet(9, opts) +
+            '">{key_label}</div>' +
             '<div style="display:table-cell; padding:9px 8px; vertical-align:middle; border-bottom:1px solid #e5e7eb; width:55%;">' +
             '<div style="display:table; width:100%; height:18px; border:1px solid #d1d5db;">' +
             '{#cols}' +

--- a/force-app/main/default/classes/DocGenChartTagExpanderTest.cls
+++ b/force-app/main/default/classes/DocGenChartTagExpanderTest.cls
@@ -584,4 +584,85 @@ private class DocGenChartTagExpanderTest {
         out.sort();
         return String.join(out, ',');
     }
+
+    /**
+     * The category labels have to move with fontSize= as well.
+     *
+     * Measured in a rendered PDF: at fontSize=30 the value labels grew from 7.8pt to
+     * 23.4pt while "Sales" and "Engineering" stayed at 10.3. Those cells carried no
+     * font-size at all and were inheriting the document's, so the option moved half the
+     * chart.
+     *
+     * The size is emitted only when the tag asks for one. Always-on would give those
+     * cells a fixed base and silently restyle every existing chart in a template that
+     * sets its own body font.
+     */
+    @isTest
+    static void categoryLabelsScaleAndDefaultsAreUntouched() {
+        String tag = '{#ChartBucket:Contacts:Department}{key}{count}{percent}{/ChartBucket}';
+        Test.startTest();
+        for (String style : new List<String>{ 'bar', 'pivot', 'stacked', 'clustered' }) {
+            Map<String, String> plain = new Map<String, String>{ 'style' => style, 'colSort' => 'A,B' };
+            Map<String, String> big = new Map<String, String>{
+                'style' => style,
+                'colSort' => 'A,B',
+                'fontSize' => '24'
+            };
+            String a = DocGenChartTagExpander.renderForTest('T', tag, plain);
+            String b = DocGenChartTagExpander.renderForTest('T', tag, big);
+
+            System.assertNotEquals(a, b, style + ': fontSize= must change the output');
+            System.assert(
+                b.substringBefore('{key_label}').substringAfterLast('<').contains('font-size'),
+                style + ': the category cell carries a size once fontSize= is set'
+            );
+            System.assertEquals(
+                a,
+                DocGenChartTagExpander.renderForTest('T', tag, plain),
+                style + ': rendering is deterministic'
+            );
+        }
+        Test.stopTest();
+    }
+
+    /**
+     * Sizes must be valid CSS at every fontSize=, not just the convenient ones.
+     *
+     * Decimal.stripTrailingZeros() renders any multiple of ten in scientific notation —
+     * 1E+1, 2E+1, 4E+1 — which is not a CSS length. The engine discards the declaration
+     * and the element falls back to the inherited size, silently.
+     *
+     * It bit unevenly, which is why it survived: at fontSize=12 the 10pt cell broke, at
+     * 30 the 16pt title broke, and at 24 nothing did. 24 is the value the first tests
+     * happened to use.
+     */
+    @isTest
+    static void chartSizesAreAlwaysValidCss() {
+        String tag = '{#ChartBucket:Contacts:Department}{key}{count}{percent}{/ChartBucket}';
+        Test.startTest();
+        for (String style : new List<String>{ 'bar', 'pivot', 'stacked', 'clustered' }) {
+            // 12 and 30 are the values that produced 1E+1 and 4E+1; 18 gives fractions.
+            for (String req : new List<String>{ '6', '12', '18', '24', '30', '48' }) {
+                String html = DocGenChartTagExpander.renderForTest(
+                    'Title',
+                    tag,
+                    new Map<String, String>{ 'style' => style, 'colSort' => 'A,B', 'fontSize' => req }
+                );
+                System.assert(
+                    !html.contains('E+'),
+                    style +
+                        ' @ fontSize=' +
+                        req +
+                        ' emitted scientific notation: ' +
+                        html.substringAfter('E+').left(0) +
+                        html
+                );
+                System.assert(
+                    Pattern.compile('font-size:[0-9]').matcher(html).find(),
+                    style + ' @ fontSize=' + req + ' emitted no usable size'
+                );
+            }
+        }
+        Test.stopTest();
+    }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -246,6 +246,7 @@
     "Portwood@3.55.0-2": "04tVx0000010fXFIAY",
     "Portwood@3.56.0-1": "04tVx0000010faTIAQ",
     "Portwood@3.56.0-2": "04tVx0000010fc5IAA",
-    "Portwood@3.56.0-3": "04tVx0000010fk9IAA"
+    "Portwood@3.56.0-3": "04tVx0000010fk9IAA",
+    "Portwood@3.56.0-4": "04tVx0000010fllIAA"
   }
 }


### PR DESCRIPTION
The sweep before building found two more faults in my own work. Both would have shipped in the **fifth** build of this feature.

## 1. Invalid CSS at certain sizes

`Decimal.stripTrailingZeros()` renders any multiple of ten in scientific notation — `1E+1`, `2E+1`, `4E+1`. Not a CSS length, so the engine discards the declaration and the element silently falls back to the inherited size.

It bit **unevenly**, which is how it survived:

| `fontSize=` | what broke |
| --- | --- |
| 12 | the 10pt cell → `1E+1` |
| 24 | nothing |
| 30 | the 16pt title → `4E+1` |

24 is exactly the value my earlier tests used. The SVG serializer returns `Integer` and was never exposed.

## 2. Category labels weren't scaling

Those cells carried **no `font-size` at all** in bar, pivot and stacked — they inherited the document's. Measured in a rendered PDF: at `fontSize=30` the values grew 7.8pt → 23.4pt while "Sales" stayed at 10.3.

Emitted **only when the tag asks for a size**. Always-on would give those cells a fixed base and silently restyle every existing chart in a template that sets its own body font.

## Verified in the document, not the markup

At `fontSize=12` vs `30` — the value that used to break:

| word | 12 | 30 | ratio |
| --- | --- | --- | --- |
| Sales | 9.4pt | 23.4pt | 2.49 |
| Engineering | 9.4pt | 23.4pt | 2.49 |
| 3 | 9.4pt | 23.4pt | 2.49 |
| (50.0%) | 9.4pt | 23.4pt | 2.49 |

Expected 2.5. Swept all four styles at 6/12/18/24/30/48 — every size present, correctly scaled, no scientific notation, no unsized text element.

39 assertions in `DocGenChartTagExpanderTest`, including multiples of ten and both clamp boundaries. Full suite **1961/1961**.