### PR TITLE
docs: make the repo contributable — skills, working setup, date milestones

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,37 @@
+# Portwood skills
+
+Project knowledge packaged as [Claude Code skills](https://docs.claude.com/en/docs/claude-code/skills).
+If you use Claude Code in this repo they load automatically when relevant; if you don't,
+read them as plain Markdown — each one is a self-contained guide.
+
+They exist because most of what makes Portwood hard to change is not visible in the
+code: the renderer silently ignores half of CSS, tags resolve through four different
+paths that don't share code, and a whole class of bug only appears in a real
+managed-package install. These write that down.
+
+| Skill                                                         | Read it when                                                                      |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| [`dev-setup`](dev-setup/SKILL.md)                             | Going from a fresh clone to a working, tested org                                 |
+| [`run-tests`](run-tests/SKILL.md)                             | Verifying a change — QA harness, e2e scripts, prettier, Code Analyzer             |
+| [`triage-report`](triage-report/SKILL.md)                     | A bug report arrives and you need to know if it's a real defect                   |
+| [`fix-merge-tag`](fix-merge-tag/SKILL.md)                     | Changing tag parsing, loops, conditionals, aggregates or charts                   |
+| [`html-template-authoring`](html-template-authoring/SKILL.md) | Writing a template, or a PDF doesn't match its source                             |
+| [`canvas-designer`](canvas-designer/SKILL.md)                 | Touching the Canvas artboard, serializer or importer                              |
+| [`managed-package-rules`](managed-package-rules/SKILL.md)     | Adding subscriber-visible Apex, a Flow action, or debugging install-only failures |
+
+## Start here
+
+New contributor: **`dev-setup`** → **`run-tests`**. That's clone to green tests.
+
+Picking up an issue: **`triage-report`** first — it tells you whether the report is a
+code defect at all. Then the skill for the area you're changing.
+
+## The two highest-value facts
+
+If you read nothing else:
+
+1. **Most "the PDF looks wrong" reports are template issues, not bugs.** The renderer is
+   CSS 2.1 and silently ignores `flex`, `grid`, `gap`, `calc()` and CSS variables. Check
+   the template before you check the code.
+2. **A merge-tag fix in one resolution path does not reach the other three.** Find out
+   which path the failing template takes before you write anything.

--- a/.claude/skills/canvas-designer/SKILL.md
+++ b/.claude/skills/canvas-designer/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: canvas-designer
+description: Work on Portwood's Canvas designer (docGenCanvas LWC and canvasModel.js). Use when changing the artboard, the box model, the HTML serializer or importer, or when a Canvas template renders differently from what the canvas showed.
+---
+
+# Working on the Canvas designer
+
+`force-app/main/default/lwc/docGenCanvas/` — a Canva-style artboard that produces
+HTML templates. ~9,900 lines of client code; `canvasModel.js` is the scene graph and
+**the only place that knows how it becomes HTML**.
+
+Canvas templates render through the HTML path (`DocGenService.isHtmlBacked`), so output
+is always PDF. The Apex side is two lines — there is no `DocGenCanvasService`.
+
+## The architecture, and why it is that way
+
+**The model is the truth. The DOM is a disposable projection.**
+
+The older designer treated the rendered DOM as the document, reading it back with
+`innerHTML` and re-parsing. Under Lightning Web Security's per-namespace sandbox that
+repeatedly broke: `ChildNode.replaceWith` is missing on proxied nodes, and
+`cloneNode(true)` silently omits browser-inserted nodes. Canvas never parses anything
+back out of the live tree, so there is no tree to be distorted. `contenteditable`
+survives only _inside_ a single text box, where the browser's restructuring can't escape.
+
+**Rules that follow from this — do not break them:**
+
+- Never read the canvas back via `cloneNode` or `replaceWith` on the live tree.
+- Never reconstruct model state from rendered DOM.
+- Boxes are plain objects with **inch** coordinates. Pixels appear only at render time
+  (inches × 96 × zoom), so changing zoom can never drift the document.
+
+## Key functions in `canvasModel.js`
+
+| Function                           | What it does                                                  |
+| ---------------------------------- | ------------------------------------------------------------- |
+| `serialize(doc, geo)`              | Model → HTML. Pinned boxes first, then flow boxes in y order. |
+| `deserialize(html)`                | HTML → model, for reopening a saved document                  |
+| `htmlToCanvas(html, measure)`      | The importer — arbitrary HTML → boxes                         |
+| `buildQueryConfig(doc)`            | Derives a V1 Query Config from the tags actually placed       |
+| `collectUsedFields(doc)`           | Merge-tag discovery, including conditions and totals          |
+| `snapBox` / `buildAnchorGroups`    | Alignment guides, and box linking with cycle detection        |
+| `sanitizeInline` / `collapseMarks` | Rich-text handling and brace repair                           |
+
+### Two behaviors worth understanding before you change anything
+
+**`flowMarginTop` emits the GAP from the previous flow box, not the box's `y`.** That
+one function is the entire "a table grows and pushes everything below it down"
+behavior. Emitting absolute `y` puts a box authored at y=5in five inches _below_ the
+table, and the error compounds with each additional flow box.
+
+**`buildQueryConfig` emits V1 flat format on purpose**, not V3 — V1 is what a human can
+read and correct in the Query Configuration tab. It is a _suggestion the author
+accepts_, never a silent overwrite.
+
+## Test before you push — no org needed
+
+The serializer is deliberately written to run without a DOM (`typeof document ===
+'undefined'` guards), so it can be checked in plain Node:
+
+```bash
+node scripts/qa/canvas-serializer-check.mjs
+node scripts/qa/canvas-anchor-check.mjs
+node scripts/qa/canvas-export-roundtrip-check.mjs
+node scripts/qa/canvas-import-fidelity.mjs
+node scripts/qa/canvas-import-placement-check.mjs
+node scripts/qa/canvas-inline-sanitize-check.mjs
+node scripts/qa/canvas-chart-box-check.mjs
+```
+
+**Run these first on any `canvasModel.js` change.** They are the fastest feedback loop
+in the repo. If you add a serializer rule, add a check here — a serializer that only
+runs in a browser cannot be verified before it ships.
+
+## Traps
+
+### Serializer fixes do not reach saved documents
+
+A stored body keeps its old markup until it is re-saved. A fix to `serialize` changes
+what _new_ saves produce; it does nothing for documents already in the org. Plan
+migrations accordingly, and don't treat "still broken after the fix" as a failed fix
+until you've re-saved.
+
+### The `Canvas` picklist value is frozen forever
+
+It shipped in a managed package (v3.54.0). The value and everything keyed to it can
+never be renamed or removed.
+
+### Bold vs symbols is an either/or
+
+`'Arial Unicode MS'` is the only family that draws symbols/CJK, and it has **no bold
+face** — `canRenderBold()` exists to disable the Bold control for it so the canvas
+doesn't promise a weight the PDF can't deliver. Every other family bolds fine.
+
+### `box.html` vs `box.text`
+
+`textToHtml` prefers `box.html` and falls back to `box.text`. The `text` path runs
+through `expandMarks`, where `__` is the underline mark — which collides with `__c` and
+`__r` in Salesforce API names. For programmatic authoring, set `box.html` (escaped,
+`<br />` for newlines) and treat `text` as the legacy fallback. See issues #282 and #295.
+
+### LWS blocks some browser APIs
+
+`createObjectURL` for `text/html` is blocked — the HTML export uses a `data:` URI
+instead. Expect similar surprises with any browser API that hands out a URL or a live
+node reference.
+
+## Reproducing namespace bugs
+
+LWS distortion **cannot be reproduced in a no-namespace scratch org**. If you're
+touching DOM handling, the bug class is only visible in a namespaced package install or
+a namespaced scratch org.

--- a/.claude/skills/dev-setup/SKILL.md
+++ b/.claude/skills/dev-setup/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: dev-setup
+description: Get from a fresh clone of Portwood to a working, fully-tested Salesforce org. Use when setting up a development environment, creating a scratch org, onboarding to the project, or when org setup fails with permission or "No such column" errors.
+---
+
+# Setting up a Portwood dev environment
+
+Two commands. If either fails, the causes are almost always in the gotchas below.
+
+## Prerequisites
+
+- Salesforce CLI (`sf`)
+- A DevHub org (a Developer Edition org works)
+- Node 18+ and `npm install` run once, for prettier and the QA harness
+
+## Stand up an org
+
+```bash
+npm install          # once — prettier + QA harness deps
+npm run org:new      # creates the `docgen-verify` scratch org and configures it end to end
+```
+
+To use an org you already have:
+
+```bash
+npm run org:setup -- my-existing-org
+```
+
+`scripts/qa/setup-org.sh` is **idempotent** — safe to re-run against a live org. It
+takes an org from nothing to fully testable:
+
+1. Creates the scratch org **`--no-namespace`**, so the e2e scripts' bare class and
+   field references compile.
+2. Deploys `force-app`.
+3. Assigns `DocGen_Admin` and `DocGen_User` — **after** the deploy.
+4. Deploys the QA-only host page, so `docGenRunner` and `docGenSignatureSender` are
+   actually placed on a record page. The package ships no FlexiPage on purpose; without
+   this there is nowhere for a browser test to reach them.
+5. Sets org defaults that stop testing stalling on infrastructure — above all
+   `Signature_Skip_Email_Verification__c`, and reminders OFF.
+6. Seeds the Account and the `Verify — Designer` template the smoke suite opens.
+
+## One manual step the script cannot do
+
+**Setup → Release Updates → "Use the Visualforce PDF Rendering Service for
+`Blob.toPdf()` Invocations" → Enable.**
+
+Without it, PDF output is wrong in ways that look like template bugs.
+
+## Verify it worked
+
+```bash
+npm run qa                  # every suite, against docgen-verify
+```
+
+Exit code is `0` only when every evaluated check passed. See the `run-tests` skill for
+the full set of options.
+
+## Gotchas that cost the most time
+
+### "No such column" on a field that plainly exists
+
+The permission set was not assigned, or was assigned **before** the deploy. Anonymous
+Apex enforces FLS, so a missing permset makes deployed fields look like corrupted
+metadata. Assign `DocGen_Admin` after deploying, then retry. This is the single most
+common false alarm.
+
+### The org must be `--no-namespace`
+
+Source-deploy has to land in the default namespace or the e2e scripts' bare class and
+field references won't compile. `setup-org.sh` already does this; if you create an org
+by hand, pass `--no-namespace`.
+
+### Namespace bugs are invisible in a dev org
+
+Lightning Web Security's per-namespace sandbox distorts DOM nodes, and
+`getPopulatedFieldsAsMap` / raw SObject keys come back namespace-prefixed in a
+subscriber org. Neither reproduces in a no-namespace scratch org. If you're touching
+LWC DOM handling or reading SObject fields in JS, that class of bug can only be caught
+in a namespaced package install.
+
+### Don't run a bare `sf apex run test`
+
+It triggers an org-wide run that locks `ContentFolder` and takes far longer than you
+want. Always scope it:
+
+```bash
+sf apex run test --target-org docgen-verify --tests DocGenServiceTest --wait 15
+```
+
+## Where things live
+
+| Path                              | What                                                                         |
+| --------------------------------- | ---------------------------------------------------------------------------- |
+| `force-app/main/default/classes/` | Apex — the merge engine, controllers, services                               |
+| `force-app/main/default/lwc/`     | Lightning Web Components — designer, runner, canvas                          |
+| `scripts/e2e-*.apex`              | Anonymous-Apex end-to-end suite                                              |
+| `scripts/qa/`                     | The one-command QA harness and its suites                                    |
+| `docs/`                           | Reference templates (`SurveyChartExample.html` is canonical for charts)      |
+| `TRIAGE.md`                       | Priority rubric                                                              |
+| `CLAUDE.md`                       | Critical engine constraints — read before touching the merge or PDF pipeline |

--- a/.claude/skills/fix-merge-tag/SKILL.md
+++ b/.claude/skills/fix-merge-tag/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: fix-merge-tag
+description: Fix a Portwood merge-tag or parser bug correctly across all of its resolution paths. Use when changing tag parsing, section/loop tags, conditionals, aggregates, or chart buckets — a fix in one path silently does not reach the others.
+---
+
+# Fixing a merge-tag bug
+
+**The trap:** there is more than one place that resolves tags, and they do not share
+code. A fix landed in one path leaves the others broken, and the failure is silent —
+the tag just prints raw or evaluates wrong for templates that happen to take a
+different route.
+
+Before writing a fix, work out which path(s) the reported template takes.
+
+## The three merge-tag resolution paths
+
+`DocGenGiantQueryAssembler` does **not** call `processXml()`. So:
+
+| Path                               | Resolved by                                             | Reached when                             |
+| ---------------------------------- | ------------------------------------------------------- | ---------------------------------------- |
+| Row-level loop bodies              | `DocGenService.processXml()`                            | normal templates                         |
+| Parent-level tags outside the loop | `DocGenGiantQueryAssembler.resolveParentMergeTags()`    | giant-query templates (>2000 child rows) |
+| Grand-total aggregates             | `DocGenGiantQueryAssembler.resolveGiantAggregateTags()` | giant-query templates                    |
+
+A section-tag fix in `processXml` covers **only** row-level loop bodies. If the change
+needs to behave consistently for giant-query templates, mirror it in the assembler or
+route it through `processXmlForTest` the same way format-suffix tags already do.
+
+**Always** check whether your fix needs the same change in the giant-query parent path,
+and add an `e2e-07` assertion either way — including one that proves it doesn't need it.
+
+## The four `{#ChartBucket}` resolution paths
+
+`{#ChartBucket:relationship:field[:mod=val&...]}body{/ChartBucket}` has its own set,
+and all four must stay consistent:
+
+1. **In-memory** — `DocGenChartBucketResolver.preprocessInline` against pre-loaded
+   relationship records. Used when child count <2000 **and** no `where=`/`groupBy=`.
+   SOQL-free, fastest.
+2. **SOQL fallback** — `tryFallbackSoqlAggregateAdvanced`, when the relationship isn't
+   on the data map or `where=`/`groupBy=` force it. Schema-auto-discovers child object
+   and FK via `ChildRelationship`, issues a `GROUP BY` aggregate at constant cost.
+   **This is how 30K-scale templates work.**
+3. **Parent-level** — `resolveParentMergeTags()`'s regex skips `{#…}` prefixes so charts
+   pass through, then `processXmlForTest` routes to the inline path.
+4. **Giant-query parent** — `resolveGiantChartBuckets` for charts targeting the giant
+   relationship. Same modifiers, same shape.
+
+**SOQL budget:** 50 chart aggregates per transaction
+(`DocGenChartBucketResolver.chartSoqlBudget`). When exhausted, charts render a sentinel
+"Chart limit reached" bucket — never silently empty.
+
+### The five modifiers
+
+Composable, and all four paths must honour each:
+
+| Modifier                        | Behavior                                                                |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| `colors=#aaa,#bbb`              | Override the default 8-color palette, cycling by row index              |
+| `where=Field='X' AND Y != null` | Sanitized SOQL fragment appended to the WHERE. Forces SOQL fallback.    |
+| `split=;`                       | Multi-select delimiter; percentages summing >100% is expected           |
+| `groupBy=Field__c`              | Cross-tab pivot; each row gets a `cols` sub-list. Forces SOQL fallback. |
+| `colSort=v1,v2`                 | Column ordering for `groupBy=`; named first, rest alpha, Total last     |
+
+## Query Config formats
+
+V1 (flat string) and V3 (node tree) reproduce similar patterns in different code —
+V3's `processChildNodes` and V1's `stitchGrandchildren`. **A fix often needs to land in
+both.**
+
+## Constraints you must not regress
+
+### Zero-heap PDF image rendering
+
+For PDF output, `{%ImageField}` tags with ContentVersion IDs skip blob loading.
+`currentOutputFormat` is set to `'PDF'` before `processXml()` calls; in
+`buildImageXml()`, when the format is `'PDF'` and the value is a `068` ID, query **only**
+`Id, FileExtension` — never `VersionData` — and store the relative URL
+`/sfc/servlet.shepherd/version/download/<cvId>`.
+
+If your fix touches `processXml`:
+
+- **Do not** add `VersionData` to the PDF-path SOQL.
+- **Do not** prepend `URL.getOrgDomainUrl()` anywhere in the image pipeline.
+
+Image URLs for `Blob.toPdf` **must be relative**. Absolute URLs and `data:` URIs render
+broken.
+
+### Exception ordering
+
+`processXml`'s try/catch must rethrow `HeapPressureException` ahead of the generic
+catch. Order: `HeapPressureException` → `DocGen*` → generic.
+
+## Verifying the fix
+
+1. Add a regression assertion in `e2e-07-syntax5` (or a new `syntax6`) exercising the
+   pattern via `processXmlForTest`. `syntax1`–`syntax4` are near the 18,000-char ceiling.
+2. Add an `e2e-07` assertion for the giant-query parent path — even if the answer is
+   "unchanged", the assertion is what stops the next person breaking it.
+3. `npm run qa -- --suite merge-tags`
+4. Scoped Apex tests, then `npm run format:check`.
+
+See the `run-tests` skill for the constraints on writing e2e assertions.

--- a/.claude/skills/html-template-authoring/SKILL.md
+++ b/.claude/skills/html-template-authoring/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: html-template-authoring
+description: Author or repair a Portwood HTML template that renders correctly through Blob.toPdf (Flying Saucer). Use when writing a new template, converting a design to a template, or fixing one whose PDF output doesn't match the source — collapsed layout, missing images, wrong fonts, broken charts.
+---
+
+# Authoring HTML templates for Portwood
+
+**HTML is the recommended source format.** It skips the DOCX→HTML parse and lands more
+reliably in the renderer. Steer new authors here, and chart authors here without
+exception.
+
+## The renderer is CSS 2.1
+
+`Blob.toPdf` is Flying Saucer: **CSS 2.1 plus a small CSS 3 subset**. Unsupported
+properties are _silently ignored_ — the page still renders, but layout collapses to
+default block flow. Nothing warns you.
+
+### Never use
+
+- `display: flex`, `display: grid`, `gap`
+- `linear-gradient(...)` and friends
+- `calc(...)`
+- CSS custom properties (`var(--x)`)
+- most CSS 3 layout
+
+### Use instead
+
+- `<table>`-based layout for anything multi-column
+- solid background colors
+- absolute lengths (`pt`, `in`) and percentages
+- `display: table-cell` / `table-row` on `<div>` where you need cell behavior without a
+  real table
+
+### The `tbody` trap
+
+```css
+table > tbody > tr > td { ... }   /* silently matches NOTHING */
+```
+
+The parse tree has no implied `<tbody>`. Use `td` attribute selectors or class-only
+selectors:
+
+```css
+td.total { ... }
+```
+
+## Images
+
+**URLs must be relative.** Absolute `https://…` URLs and `data:` URIs both render
+broken — this is a hard constraint of the renderer, not a bug to work around.
+
+If the same image appears at two different sizes, the renderer caches **one layout size
+per URL**. Vary the URL to force a re-layout (the engine appends a size key for this
+reason).
+
+## Fonts and symbols
+
+The base font families resolve to the base-14 PDF fonts (Helvetica / Times / Courier,
+WinAnsi). **Anything outside Latin-1 renders as nothing** — not a box, not a fallback,
+absent. Checkmarks, arrows, CJK, Greek, Cyrillic all disappear.
+
+`'Arial Unicode MS'` is the one family that draws them, embedding as a subsetted CID
+font. The trade-off is real and worth knowing:
+
+|                      | Symbols / CJK | Bold                                                   |
+| -------------------- | ------------- | ------------------------------------------------------ |
+| `'Arial Unicode MS'` | ✅            | ❌ — no bold face; `font-weight: bold` renders regular |
+| every other family   | ❌            | ✅                                                     |
+
+So a symbol-heavy document gives up bold. Build hierarchy from **size, colour and fill
+bands** instead — reversed white-on-dark headers, tinted totals rows, a solid band
+behind the key number.
+
+Embedding costs roughly 1.5KB → 70KB per page that uses it, and only for the glyphs
+used.
+
+## `@page` conflicts
+
+The engine builds a `<style>` from the template's `Page_Size__c`, `Page_Orientation__c`
+and `Custom_Margins__c` fields. If your source HTML also declares `@page`, the engine
+**defers to your source** — you do not need to clear the template's page fields.
+
+## Charts
+
+Charts are **not** HTML-only — Word, PowerPoint and Excel get a rasterized PNG from
+`DocGenChartRasterizer`, and in fact support _more_ chart shapes than HTML→PDF does.
+What varies is which **style** survives which output.
+
+| Style                                    | Word / PPTX / XLSX |  HTML → PDF  |    HTML in a browser     |
+| ---------------------------------------- | :----------------: | :----------: | :----------------------: |
+| `bar`                                    |       ✅ PNG       |  ✅ CSS-bar  |            ✅            |
+| `pivot`                                  |         ❌         | ✅ CSS table |            ✅            |
+| `clustered`, `stacked`                   |       ✅ PNG       | ✅ CSS table |            ✅            |
+| `column`, `pie`, `donut`, `line`, `area` |       ✅ PNG       |      ❌      | ✅ with `htmlRender=svg` |
+
+### The two rules behind that table
+
+**Flying Saucer drops inline `<svg>` from `Blob.toPdf`.** The `htmlRender=svg` modifier
+routes through `DocGenSvgChartSerializer` and looks perfect in a browser, then vanishes
+in the PDF. If your HTML template is destined for PDF, stay on the default CSS-bar
+styles: `bar`, `pivot`, `clustered`, `stacked`.
+
+**`pivot` never rasterizes.** It isn't in the rasterizer's `KNOWN_STYLES` because a
+cross-tab is a table, not a chart shape. Cross-tab belongs in HTML.
+
+So: rich chart shapes in a PDF → author the template in **Word** and let the PNG
+pipeline handle it. Cross-tab pivots → **HTML**.
+
+### The pivot layout gotcha
+
+HTML container auto-expansion looks for the nearest open `<tr>` when processing nested
+`{#…}` loops. Putting `{#cols}` directly inside a `<tr>` makes **each column duplicate
+the whole row**.
+
+```html
+<!-- WRONG — every column repeats the entire row -->
+<tr>
+    {#cols}
+    <td>{key}</td>
+    {/cols}
+</tr>
+
+<!-- RIGHT — div + table-row, CSS 2.1 safe -->
+<div class="row" style="display: table-row">
+    {#cols}
+    <div style="display: table-cell">{key}</div>
+    {/cols}
+</div>
+```
+
+### Reference templates
+
+| File                             | What it shows                                                               |
+| -------------------------------- | --------------------------------------------------------------------------- |
+| `docs/SurveyChartExample.html`   | Canonical chart template — single-dimension per question + cross-tab spread |
+| `docs/CommuteSurveyExample.html` | Pivot + filter + multi-select + colSort composed together                   |
+| `docs/ChartEngineShowcase.html`  | The full style gallery                                                      |
+
+## Large tables
+
+For giant-query templates, repeating headers on every PDF page come from Flying
+Saucer's `-fs-table-paginate: paginate` plus `thead { display: table-header-group; }`.
+Be aware this **mis-paginates some real-world templates dramatically** — verify page
+count on a full render before relying on it.
+
+## Before you ship a template
+
+- Grep your own CSS: `grep -nE "flex|grid|gap:|gradient|calc\(|var\(--" template.html`
+- Confirm every `<img src>` is relative
+- If it has symbols, confirm the font is `'Arial Unicode MS'` and you haven't relied on bold
+- Render it and count the pages

--- a/.claude/skills/managed-package-rules/SKILL.md
+++ b/.claude/skills/managed-package-rules/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: managed-package-rules
+description: Constraints that only bite in a real managed-package install of Portwood — global visibility, Flow Apex-Defined types, namespace-prefixed keys, USER_MODE on internal reads, immutable API names. Use when adding Apex a subscriber must see, building a Flow action, or debugging something that works in a scratch org but fails in a package install.
+---
+
+# Managed-package constraints
+
+Portwood ships as **Managed 2GP**, namespace `portwoodglobal`. A large class of bugs
+exists only in a real subscriber install and **cannot be reproduced in a no-namespace
+scratch org**. If something works in dev and fails in an install, start here.
+
+## Only `global` Apex is visible to subscribers
+
+`public` classes and methods are **invisible** in a subscriber org.
+
+- An `@InvocableMethod` must be `global` to appear in a subscriber's Flow Builder.
+- Helper classes a subscriber is meant to call must be `global`, along with their inner
+  types, fields and methods.
+
+## Flow Apex-Defined variable types — all four are required
+
+For a type to be selectable as a Flow Apex-Defined variable in a subscriber org:
+
+1. **Top-level / standalone class.** Flow ignores inner and nested classes entirely.
+2. **`global`** class.
+3. **`@AuraEnabled`** members.
+4. **`global` no-arg constructor.**
+
+Missing any one produces the same symptom: the action appears, but its variable type
+can't be selected. This cost three separate releases to get right, each time because
+only one of the four was missing. **Verify in a real subscriber install or a namespaced
+scratch org** — a no-namespace staging org cannot show you the failure.
+
+## API names are frozen forever
+
+Everything shipped is immutable: `DocGen_Template__c`, `DocGenService`, `DocGen_Admin`,
+the `portwoodglobal` namespace, the `Canvas` picklist value. Display names (labels,
+descriptions, user-visible strings) can change; API names cannot.
+
+Two scheduled job names deliberately keep their old strings because they're matched by
+`CronJobDetail.Name` in orgs that already scheduled them: `DocGen Signature Reminders`
+and `DocGen Chart CV Reaper`.
+
+2GP also cannot drop Apex classes without the "Remove Metadata Components" DevHub
+feature — the workaround is inert stubs.
+
+## Namespace-prefixed keys break JS
+
+In a subscriber org, SObject field keys come back **namespace-prefixed**:
+
+- `row.Field__c` is `undefined` in a shipped package — it's `row.portwoodglobal__Field__c`.
+  Use `@salesforce/schema` imports or a normalizing mapper in LWC.
+- `getPopulatedFieldsAsMap()` keys are prefixed too. Prefer direct field access.
+
+Neither reproduces in a no-namespace org. A namespaced build is the real gate.
+
+## `WITH USER_MODE` on internal reads
+
+Portwood's internal ContentVersions (`docgen_tmpl_html_*`, `docgen_tmpl_xml_*`) have
+`ContentDocumentLink.Visibility = InternalUsers`, which is **invisible under
+`USER_MODE`** — the read silently returns empty and the caller falls back to something
+degraded. Use the FLS-guard + `WITH SYSTEM_MODE` hybrid for these.
+
+The same applies to a **newly packaged field**: the build's test user has no permission
+set, so `WITH USER_MODE` fails the package build with "No such column" on a field that
+plainly exists. Use `SYSTEM_MODE` plus an FLS guard for internal config reads.
+
+## Guest-context rules
+
+- Guest profiles need the **guest** FLS-guard variants, not the admin ones — the
+  per-field verdict throws for guests even when the permission set grants access.
+- `@AuraEnabled(cacheable=true)` serves stale empty results to guests. Never cache
+  context-sensitive Apex.
+- Every guest-reachable `SYSTEM_MODE` query must be **token-keyed**, never keyed by a
+  guessable Id — that shape has already produced one IDOR.
+- A guest LWC silently fails to render if the guest can't see the `recordId`. Check
+  sharing before debugging the component.
+
+## No external callouts
+
+Portwood is 100% native — no external services, APIs, or callouts, and document data
+never leaves the org. Client-side libraries are **vendored as pinned static resources**,
+not pulled from npm at build time. If you add or update one: keep it patched, retain its
+license/NOTICE, and disclose it.
+
+Extension points exist precisely so the non-native hop can live outside the package —
+see `DocGenAiProvider` and `DocGenDataProvider`, both resolved by `Type.forName` with a
+namespace fallback.
+
+## Testing the things a scratch org can't show you
+
+A namespaced pre-flight org catches build traps in minutes rather than after a 20–40
+minute package build: deploy plus `RunLocalTests`, **without** assigning the permission
+set, so you see exactly what the build's test user sees.

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: run-tests
+description: Run Portwood's test suites — the one-command QA harness, the anonymous-Apex e2e scripts, Apex unit tests, prettier, and Code Analyzer. Use before opening a PR, when verifying a fix, or when a test fails and you need to know whether it's your change or the harness.
+---
+
+# Running Portwood's tests
+
+## The one command
+
+```bash
+npm run qa
+```
+
+Runs every suite against the `docgen-verify` org and writes one report. **Exit code
+is `0` only when every evaluated check passed**, so it drops straight into CI.
+
+```bash
+npm run qa -- --org myorg           # a different org
+npm run qa -- --offline             # only suites needing no org — CI-safe, fast
+npm run qa -- --fast                # skip the slow suites
+npm run qa -- --suite merge-tags,metadata-audit
+npm run qa -- --headed              # watch the browser suites run
+npm run qa -- --list                # what suites exist
+```
+
+Output lands in `scripts/qa/report/`:
+
+- `qa-report.md` — headline numbers, coverage by area, and an ordered **what to fix** list
+- `qa-report.json` — the same data, for tracking over time
+
+**Start with `npm run qa -- --offline`.** It needs no org at all, so it's the fastest
+way to know whether you broke something, and it's what a contributor without a
+configured org can still run.
+
+### Suites
+
+`apex-e2e`, `apex-unit`, `flow-actions`, `merge-tags`, `metadata-audit`,
+`output-formats`, `pdf-content`, `record-pages`, `template-integrity`, `ui-admin`,
+`ui-designer`, `ui-runner`.
+
+A suite that cannot run returns "skipped" rather than throwing — the report says so out
+loud instead of quietly reporting 100%. **A skipped suite is not a passing suite**;
+check the report rather than just the exit code when you care about coverage.
+
+### Adding a suite
+
+Drop a file in `scripts/qa/suites/` exporting `run({ org, headed, base })` that returns
+`suiteResult(...)` from `lib/report.mjs`, then register it in `SUITES` in
+`scripts/qa/run-all.mjs`. Suites must never throw.
+
+## The pure-Node checks
+
+`scripts/qa/canvas-*.mjs` and friends run serializer and layout logic **with no browser
+and no org** — that's why the serializer is written to survive `typeof document ===
+'undefined'`. They're the fastest feedback loop in the repo:
+
+```bash
+node scripts/qa/canvas-serializer-check.mjs
+node scripts/qa/canvas-anchor-check.mjs
+node scripts/qa/canvas-export-roundtrip-check.mjs
+node scripts/qa/canvas-import-fidelity.mjs
+node scripts/qa/canvas-inline-sanitize-check.mjs
+```
+
+If you change `canvasModel.js`, run these before anything else.
+
+## The anonymous-Apex e2e suite
+
+Each script prints `PASS: N  FAIL: 0  ALL TESTS PASSED`.
+
+```bash
+sf apex run --target-org docgen-verify -f scripts/e2e-01-permissions.apex
+sf apex run --target-org docgen-verify -f scripts/e2e-02-template-crud.apex
+sf apex run --target-org docgen-verify -f scripts/e2e-03-generate-pdf.apex
+sf apex run --target-org docgen-verify -f scripts/e2e-03b-page-setup.apex
+sf apex run --target-org docgen-verify -f scripts/e2e-04-generate-docx.apex
+sf apex run --target-org docgen-verify -f scripts/e2e-05-generate-bulk.apex
+sf apex run --target-org docgen-verify -f scripts/e2e-06-signatures.apex
+sf apex run --target-org docgen-verify -f scripts/e2e-06b-signature-lifecycle.apex
+sf apex run --target-org docgen-verify -f scripts/e2e-07-syntax1.apex
+sf apex run --target-org docgen-verify -f scripts/e2e-07-syntax2.apex
+sf apex run --target-org docgen-verify -f scripts/e2e-07-syntax3.apex
+sf apex run --target-org docgen-verify -f scripts/e2e-07-syntax4.apex
+sf apex run --target-org docgen-verify -f scripts/e2e-07-syntax5.apex
+sf apex run --target-org docgen-verify -f scripts/e2e-08-cleanup.apex
+```
+
+Sequence matters: `01` standalone, `02` creates test data, `03`–`06b` depend on `02`,
+`07-syntax*` standalone, `08` cleans up.
+
+### Reading a failure correctly
+
+**A governor-limit throw prints NO summary line at all.** Watch for a script that emits
+no `PASS: N`, not just a non-zero `FAIL`. That's why `03b` is split out of `03` — each
+full `generateDocument` costs ~10 SOQL, and the combined run blew the 100-SOQL
+synchronous limit.
+
+### Constraints when adding assertions
+
+- Each script must stay under **18,000 characters** (the Anonymous Apex ceiling is
+  20,000). `syntax1`–`syntax4` are already within a few hundred characters of it — put
+  new parser assertions in `syntax5` or a new `syntax6`.
+- **Anonymous Apex cannot catch a thrown `AuraHandledException`** (uncatchable
+  `LimitException`). Negative-path assertions on `@AuraEnabled` guard methods belong in
+  unit tests, not e2e.
+- **`@TestVisible private` members are unreachable from anonymous Apex.** Prettier
+  passing does not mean the script compiles — actually run it.
+
+When you fix a parser-level bug, add a regression assertion exercising the pattern via
+`processXmlForTest`.
+
+## Apex unit tests
+
+Scoped, for a fix:
+
+```bash
+sf apex run test --target-org docgen-verify --tests DocGenServiceTest --wait 15
+```
+
+**Never run a bare `sf apex run test`** — it triggers an org-wide run that locks
+`ContentFolder`. Always pass `--tests` or `--class-names`.
+
+Full local run (what release validation uses):
+
+```bash
+sf apex run test --target-org docgen-verify --test-level RunLocalTests --wait 15 --code-coverage
+```
+
+Expected: `Outcome: Passed`, `Pass Rate: 100%`, org-wide coverage ≥ 75%.
+
+## Prettier — a CI merge gate
+
+`npm run format:check` blocks merge. Run before pushing:
+
+```bash
+npm run format        # auto-fix
+npm run format:check  # verify clean
+```
+
+Covers `force-app/**/*.{cls,trigger,page,component,cmp,html,js,xml}`, `scripts/**/*.apex`,
+and root `*.{json,md,yml,yaml}`. Apex scripts get reflowed — don't fight the wrap.
+
+## Code Analyzer
+
+```bash
+sf code-analyzer run --workspace "force-app/" --rule-selector "Security" --rule-selector "AppExchange" --view table
+```
+
+Expected: `0 High severity violation(s) found`. ~30 Moderate false positives are
+acceptable and documented in `code-analyzer.yml`.
+
+## What to run before opening a PR
+
+1. `npm run qa -- --offline` — fastest signal, no org needed
+2. The `canvas-*.mjs` checks if you touched `canvasModel.js`
+3. Scoped Apex tests for classes you changed
+4. `npm run format:check`
+5. `npm run qa` in full if you have an org configured

--- a/.claude/skills/triage-report/SKILL.md
+++ b/.claude/skills/triage-report/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: triage-report
+description: Decide whether a Portwood bug report is a real code defect or a template-authoring problem, before any code is written. Use when a user reports "the PDF looks wrong", a merge tag didn't resolve, an image is missing, a chart is distorted, or output doesn't match the template. Most reports are template issues.
+---
+
+# Triaging a Portwood report
+
+**Most reports are template issues, not code defects.** Work through this before
+calling anything a bug. A report that turns out to be an authoring problem gets
+answered as guidance and closed with the `template-help` label — it does not become
+engineering work.
+
+## Step 1 — Reproduce it
+
+Do not skip to a diagnosis from the description. Get the template, the record, and
+the output format. If you can't reproduce, ask for the template body and the
+generated file before anything else.
+
+The single most useful question to ask a reporter: **"Is the template HTML or DOCX?"**
+It splits the decision tree in half.
+
+## Step 2 — Rule out the template
+
+These account for the majority of "it looks wrong" reports.
+
+### CSS 3 in an HTML template
+
+The PDF engine is `Blob.toPdf` → Flying Saucer, which is **CSS 2.1** plus a small
+CSS 3 subset. These are **silently ignored** — the page renders, but layout collapses
+to default block flow:
+
+- `display: flex`, `display: grid`, `gap`
+- `linear-gradient(...)` and other gradient functions
+- `calc(...)`
+- CSS custom properties / variables
+- most CSS 3 layout features
+
+Grep the template body first:
+
+```bash
+grep -nE "display:\s*(flex|grid)|gap:|linear-gradient|calc\(|var\(--" template.html
+```
+
+Any hit → template issue. The fix is `<table>`-based layout and solid colors.
+
+### The `tbody` selector trap
+
+`table > tbody > tr > td` silently matches nothing, because the parser's tree doesn't
+have the implied `<tbody>` the browser inserts. Use `td` attributes or class-only
+selectors instead. A stylesheet that "does nothing" usually has one of these.
+
+### A chart style the output format can't render
+
+Charts work in **Word, PowerPoint, Excel, PDF and HTML** — but not every _style_ works
+in every format, and the mismatch is silent. Check the style against the format before
+calling it a bug:
+
+| Style                                    | Word / PPTX / XLSX |  HTML → PDF  |    HTML in a browser     |
+| ---------------------------------------- | :----------------: | :----------: | :----------------------: |
+| `bar`                                    |       ✅ PNG       |  ✅ CSS-bar  |            ✅            |
+| `pivot`                                  |         ❌         | ✅ CSS table |            ✅            |
+| `clustered`, `stacked`                   |       ✅ PNG       | ✅ CSS table |            ✅            |
+| `column`, `pie`, `donut`, `line`, `area` |       ✅ PNG       | ❌ needs SVG | ✅ with `htmlRender=svg` |
+
+Two rules explain the whole table:
+
+- **Word / PowerPoint / Excel** get a rasterized PNG from `DocGenChartRasterizer`. Its
+  `KNOWN_STYLES` are `bar, column, pie, donut, stacked, clustered, line, area` —
+  **`pivot` is not among them**, because a cross-tab is a table, not a chart shape.
+- **HTML → PDF** renders CSS-bar tables. `htmlRender=svg` produces inline `<svg>`, and
+  **Flying Saucer drops inline SVG from `Blob.toPdf`** — it renders in a browser and
+  vanishes in the PDF. So `column`/`pie`/`donut`/`line`/`area` need a non-PDF HTML
+  target, or a different style.
+
+"My pie chart is blank in the PDF" is the classic report, and it's a format/style
+mismatch, not a defect.
+
+Reference templates in `docs/`: `SurveyChartExample.html` is canonical,
+`CommuteSurveyExample.html` composes pivot + filter + multi-select + colSort,
+`SurveyChartExample.docx` is the Word-authored variant.
+
+### Images that never appear
+
+Image URLs for `Blob.toPdf` must be **relative**. Absolute URLs and `data:` URIs both
+render broken. If the template has `https://...` or `data:image/...` in an `<img src>`,
+that's the answer.
+
+### Fields that "don't exist"
+
+`No such column` on a field that plainly exists in the org almost always means the
+permission set was not assigned, or was assigned before the deploy. Assign
+`DocGen_Admin` **after** deploying, then retry.
+
+### A `{#ChartBucket}` pivot duplicating whole rows
+
+Placing `{#cols}` directly inside a `<tr>` makes each column duplicate the entire row —
+the HTML container auto-expansion looks for the nearest open `<tr>`. Use
+`<div class="row">` + `display: table-row`. Canonical pattern in
+`docs/CommuteSurveyExample.html`.
+
+## Step 3 — If it survives, it's a bug: record it
+
+Do **not** fix it. File the issue. The issue is the deliverable — it is the work queue
+that community contributors pick from, so the write-up carries the weight a direct fix
+used to.
+
+A good Portwood issue has:
+
+- **Exact repro** — template shape, record shape, output format, what you expected.
+- **`file:line` citations** into the actual code.
+- **The mechanism proven, not asserted.** Run the code and paste the real output. A
+  one-liner that demonstrates the failure beats a paragraph describing it.
+- **Ranked fix options**, with a recommendation and why.
+- **An explicit scope note** — which code paths reach this, and which don't.
+
+Label it: `bug`, a `priority:*`, a `severity:*` if output is silently wrong, plus the
+area label (`designer`, `pdf`, `docx`, `bulk-generation`, `flow-action`). Add
+`good first issue` when the fix is well-bounded and you've named the option to take —
+those are what a new contributor can actually land.
+
+See issues #282 and #295 for the reference shape.
+
+## Step 4 — Is it a showstopper?
+
+Only **P0** breaks the batching pattern and gets fixed immediately.
+
+**The P0 test:** would a customer hit this and not know their output is wrong? If yes,
+it's P0 regardless of how rare. Silent corruption beats loud crashes. Data loss and
+"package unusable for a whole customer segment" also qualify.
+
+Everything else waits for a designated fix session. See `TRIAGE.md` for the full
+rubric.
+
+## The four merge-tag resolution paths
+
+If the report _is_ a merge-tag bug, find out which path it took before diagnosing —
+a fix in one path does not reach the others. See the `fix-merge-tag` skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,43 @@
 # CLAUDE.md — Portwood
 
+## Skills
+
+`.claude/skills/` packages the project's working knowledge as Claude Code skills — they load automatically when relevant, and read as plain Markdown otherwise. Prefer them over re-deriving from this file:
+
+| Skill                     | Covers                                                        |
+| ------------------------- | ------------------------------------------------------------- |
+| `dev-setup`               | Fresh clone → working, tested org                             |
+| `run-tests`               | QA harness, e2e scripts, Apex tests, prettier, Code Analyzer  |
+| `triage-report`           | Is a report a real defect or a template issue?                |
+| `fix-merge-tag`           | The merge-tag resolution paths and how not to half-fix one    |
+| `html-template-authoring` | CSS 2.1 constraints, charts, fonts, images                    |
+| `canvas-designer`         | Canvas artboard, serializer, importer                         |
+| `managed-package-rules`   | `global` visibility, Flow Apex-Defined types, namespace traps |
+
+## How this project runs (from 2026-08-10)
+
+Portwood is in **community-development mode**. Dave has deliberately stepped back from the code so contributors have work to pick up.
+
+- **File issues; don't fix them.** When you find a bug, write the issue and stop. No PR, no patched working tree. The issue is the deliverable — it's the contributor work queue, so the write-up carries the weight a direct fix used to: exact repro, `file:line` citations, the mechanism **proven by running the code** rather than asserted, ranked fix options, an explicit scope note. Issues #282 and #295 are the reference shape.
+- **Triage before recording.** Real defect, or template-authoring problem? **Most reports are template issues.** See the `triage-report` skill — it's the gate, not an optional step.
+- **Fixes happen in designated sessions only.** Bugs accumulate until Dave says otherwise. Don't prompt for a release between dates.
+- **Only P0 jumps the queue.** The test: would a customer hit this and not know their output is wrong? Silent corruption beats loud crashes.
+- **Reach for `good first issue` / `help wanted`.** A well-specified bug with a named fix option is exactly what a new contributor can land. `community-contribution` covers the inbound side.
+- **Community PRs change merge mechanics.** `gh pr merge --admin` after self-approval was the sole-coder shortcut; real contributor PRs mean actual review, and CI gates now matter to people other than Dave — `npm run format:check` blocks merge.
+
+### Release cadence
+
+**Fridays, every two weeks.** Next release: **2026-09-11**, deliberately ~4.6 weeks out to collect real user feedback first. Then 09-25, 10-09, 10-23, 11-06.
+
+Milestones on GitHub are **release dates**, not version numbers — a contributor can see when their PR would actually ship. Version numbers are assigned at release time.
+
 ## Triage
 
-See `TRIAGE.md` at the repo root for the priority rubric (P0/P1/P2/P3 + severity labels + milestone scheme). Apply it when classifying new issues or proposing what to work on next. Current milestones live on GitHub: `v1.89.0` (in flight — Template_Version Type picklist fix + CSS 2.1 guidance + #60/#72), `v1.90.0`, `Backlog`.
+See `TRIAGE.md` for the priority rubric (P0/P1/P2/P3 + severity labels). Apply it when classifying new issues.
 
 ## Mission
 
 Maintain Portwood — a native Salesforce 2GP package for generating Word and PDF documents from any Salesforce record. Work is roadmap-driven via the GitHub issue board; treat it as the source of truth for what's in flight.
-
-When picking up work, prefer the highest open priority on the smallest milestone. P0 silent-corruption bugs jump the queue. Community-contributed fixes (the `community-contribution` label) are usually fast wins because the reporter has already done the diagnostic work.
 
 ## Critical: three merge-tag resolution paths
 
@@ -43,9 +72,30 @@ When picking up work, prefer the highest open priority on the smallest milestone
 
 - `docs/SurveyChartExample.html` — single-dimension chart per question + cross-tab spread (rich pivot + vertical clustered bars + stacked composition) using Department dimension. Canonical chart template.
 - `docs/CommuteSurveyExample.html` — pivot + filter + multi-select + colSort all composed
-- `docs/SurveyChartExample.docx` — Word-authored variant. Supports simple bars only; pivot/stacked/vertical-clustered styles require `<div>` table-cell layout which Word lacks. Steer chart customers to HTML.
+- `docs/SurveyChartExample.docx` — Word-authored variant, hand-built `{#ChartBucket}` bars.
 
-**HTML is the recommended chart source format.** Word `.docx` chart templates work but are constrained — Word's row auto-expansion (`{#Lines}` semantics) conflicts with the inner `{#cols}` loop when both want to drive cell placement in the same `<w:tr>`. `<div>` + `display:table-cell` in HTML dodges this entirely; Word has no `<div>` equivalent. The `{color_hex}` chart field exists specifically so Word's `w:shd w:fill` attributes can use cycled palette colors (raw hex, no `#`).
+### Charts render in EVERY format — pick by style, not by format
+
+**Do not say "charts are HTML only." That is wrong**, and it contradicts how charts are actually authored (Word, PowerPoint and PDF all in active use). Two separate authoring surfaces, with opposite constraints:
+
+1. **The `{Chart:}` tag → PNG-via-CV pipeline.** `DocGenChartRasterizer` emits real PNG bytes server-side; `DocGenChartImageController` gates on `Word` / `isHtmlBacked` / `PowerPoint`. `KNOWN_STYLES` = `bar, column, pie, donut, stacked, clustered, line, area`. **This is the path to recommend.**
+2. **Hand-authored `{#ChartBucket}` loops building bars from table-cell widths.** Constrained in Word — `w:type="pct"` normalizes within the row, compressing dynamic range (45.9% vs 2.9% renders at ~6–9× instead of 15.8×), and `{#cols}` nesting conflicts with `<w:tr>` auto-expansion. This is what the old "steer to HTML" advice was about.
+
+| Style                                    | Word / PPTX / XLSX | HTML → PDF | HTML in browser  |
+| ---------------------------------------- | :----------------: | :--------: | :--------------: |
+| `bar`                                    |        PNG         |  CSS-bar   |       yes        |
+| `pivot`                                  |       **no**       | CSS table  |       yes        |
+| `clustered`, `stacked`                   |        PNG         | CSS table  |       yes        |
+| `column`, `pie`, `donut`, `line`, `area` |        PNG         |   **no**   | `htmlRender=svg` |
+
+Two rules generate that table:
+
+- **`pivot` never rasterizes** — not in `KNOWN_STYLES`, because a cross-tab is a table, not a chart shape. Cross-tab belongs in HTML.
+- **Flying Saucer drops inline `<svg>` from `Blob.toPdf`.** `htmlRender=svg` looks right in a browser and vanishes in the PDF, so HTML→PDF templates must stay on CSS-bar styles (`bar`, `pivot`, `clustered`, `stacked`).
+
+**This inverts the old guidance:** for rich chart shapes in a PDF, **Word is the better source**, because the PNG pipeline carries pie/donut/column/line/area that HTML→PDF cannot render at all. HTML is better for cross-tab.
+
+The `{color_hex}` chart field exists so Word's `w:shd w:fill` attributes can use cycled palette colors (raw hex, no `#`).
 
 ## Critical: zero-heap PDF image rendering (don't accidentally regress)
 
@@ -56,7 +106,9 @@ If your fix touches `processXml`, do not add `VersionData` to the PDF-path SOQL 
 ## Package info
 
 - Package: **Portwood**, Managed 2GP (id `0Hoal0000003d9hCAA`), namespace `portwoodglobal`. This is the package `sfdx-project.json` builds and what customers install. (A legacy Unlocked package `Portwood (Unlocked)` `0Hoal0000003TwjCAE` also exists in the Dev Hub but is NOT the release artifact.) **Managed-package consequence:** only `global` Apex is visible to subscribers — `public` classes/methods are invisible in subscriber orgs. An `@InvocableMethod` must be `global` to appear in a subscriber's Flow Builder; a Flow **Apex-Defined variable type** needs ALL of: (1) **top-level/standalone class** (Flow ignores inner/nested classes — the v2.7.0 lesson), (2) `global` class, (3) `@AuraEnabled` members, (4) `global` no-arg constructor. See [[feedback_flow_apexdefined_managed_pkg_recipe]].
-- Current shipped version: **v3.54.0** (`04tVx0000010Y4LIAU`, build `3.54.0-1`, promoted 2026-08-06, ancestor 3.53.0) — the **Canvas designer**, a new `Canvas` template type with a Canva-style artboard: pinned and flow boxes, tables with nested grandchild loops and totals, images from Portwood Assets via `{%asset:key:WIDTHx}`, shapes, QR/barcodes, signature placements, per-box `{#IF}` conditions, z-order, undo/redo and an HTML importer. Renders through the HTML path (`DocGenService.isHtmlBacked`), so output is always PDF. **The `Canvas` picklist value and everything around it are now frozen forever.** Shipped labelled Beta in the UI. Two notes for anyone touching it: `Blob.toPdf` only draws symbols/CJK under `'Arial Unicode MS'` (the generic families render them as nothing), and serializer fixes do NOT reach documents already saved — a stored body keeps its old markup until re-saved. 1,905 tests pass, 78% coverage.
+- Current shipped version: **v3.56.0** (`04tVx0000010fnNIAQ`, build `3.56.0-5`) — chart label sizing made an explicit control (`fontSize=` on a chart tag, **Label size** on the Canvas chart), with title and other text scaling with it; plus **Bold** disabled for `'Arial Unicode MS'`, which has no bold face and was silently printing regular (#281). This is the ID the README's install link points at — keep the two in sync.
+- Previous shipped version: **v3.55.0** (`04tVx0000010fXFIAY`, build `3.55.0-2`) — Canvas element linking (a block **follows** another and travels with it as the table above grows), named blocks, and charts as a Canvas element with live preview. PowerPoint and Excel now assemble in the browser like Word, lifting the 6 MB ceiling (tested to 30,000 child records), with Chart.js on that path.
+- Previous shipped version: **v3.54.0** (`04tVx0000010Y4LIAU`, build `3.54.0-1`, promoted 2026-08-06, ancestor 3.53.0) — the **Canvas designer**, a new `Canvas` template type with a Canva-style artboard: pinned and flow boxes, tables with nested grandchild loops and totals, images from Portwood Assets via `{%asset:key:WIDTHx}`, shapes, QR/barcodes, signature placements, per-box `{#IF}` conditions, z-order, undo/redo and an HTML importer. Renders through the HTML path (`DocGenService.isHtmlBacked`), so output is always PDF. **The `Canvas` picklist value and everything around it are now frozen forever.** Shipped labelled Beta in the UI. Two notes for anyone touching it: `Blob.toPdf` only draws symbols/CJK under `'Arial Unicode MS'` (the generic families render them as nothing), and serializer fixes do NOT reach documents already saved — a stored body keeps its old markup until re-saved. 1,905 tests pass, 78% coverage.
 - Previous shipped version: **v3.50.0** (`04tVx000000zxCrIAI`, build `3.50.0-1`, promoted 2026-07-31, ancestor 3.49.0) — the DocGen -> Portwood rename (PR #263). Display names only: labels, masterLabels, descriptions, user-visible strings. **Every API name is unchanged and frozen forever** — `DocGen_Template__c`, `DocGenService`, `DocGen_Admin`, the `portwoodglobal` namespace. Two scheduled job names deliberately keep the old string because they are matched by `CronJobDetail.Name` in orgs that already scheduled them: `DocGen Signature Reminders` and `DocGen Chart CV Reaper`. 1,890 tests pass, 78% coverage.
 - Previous shipped version: **v2.9.0** (`04tVx000000a7fhIAA`, build `2.9.0-1`, promoted 2026-05-27) — Large-table repeating headers. Tight follow-up to v2.8 for giant-query PDFs, verified on a real customer short-codes `.docx` and 3,559 staging records. Adds Flying Saucer's table pagination CSS (`-fs-table-paginate: paginate` + `thead { display: table-header-group; }`) to snapshot-backed and HTML-backed giant-query tables so Word-authored headers repeat on every PDF page. Also forces `border-collapse: collapse` + `border-spacing: 0` and Word-style cell padding (`0pt 5.4pt`) so the repeated-header table keeps a continuous single-line frame rather than separated cell boxes. Fixes the Word edge case where both the visible header row and the merge-loop row carry `w:tblHeader`, causing the DOCX HTML snapshot to put the loop row inside `<thead>`; `replaceGiantLoopTableTail` now closes `<thead>` before generated rows. Validation: real-template proof = repeated orange header page 2+, continuous borders, 68-page PDF; e2e-01..08 + 07-syntax1..4 PASS/FAIL0; RunLocalTests 1470/100%/77%; `sf code-analyzer` 0; package build coverage 77%.
 - Previous shipped version: **v2.8.0** (`04tVx000000a7e5IAA`, build `2.8.0-1`, promoted 2026-05-27) — Large-table rendering fidelity (PR #144). Three giant-query table fixes, all found + verified on a **real customer short-codes template** (~3,560-row `.docx`) generated through the giant path → 86-page PDF. (1) **Giant tables rendered ~50% width**: `DocGenGiantQueryAssembler` prepended its own `<colgroup>` on top of the snapshot's authored one → 2 colgroups = 2× columns = 200% width, packing cells into the left half (regression surfaced by the v2.5.0 chrome fix — before it, the empty-snapshot fallback gave a single-colgroup `width:100%` table). Fix: drop the duplicate; capture the snapshot's authored `<table>` tag + single colgroup and reuse them in every chunk-break table; `max-width:100%` clamp stops an authored absolute width clipping the last column. (2) **Footer = black box**: `processTable` collapsed borders into one `hasBorders` boolean + blanket `border:0.5pt solid #000` per cell — a top-rule-only footer became a full grid. Replaced with **per-side translation** (explicit `<w:tblBorders>` beats the named style; outer sides → `<table>`, `insideH/insideV` → cell grid lines in the authored color); new `addInteriorBorders` + public `resolveCellGridBorderCss`. (3) **Giant data rows used invented gray `#ccc`**: now carry a `gqc` class and inherit the authored grid border (scoped to data cells so it never leaks onto the running footer). `{RepeatHeader}` marker (pre-merge `applyRepeatHeaderMarkers` → Word `<w:tblHeader/>` → `<thead>`) groups the header for section-level repeat. **DEFERRED to a future release — true per-page header repeat on giant tables:** Flying Saucer's `-fs-table-paginate` is the only mechanism, works on clean content (78 pages at 3,559 rows, scales to 15K) but **mis-paginates the real metric/multi-running-element template to 8,258 pages**; metric→inch `@page` decimals (210mm→`8.26388…in`) are a contributing factor (~20%) but not the root. Validation: e2e-01..08 + 07-syntax1..4 PASS/FAIL0, RunLocalTests 1469/100%/77%, `sf code-analyzer` 0, real-template render confirmed (full-width every page, footer top-rule-only, no clipped columns, 86 pages).
@@ -89,6 +141,15 @@ The detailed engineering-language belongs in `CHANGELOG.md` (and the local-only 
 ## Release validation checklist
 
 All three checks MUST pass before release. No exceptions.
+
+**The one-command version** (runs every suite and writes `scripts/qa/report/qa-report.md`, exit 0 only when everything evaluated passed):
+
+```bash
+npm run qa                  # against docgen-verify
+npm run qa -- --offline     # only suites needing no org — CI-safe
+```
+
+A suite that cannot run reports as **skipped**, not passed — check the report, not just the exit code. The explicit sequences below are what the harness runs, and what to fall back on when diagnosing a single failure. See the `run-tests` skill.
 
 ### 1. E2E test suite
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,100 +2,145 @@
 
 Thanks for your interest in contributing! Portwood is a community-driven Salesforce document generation tool, and contributions of all kinds are welcome — bug fixes, features, documentation, template examples, and testing.
 
-## Getting Started
+## Quick start
 
-### Prerequisites
+```bash
+git clone <your fork>
+cd DocGen
+npm install          # prettier + the QA harness
+npm run org:new      # creates and fully configures the `docgen-verify` scratch org
+npm run qa           # runs every suite and writes a report
+```
 
-- Salesforce CLI (`sf`) installed
-- A Salesforce DevHub org (or use a Developer Edition org)
-- Git
+That's clone to green tests. If anything fails, the answer is very likely in [`.claude/skills/dev-setup/SKILL.md`](.claude/skills/dev-setup/SKILL.md).
 
-### Local Setup
+**One manual step the script can't do:** Setup → Release Updates → "Use the Visualforce PDF Rendering Service for `Blob.toPdf()` Invocations" → **Enable**. Without it, PDF output is wrong in ways that look like template bugs.
 
-1. **Fork and clone** this repo
-2. **Create a scratch org:**
-    ```bash
-    sf org create scratch --definition-file config/project-scratch-def.json --alias docgen-dev --set-default --duration-days 30
-    ```
-3. **Push source:**
-    ```bash
-    sf project deploy start --target-org docgen-dev
-    ```
-4. **Assign permission set:**
-    ```bash
-    sf org assign permset --name DocGen_Admin --target-org docgen-dev
-    ```
-5. **Enable the Release Update:** Setup > Release Updates > "Use the Visualforce PDF Rendering Service for Blob.toPdf() Invocations" > Enable
-6. **Run E2E tests** to verify:
-    ```bash
-    sf apex run --target-org docgen-dev -f scripts/e2e-test.apex
-    ```
+No org yet? `npm run qa -- --offline` runs every suite that doesn't need one.
 
-You should see `PASS: 23  FAIL: 0  ALL TESTS PASSED`.
+## Read the skills first
 
-## How to Contribute
+`.claude/skills/` packages the things that make this codebase hard to change and aren't visible from the code. If you use Claude Code they load automatically; otherwise read them as plain Markdown. See [`.claude/skills/README.md`](.claude/skills/README.md).
 
-### Reporting Bugs
+| Skill                     | Read it when                                                                      |
+| ------------------------- | --------------------------------------------------------------------------------- |
+| `dev-setup`               | Going from a fresh clone to a working, tested org                                 |
+| `run-tests`               | Verifying a change                                                                |
+| `triage-report`           | A bug report arrives and you need to know if it's a real defect                   |
+| `fix-merge-tag`           | Changing tag parsing, loops, conditionals, aggregates or charts                   |
+| `html-template-authoring` | Writing a template, or a PDF doesn't match its source                             |
+| `canvas-designer`         | Touching the Canvas artboard, serializer or importer                              |
+| `managed-package-rules`   | Adding subscriber-visible Apex, a Flow action, or debugging install-only failures |
 
-[Open a bug report](https://github.com/Portwood-Global-Solutions/Portwood/issues/new?template=bug_report.md). Include your package version, Salesforce edition, and steps to reproduce. Screenshots and error messages help a lot.
+**The two facts that save the most time:**
 
-### Suggesting Features
+1. **Most "the PDF looks wrong" reports are template issues, not bugs.** The renderer is CSS 2.1 and silently ignores `flex`, `grid`, `gap`, `calc()` and CSS variables.
+2. **A merge-tag fix in one resolution path does not reach the other three.**
+
+## How this project runs
+
+Portwood releases **every two weeks, on a Friday**. Bugs are collected, triaged, and fixed in batches rather than one at a time — going slow is deliberate, and it's what creates room for contributors to pick work up.
+
+- **Bug reports are always welcome**, and they don't wait for a release. File them as they happen.
+- **A report gets triaged before it becomes work** — real defect, or template-authoring problem? Most are the latter, and get answered as guidance under the `template-help` label.
+- **Only P0 jumps the queue.** The test: would a customer hit this and not know their output is wrong? Silent corruption beats loud crashes.
+- **Issues labelled `good first issue`** are well-specified and have a named fix approach. They're the best place to start.
+
+See [`TRIAGE.md`](TRIAGE.md) for the full priority rubric.
+
+## Reporting bugs
+
+[Open a bug report](https://github.com/Portwood-Global-Solutions/Portwood/issues/new?template=bug_report.md). Include your package version, Salesforce edition, output format (PDF/DOCX/PPTX/XLSX), whether the template is HTML or DOCX, and steps to reproduce. Attach the template body if you can — it's the single most useful thing.
+
+## Suggesting features
 
 [Open a feature request](https://github.com/Portwood-Global-Solutions/Portwood/issues/new?template=feature_request.md) or start a [Discussion](https://github.com/Portwood-Global-Solutions/Portwood/discussions) to talk through the idea first.
 
-### Submitting Code
+## Submitting code
 
 1. **Check existing issues** — is someone already working on this?
 2. **Open an issue first** for non-trivial changes so we can align on approach
-3. **Fork the repo** and create a branch from `main`
-4. **Make your changes** — follow the guidelines below
-5. **Run all tests** — E2E and Apex unit tests must pass
+3. **Fork** and branch from `main`
+4. **Make your change** — follow the guidelines below
+5. **Run the tests** (see below)
 6. **Open a PR** against `main` with a clear description
 
-### Code Guidelines
+### Before you push
 
-- **Read CLAUDE.md** before making changes to the merge engine or PDF pipeline. It documents critical constraints (relative image URLs, zero-heap rendering, no VersionData in PDF queries).
-- **Run the E2E test script** after every change. If you add a feature, add a test for it.
-- **Run Code Analyzer:** `sf code-analyzer run --rule-selector "recommended" --target force-app` — 0 Critical, 0 High required.
-- **No external runtime dependencies.** Portwood runs 100% on-platform — no external services, APIs, or callouts, and document data never leaves the org. Client-side libraries (e.g., PDF.js for the signature viewer, pdf-lib for in-browser signature compositing) are **vendored as pinned static resources**, not pulled from npm at build time. If you add or update one, keep it patched (track CVEs), retain its license/NOTICE, and disclose it in the AppExchange security materials.
-- **E-signatures are native + first-party.** The signature workflow (guided signing, signer identity/PIN, audit, signed-PDF generation) ships in the package — no third-party signing or document-generation provider.
-- **Use `WITH USER_MODE`** or `Security.stripInaccessible()` for all SOQL/DML in user-facing code.
-- **Namespace awareness:** Source code does not use namespace prefixes. The platform resolves `portwoodglobal__` at compile time.
+```bash
+npm run qa -- --offline    # fastest signal, no org needed
+npm run format:check       # CI merge gate — a failure blocks the PR
+```
 
-### What Makes a Good PR
+If you touched `canvasModel.js`, also run the pure-Node serializer checks:
 
-- **Small and focused.** One bug fix or one feature per PR.
-- **Tests included.** E2E assertions for new behavior, Apex tests for new methods.
+```bash
+node scripts/qa/canvas-serializer-check.mjs
+node scripts/qa/canvas-anchor-check.mjs
+```
+
+If you have an org configured, run the full `npm run qa`. Scope Apex test runs to the classes you changed — **never run a bare `sf apex run test`**, which triggers an org-wide run that locks `ContentFolder`:
+
+```bash
+sf apex run test --target-org docgen-verify --tests DocGenServiceTest --wait 15
+```
+
+Code Analyzer, before a release-bound change:
+
+```bash
+sf code-analyzer run --workspace "force-app/" --rule-selector "Security" --rule-selector "AppExchange" --view table
+```
+
+0 High severity required. ~30 Moderate false positives are expected and documented in `code-analyzer.yml`.
+
+### Code guidelines
+
+- **Read `CLAUDE.md`** before touching the merge engine or PDF pipeline. It documents constraints that are easy to regress — relative image URLs, zero-heap PDF rendering, no `VersionData` in PDF-path queries.
+- **Add a test for new behavior.** E2E assertions for parser changes (via `processXmlForTest`), Apex tests for new methods. Note the e2e scripts have an 18,000-character ceiling — put new parser assertions in `e2e-07-syntax5` or a new `syntax6`.
+- **No external runtime dependencies.** Portwood runs 100% on-platform — no external services, APIs, or callouts, and document data never leaves the org. Client-side libraries (PDF.js, pdf-lib) are **vendored as pinned static resources**, not pulled from npm at build time. If you add or update one, keep it patched, retain its license/NOTICE, and disclose it in the AppExchange security materials.
+- **E-signatures are native + first-party.** The signature workflow ships in the package — no third-party signing or document-generation provider.
+- **Use `WITH USER_MODE`** or `Security.stripInaccessible()` for all SOQL/DML in user-facing code. Internal ContentVersion reads are the documented exception — see the `managed-package-rules` skill.
+- **Namespace awareness:** source code does not use namespace prefixes; the platform resolves `portwoodglobal__` at compile time. But **JS is different** — SObject keys come back namespace-prefixed in a subscriber org, so `row.Field__c` is `undefined` in a shipped package.
+
+### What makes a good PR
+
+- **Small and focused.** One bug fix or one feature.
+- **Tests included.**
 - **Clear description.** What changed, why, and how you tested it.
 - **No unrelated changes.** Don't refactor surrounding code or add comments to files you didn't change.
 
-## Architecture Overview
+## Architecture overview
 
-If you're new to the codebase, start here:
+Apex:
 
-| Class                 | What It Does                                                                         |
-| --------------------- | ------------------------------------------------------------------------------------ |
-| `DocGenService`       | Core merge engine — template parsing, tag replacement, image handling, PDF rendering |
-| `DocGenHtmlRenderer`  | Converts DOCX XML to HTML for `Blob.toPdf()`                                         |
-| `DocGenDataRetriever` | Multi-level SOQL with V1/V2/V3/V4 query config routing                               |
-| `DocGenController`    | LWC controller — template CRUD, generation endpoints                                 |
-| `BarcodeGenerator`    | Pure Apex Code 128 + QR code generation                                              |
-| `DocGenBatch`         | Batch Apex for bulk document generation                                              |
+| Class                       | What it does                                                                         |
+| --------------------------- | ------------------------------------------------------------------------------------ |
+| `DocGenService`             | Core merge engine — template parsing, tag replacement, image handling, PDF rendering |
+| `DocGenController`          | LWC controller — template CRUD, generation endpoints                                 |
+| `DocGenHtmlRenderer`        | Converts DOCX XML to HTML for `Blob.toPdf()`                                         |
+| `DocGenDataRetriever`       | Multi-level SOQL with V1/V3/V4 query config routing                                  |
+| `DocGenGiantQueryAssembler` | The >2000-child-row path. **Does not call `processXml()`** — see `fix-merge-tag`     |
+| `DocGenChartBucketResolver` | `{#ChartBucket}` aggregation across four resolution paths                            |
+| `DocGenBatch`               | Batch Apex for bulk generation                                                       |
+| `BarcodeGenerator`          | Pure Apex Code 128 + QR generation                                                   |
 
-Client-side (LWC):
-| Component | What It Does |
-|-----------|-------------|
-| `docGenRunner` | Main record page component — template selection, generation, PDF merge |
-| `docGenAdmin` | Template manager — create, edit, version, query builder |
-| `docGenColumnBuilder` | Visual query builder with tree visualization |
-| `docGenPdfMerger` | Client-side PDF merge engine (pure JS) |
-| `docGenZipWriter` | Client-side DOCX/XLSX assembly (pure JS) |
+Lightning Web Components:
+
+| Component               | What it does                                                                                                               |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `docGenRunner`          | Main record-page component — template selection, generation. Contains the `docGenPdfMerger` and `docGenZipWriter` modules. |
+| `docGenAdmin`           | Template manager — create, edit, version, query builder                                                                    |
+| `docGenCanvas`          | The Canvas designer — artboard, box model, HTML serializer (`canvasModel.js`)                                              |
+| `docGenColumnBuilder`   | Visual query builder with tree visualization                                                                               |
+| `docGenSignatureSender` | Signature request composition and placement                                                                                |
+
+`docGenPdfMerger.js` (client-side PDF merge) and `docGenZipWriter.js` (client-side DOCX/XLSX assembly) are **modules inside** the `docGenRunner` and `docGenAdmin` bundles, not standalone components.
 
 ## Community
 
-- **Issues:** Bug reports, feature requests, and questions
-- **Discussions:** General conversation, ideas, show-and-tell, template sharing
-- **Community Hub:** [portwood.dev/community](https://portwood.dev/community) — forum with real-time help
+- **Issues:** bug reports, feature requests, questions
+- **Discussions:** ideas, show-and-tell, template sharing
+- **Community Hub:** [portwood.dev/community](https://portwood.dev/community)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -448,7 +448,9 @@ Decompress → Merge XML tags → Recompress
 
 ## Releases
 
-Portwood ships on a **biweekly release cycle**.
+Portwood ships **every two weeks, on a Friday**. Next release: **2026-09-11**, then 09-25, 10-09, 10-23.
+
+Milestones on the issue board are release dates rather than version numbers, so you can see when a fix or a merged PR would actually ship. Bug reports are welcome at any time and don't wait for a release — they're triaged as they arrive.
 
 | Version     | Headline                                                                                                                        |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------- |
@@ -493,7 +495,25 @@ Need dedicated support? Contact us at [hello@portwood.dev](mailto:hello@portwood
 
 ## Contributing
 
-We welcome contributions — see [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions.
+Portwood is built in the open and **actively looking for contributors**. Clone to green tests is three commands:
+
+```bash
+npm install          # prettier + the QA harness
+npm run org:new      # creates and fully configures a scratch org
+npm run qa           # runs every suite and writes a report
+```
+
+No Salesforce org yet? `npm run qa -- --offline` runs every suite that doesn't need one.
+
+**Good places to start:**
+
+- [`good first issue`](https://github.com/Portwood-Global-Solutions/Portwood/labels/good%20first%20issue) — well-specified, bounded, with a named fix approach
+- [`help wanted`](https://github.com/Portwood-Global-Solutions/Portwood/labels/help%20wanted) — we'd particularly welcome someone picking these up
+- [`template-help`](https://github.com/Portwood-Global-Solutions/Portwood/labels/template-help) — answer an authoring question; no Apex required
+
+**Before you write code,** read [`.claude/skills/`](.claude/skills/README.md). It packages the things that make this codebase hard to change and aren't visible from the code — the PDF engine is CSS 2.1 and silently ignores `flex`/`grid`/`calc()`, merge tags resolve through several paths that don't share code, and a whole class of bug only appears in a real managed-package install. If you use Claude Code they load automatically; otherwise they read as plain Markdown.
+
+Full setup, architecture map, and PR guidelines in [CONTRIBUTING.md](CONTRIBUTING.md). Priority rubric in [TRIAGE.md](TRIAGE.md).
 
 ## Security
 

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -22,28 +22,38 @@ How we prioritize issues and enhancement requests on this repo. Reporters are we
 
 A bug should usually carry one severity label. Enhancements don't need a severity.
 
-## Milestones
+## Is it even a bug?
 
-Three rolling milestones plus a backlog:
+Before applying any of the above: **most reports are template-authoring problems, not code defects.** The renderer is CSS 2.1 and silently ignores `flex`, `grid`, `gap`, `calc()` and CSS variables; image URLs must be relative; and a chart style that doesn't survive the chosen output format fails silently (`pivot` never rasterizes for Word/PPTX; SVG-rendered styles are dropped from `Blob.toPdf`). Reproduce and rule the template out first.
 
-- **vNEXT.0** — current release in flight. Bug-fix-only when possible. Pull P0s here unconditionally.
-- **vNEXT+1.0** — next release after that. P1 bugs and small enhancements land here.
-- **vNEXT+2.0** — enhancement bundle. Larger features with completed specs.
+A report that turns out to be an authoring problem gets answered as guidance and closed with `template-help`. It does not become engineering work. See `.claude/skills/triage-report/SKILL.md` for the full checklist.
+
+## Milestones — release dates, not version numbers
+
+Portwood releases **every two weeks, on a Friday**. Milestones are the release date, so a contributor can see when their PR would actually ship. Version numbers are assigned at release time, not in advance.
+
+- **The next date** (currently `2026-09-11`) — what's shipping next. Bug-fix-only when possible. P0s land here unconditionally.
+- **The date after** — P1 bugs and small enhancements.
+- **Later dates** — larger features with completed specs.
 - **Backlog** — P3 items, anything needing more scoping, parking lot.
 
-When we cut a release we close its milestone, rename `vNEXT+1.0` → `vNEXT.0`, etc., and re-evaluate the backlog.
+When a release ships we close its date milestone and add the next Friday two weeks out. Closed version-numbered milestones (`v1.x`, `v3.4x`) are retained for historical record and are not used for new work.
 
 ## Other useful labels
 
-- `community-contribution` — reporter included a verified fix or substantial RCA. These are fast wins; surface them in triage.
+- `good first issue` — well-specified, bounded, with a named fix approach. The best entry point for a new contributor; apply it whenever a bug qualifies.
+- `help wanted` — we'd particularly welcome someone picking this up.
+- `community-contribution` — reporter included a verified fix or substantial RCA. Fast wins; surface them in triage.
 - `bug`, `enhancement` — the type. Set automatically by issue templates.
-- `pdf`, `docx`, `flow-action`, `bulk-generation`, `install-upgrade`, `template-help` — subsystem tags for filtering.
+- `pdf`, `docx`, `designer`, `flow-action`, `bulk-generation`, `install-upgrade`, `template-help` — subsystem tags for filtering.
 
 ## Filter recipes
 
 ```
 is:open label:priority:P0                  # fire-now list
-is:open milestone:vNEXT.0                  # what's shipping
+is:open milestone:2026-09-11               # what's shipping next
 is:open label:severity:silent-corruption   # quality-of-fix watchlist
+is:open label:"good first issue"           # newcomer entry points
 is:open label:community-contribution       # reporter-fix-attached
+is:open no:milestone                       # untriaged
 ```


### PR DESCRIPTION
Documentation and project process only — no functional change.

Opening Portwood to community development surfaced several docs that were telling a new contributor the wrong thing.

## The thing that most blocked contribution

`CONTRIBUTING.md` told people to run **`scripts/e2e-test.apex`, which does not exist**, and to expect `PASS: 23` from it. It never mentioned `npm run qa` — the 12-suite harness with an offline mode, report generation and a real exit code. A first-time contributor's very first command failed while the good tooling stayed invisible.

Now: `npm install` → `npm run org:new` → `npm run qa`, with `npm run qa -- --offline` called out as the path for someone without an org.

Its architecture table was also wrong: it named `docGenPdfMerger` and `docGenZipWriter` as components, but both are *modules inside* the `docGenRunner` and `docGenAdmin` bundles — and `docGenCanvas`, the flagship, was missing entirely.

## New: `.claude/skills/`

Seven skills packaging the knowledge that isn't visible from the code. They load automatically under Claude Code and read as plain Markdown otherwise.

| Skill | Covers |
|---|---|
| `dev-setup` | Fresh clone → working, tested org |
| `run-tests` | QA harness, e2e scripts, prettier, Code Analyzer |
| `triage-report` | Is a report a real defect or a template issue? |
| `fix-merge-tag` | The resolution paths, and how not to half-fix one |
| `html-template-authoring` | CSS 2.1 constraints, charts, fonts, images |
| `canvas-designer` | Artboard, serializer, importer |
| `managed-package-rules` | `global` visibility, Flow Apex-Defined types, namespace traps |

`.gitignore` already whitelisted `.claude/skills/`, so this ships as intended.

## Corrected: chart guidance was backwards

`CLAUDE.md` said to steer chart authors to HTML, and the note read as a blanket rule. It applied only to **hand-authored `{#ChartBucket}` table-cell bars**. The `{Chart:}` tag rasterizes to PNG and works in Word, PowerPoint, Excel, PDF and HTML — `DocGenChartImageController` gates on `Word` / `isHtmlBacked` / `PowerPoint`.

What actually varies is **style by format**:

| Style | Word / PPTX / XLSX | HTML → PDF | HTML in browser |
|---|:---:|:---:|:---:|
| `bar` | PNG | CSS-bar | yes |
| `pivot` | **no** | CSS table | yes |
| `clustered`, `stacked` | PNG | CSS table | yes |
| `column`, `pie`, `donut`, `line`, `area` | PNG | **no** | `htmlRender=svg` |

`pivot` isn't in the rasterizer's `KNOWN_STYLES` (a cross-tab is a table, not a chart shape), and Flying Saucer drops inline SVG from `Blob.toPdf`. Which inverts the old advice: **for pie/donut/column in a PDF, Word is the better source format.**

## Milestones: release dates, not version numbers

So a contributor can see when a merged PR would actually ship. `TRIAGE.md` gains the bug-vs-template gate that now precedes any priority call, plus `good first issue` / `help wanted` guidance.

## Also

`CLAUDE.md` was two releases stale — it claimed v3.54.0 was current. Actual is **v3.56.0** (`04tVx0000010fnNIAQ`), which is what the README install link already pointed at. Fixed, with a note to keep the two in sync.

## Verification

- `npm run format:check` clean; the pre-commit hook reformatted the new skills on commit
- Every path referenced in the new docs confirmed to exist
- No `force-app/` changes, so no Apex/e2e run applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
