### PR TITLE
docs(roadmap): correct the version and retire the shipped Canvas entry

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Portwood is free, native, and community-driven. There are no paid tiers and no feature gates, so this roadmap isn't a sales sheet. It's an honest view of what's queued and what we're still thinking about. Priorities come from real customer reports and community requests, triaged in the open on GitHub — the issue board is the source of truth for what's in flight.
 
-Portwood is [listed on the AppExchange](https://appexchange.salesforce.com/appxListingDetail?listingId=5a580bd8-2745-41e5-b62c-c495957857d3) and ships on a fast release cadence — currently v3.30. Recent releases brought guest e-signing with drawn signatures, a shared image-asset manager, brandable email templates, quick-action generation, and template management upgrades. For the full record, see the [changelog](/changelog).
+Portwood is [listed on the AppExchange](https://appexchange.salesforce.com/appxListingDetail?listingId=5a580bd8-2745-41e5-b62c-c495957857d3) and ships on a fast release cadence — currently v3.56, with 51 releases since v3.0 in May 2026. Recent releases brought the Canvas designer (Beta), element linking and named blocks, client-side charts, Excel output as real `.xlsx`, and the runner on any page. For the full record, see the [changelog](/changelog).
 
 **Want to shape it?** Open a request on [GitHub Issues](https://github.com/Portwood-Global-Solutions/Portwood/issues) or post in [Slack](/community). Every request gets read, labeled, and tracked. Bugs that silently corrupt output jump the queue.
 
@@ -21,6 +21,10 @@ A comment syntax for template authors: leave notes to yourself ("this table feed
 ### Custom Label merge tags ([#204](https://github.com/Portwood-Global-Solutions/Portwood/issues/204))
 
 Resolve Salesforce Custom Labels inside templates, so one template can serve a multi-language org — the label renders in each recipient's language instead of hardcoded text.
+
+### Canvas designer out of Beta ([#55](https://github.com/Portwood-Global-Solutions/Portwood/issues/55))
+
+The drag-and-drop template builder shipped in **v3.54 as a Beta**: a Canva-style artboard where boxes are placed in inches and land there in the PDF, with lists still flowing across as many pages as the data needs. Word and HTML templates remain fully supported and are still the right choice for many documents — the Canvas is an additional authoring path, not a replacement. Hardening it to general availability is paced by what early users hit, so feedback on this one is worth more than a vote.
 
 ## On the horizon
 
@@ -45,10 +49,6 @@ Ideas with merit that are iceboxed until demand moves them up. Feedback here is 
 ### Reusable template partials ([#31](https://github.com/Portwood-Global-Solutions/Portwood/issues/31))
 
 Define a header, footer, or signature block once and include it across many templates. A design spec is drafted; it's iceboxed until enough teams ask for it.
-
-### Drag-and-drop template builder ([#55](https://github.com/Portwood-Global-Solutions/Portwood/issues/55))
-
-A visual, no-Word path to authoring templates. Iceboxed — Word and HTML templates with merge tags remain the supported authoring path, and they cover the same ground with tools authors already know. Would revisit if demand builds.
 
 ### Native, editable Office charts
 


### PR DESCRIPTION
The public roadmap had drifted 26 releases behind the changelog, and one entry told readers a shipped feature did not exist.

### What was wrong

- **Stale version.** `ROADMAP.md` said *"currently v3.30"*; the changelog is on **v3.56.0** (released 2026-08-08). The "recent releases" sentence still described the v3.30 era — guest e-signing, the image-asset manager, brandable email templates.
- **A shipped feature listed as iceboxed.** *"Drag-and-drop template builder (#55)"* sat under **Exploring**, described as iceboxed, saying "Word and HTML templates remain the supported authoring path … would revisit if demand builds." The **Canvas designer shipped in v3.54.0 on 2026-08-06** — a Canva-style artboard placing boxes in inches. Anyone reading the roadmap to decide whether to wait for a visual authoring path was told it wasn't coming.

### What changed

- Version and cadence updated to v3.56, 51 releases since v3.0 in May 2026.
- Recent-releases list refreshed: Canvas designer (Beta), element linking and named blocks, client-side charts, Excel output as real `.xlsx`, runner on any page.
- **#55 moved from Exploring to Up next** as "Canvas designer out of Beta", describing what actually shipped and what Beta currently means. Kept rather than deleted so anyone subscribed to the issue sees an accurate status; say the word if you'd rather it disappear entirely.

### Why now

Surfaced while making `/roadmap` server-rendered on portwood.dev. That page mirrors this file, and it was about to publish "currently v3.30" two paragraphs above the live release facts (v3.56, shipped 8 Aug, 1,961 tests). The website deploy is held until this merges.

No product or content decisions here beyond correcting the record — priorities and ordering are otherwise untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)