### PR TITLE
Currency: option to render the ISO code instead of the symbol (SEK/NOK/DKK all print as "kr")  #296 AND Fidelity report: false positives on loop-scoped variables ({key_label}, {percent}, {RowNumber}, {GroupName})  #311

### DIFF
--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -5939,10 +5939,13 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
     }
 
     /**
-     * {Amount:currency}                          → backward-compat hardcoded $
-     * {Amount:currency:EUR[:de_DE]}              → explicit ISO (+ optional locale)
-     * {Amount:currency:auto[:locale]}            → ISO read from the record's CurrencyIsoCode
-     * {Amount:currency:auto=Field__c[:locale]}   → ISO read from a named record field
+     * {Amount:currency}                              → backward-compat hardcoded $
+     * {Amount:currency:EUR[:de_DE]}                  → explicit ISO (+ optional locale)
+     * {Amount:currency:auto[:locale]}                → ISO read from the record's CurrencyIsoCode
+     * {Amount:currency:auto=Field__c[:locale]}       → ISO read from a named record field
+     * {Amount:currency:SEK:iso}                      → force the ISO code instead of the symbol
+     * {Amount:currency:SEK:sv_SE:iso}                → same, with an explicit locale
+     * {Amount:currency:auto:iso} / {…:auto:locale:iso} → same, resolved from the record
      *
      * The auto forms need the record's field map (`data`); when it's null/missing the
      * source field, or the value isn't a known ISO code, we fall back to the safe `$`
@@ -5952,6 +5955,27 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         // Bare :currency → backward compat: hardcoded $ with US separators
         if (segments.size() == 1) {
             return formatCurrencyDollarFallback(num);
+        }
+
+        // Vijay: fix for #296 — a trailing `:iso` segment forces the ISO code
+        // (e.g. "SEK") instead of the mapped symbol. Needed because SEK/NOK/DKK
+        // all print as "kr" and JPY/CNY both print as "¥" in CURRENCY_SYMBOLS,
+        // which makes a generated Nordic invoice genuinely ambiguous about which
+        // currency it's billed in. Stripped BEFORE the existing locale-slot
+        // logic below runs, so `:iso` composes with an explicit locale
+        // ({Amount:currency:SEK:sv_SE:iso}) exactly like without one
+        // ({Amount:currency:SEK:iso}), and works for both the explicit-ISO and
+        // :auto forms since the strip happens ahead of that branch.
+        Boolean forceIso = false;
+        if (!segments.isEmpty() && 'iso'.equalsIgnoreCase(segments[segments.size() - 1].trim())) {
+            forceIso = true;
+            segments = segments.clone();
+            segments.remove(segments.size() - 1);
+            // {Amount:currency:iso} with nothing left to force — no ISO/auto was
+            // given, so there's nothing to override. Fall back like bare :currency.
+            if (segments.size() == 1) {
+                return formatCurrencyDollarFallback(num);
+            }
         }
 
         String spec = segments[1].trim();
@@ -5966,13 +5990,13 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                 return formatCurrencyDollarFallback(num);
             }
             String autoLocale = segments.size() >= 3 ? segments[2].trim() : UserInfo.getLocale();
-            return formatCurrencyWithIso(num, autoIso, autoLocale);
+            return formatCurrencyWithIso(num, autoIso, autoLocale, forceIso);
         }
 
         // :currency:ISO or :currency:ISO:locale
         String iso = spec.toUpperCase();
         String locale = segments.size() >= 3 ? segments[2].trim() : null;
-        return formatCurrencyWithIso(num, iso, locale);
+        return formatCurrencyWithIso(num, iso, locale, forceIso);
     }
 
     /** Backward-compat bare-:currency output: hardcoded $ with US separators. */
@@ -5980,10 +6004,18 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         return '$' + formatNumberLocale(num.setScale(2, RoundingMode.HALF_UP), ',', '.');
     }
 
-    /** Formats `num` with the symbol for `iso` and the separators/placement for `locale`. */
-    private static String formatCurrencyWithIso(Decimal num, String iso, String locale) {
+    /**
+     * Formats `num` with the symbol for `iso` and the separators/placement for `locale`.
+     *
+     * Vijay: fix for #296 (SEK/NOK/DKK all render "kr", JPY/CNY both render "¥").
+     * `forceIso` overrides CURRENCY_SYMBOLS even for a currency that DOES have a
+     * mapped symbol, so the author can disambiguate. Same "unmapped currency"
+     * fallback (`iso + ' '`) as before covers both cases — forced and genuinely
+     * unmapped both want the bare ISO code.
+     */
+    private static String formatCurrencyWithIso(Decimal num, String iso, String locale, Boolean forceIso) {
         // Resolve symbol
-        String symbol = CURRENCY_SYMBOLS.containsKey(iso) ? CURRENCY_SYMBOLS.get(iso) : iso + ' ';
+        String symbol = (!forceIso && CURRENCY_SYMBOLS.containsKey(iso)) ? CURRENCY_SYMBOLS.get(iso) : iso + ' ';
 
         // Determine decimal places (0 for JPY, KRW, etc.)
         Integer scale = ZERO_DECIMAL_CURRENCIES.contains(iso) ? 0 : 2;

--- a/force-app/main/default/classes/DocGenTemplateLinter.cls
+++ b/force-app/main/default/classes/DocGenTemplateLinter.cls
@@ -34,6 +34,16 @@ public with sharing class DocGenTemplateLinter {
     };
     private static final Set<String> AGGREGATE_TAGS = new Set<String>{ 'SUM', 'COUNT', 'AVG', 'MIN', 'MAX' };
 
+    // Vijay: fix for false-positive on {#ChartBucket} loop variables (RCA below).
+    // These are scopes supplied by a resolver (e.g. the chart-bucket resolver),
+    // not real SObject child relationships. Their inner tags (key_label,
+    // percent, …) must be skipped from base-object field validation, but they
+    // must NOT be checked against child relationship names either — unlike a
+    // real {#Rel} loop, there is no Schema describe or Query Config node that
+    // will ever "define" ChartBucket. Add future resolver-supplied loop names
+    // here, not to isRelationshipLoop().
+    private static final Set<String> SYNTHETIC_SCOPE_TAGS = new Set<String>{ 'ChartBucket' };
+
     // {Field}, {Parent.Field}, {Field:format} — the GiantQueryAssembler tag shape.
     private static final Pattern FIELD_TAG = Pattern.compile(
         '^([A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*)(?::(.+))?$'
@@ -402,13 +412,20 @@ public with sharing class DocGenTemplateLinter {
                         );
                     }
                     loopDepth++;
+                } else if (SYNTHETIC_SCOPE_TAGS.contains(t.key)) {
+                    // Vijay: bucket-resolver scope (e.g. ChartBucket) — treat like a
+                    // relationship loop for field-validation purposes (bump loopDepth
+                    // so inner tags are skipped below), but skip the relationship-name
+                    // check above since it's never a real child relationship.
+                    loopDepth++;
                 }
                 continue;
             }
             if (t.isClose == true) {
                 if (!stack.isEmpty() && stack[stack.size() - 1].key.equals(t.key)) {
                     MergeToken popped = stack.remove(stack.size() - 1);
-                    if (isRelationshipLoop(popped.key)) {
+                    // Vijay: pop loopDepth for synthetic scopes too, mirroring the push above.
+                    if (isRelationshipLoop(popped.key) || SYNTHETIC_SCOPE_TAGS.contains(popped.key)) {
                         loopDepth--;
                     }
                 }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it brief — 1-3 sentences. -->

## Changes

<!-- Bullet list of what changed and why. -->

-

## Testing

<!-- How did you verify this works? -->

- [ ] Ran E2E tests (`sf apex run --target-org <org> -f scripts/e2e-test.apex`) — all passing
- [ ] Ran Apex unit tests (`sf apex run test --synchronous --code-coverage`) — all passing
- [ ] Tested manually in a scratch org
- [ ] Added/updated E2E test assertions for new behavior

## Related Issues

<!-- Link issues: "Fixes #123" or "Closes #123" to auto-close, "Related to #123" for reference -->

## Screenshots

<!-- If UI changes, before/after screenshots help reviewers. Delete this section if not applicable. -->

## Checklist

- [ ] No hardcoded IDs, URLs, or credentials
- [ ] No `VersionData` in PDF image queries (see CLAUDE.md)
- [ ] SOQL uses `WITH USER_MODE` or `Security.stripInaccessible()` where appropriate
- [ ] No new external dependencies introduced
