### PR TITLE
fix(lint): size-guard the fidelity report — "Regex too complex" is killing large-template saves

### DIFF
--- a/force-app/main/default/classes/DocGenTemplateLinter.cls
+++ b/force-app/main/default/classes/DocGenTemplateLinter.cls
@@ -34,6 +34,20 @@ public with sharing class DocGenTemplateLinter {
     };
     private static final Set<String> AGGREGATE_TAGS = new Set<String>{ 'SUM', 'COUNT', 'AVG', 'MIN', 'MAX' };
 
+    /**
+     * Bodies at or below this many characters are safe to lint. Above it, the
+     * report is skipped entirely — see the block comment on lint().
+     *
+     * Measured on the 383,163-char customer template from the v3.56 reports:
+     * the full lint() completes at 130,000 chars (300ms CPU) and throws
+     * `System.LimitException: Regex too complicated` at 140,000. The ceiling is
+     * content-dependent, not just length-dependent — a body dense in CSS-like
+     * text does more per-position work — so this sits ~25% under the lowest
+     * ceiling actually observed rather than at it.
+     */
+    @TestVisible
+    private static Integer maxLintChars = 100000;
+
     // {Field}, {Parent.Field}, {Field:format} — the GiantQueryAssembler tag shape.
     private static final Pattern FIELD_TAG = Pattern.compile(
         '^([A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*)(?::(.+))?$'
@@ -47,6 +61,38 @@ public with sharing class DocGenTemplateLinter {
     public static List<DocGenAiHtmlValidator.Finding> lint(String html, DocGen_Template__c tmpl) {
         List<DocGenAiHtmlValidator.Finding> findings = new List<DocGenAiHtmlValidator.Finding>();
         if (String.isBlank(html)) {
+            return findings;
+        }
+        // Size gate — this MUST be a pre-check, not a try/catch.
+        //
+        // Apex throws `System.LimitException: Regex too complicated` when one
+        // Matcher exceeds its internal step budget, and LimitException is NOT
+        // caught by `catch (Exception)`. Every caller of this method wraps it in
+        // exactly that catch on the assumption that a lint failure can never
+        // fail a save (DocGenController.saveHtmlTemplateBody), and that
+        // assumption does not hold: the exception escapes the catch, the whole
+        // transaction rolls back, and the author's template does not save. That
+        // is the v3.55/v3.56 "Regex too complex" regression — reproduced against
+        // the real 383,163-char customer body, where sanitize() and this class's
+        // own line-190 <style>/<script> strip both throw.
+        //
+        // Nothing here can be made safe by rewriting patterns: the budget is
+        // spent by input length, not by pattern authorship. A trivial
+        // `font-weight:\s*([1-9]00)` throws on the same body. The only reliable
+        // guard is to not start.
+        if (html.length() > maxLintChars) {
+            findings.add(
+                new DocGenAiHtmlValidator.Finding(
+                    'warning',
+                    'Template too large to check',
+                    1,
+                    'This body is ' +
+                        html.length() +
+                        ' characters, above the ' +
+                        maxLintChars +
+                        '-character limit for the fidelity report, so it was not checked. Your template saved normally and will render normally — this is the report opting out, not a problem with your file.'
+                )
+            );
             return findings;
         }
         runRendererCompatibilityCheck(html, findings);
@@ -63,16 +109,41 @@ public with sharing class DocGenTemplateLinter {
     //    finding so nothing tells the author their file was changed. It wasn't.
     // -----------------------------------------------------------------------
 
+    /**
+     * Report-mode detail for the validator rules whose own detail describes a
+     * REPAIR it performed. The validator is the Agentforce repair pass; those
+     * sentences are true there. Here nothing is rewritten, so reusing them
+     * produced findings that contradicted themselves in the same breath —
+     * "your file was not modified. Mapped 600 and above to bold" — which is
+     * what made the report read as untrustworthy. Rules whose detail is already
+     * purely diagnostic (calc(), flex/grid, position, @import, <svg>, the two
+     * un-repairable loop rules) are passed through unchanged.
+     */
+    private static final Map<String, String> REPORT_MODE_DETAIL = new Map<String, String>{
+        'Markdown code fence' => 'This file starts or ends with a ``` fence, which prints as literal text. Delete the fence lines.',
+        'CSS variable' => 'var(...) resolves to nothing in this engine, so the property it feeds is dropped. Write the literal value instead.',
+        'Unresolved CSS variable' => 'A var(...) here has no definition and no fallback, so it reads as "inherit". Set a literal value.',
+        'Custom property declaration' => 'The --name: value declarations are inert — this engine never reads them back out.',
+        'rgba() colour' => 'rgba() does NOT fall back to a solid colour here — it resolves to nothing and the element renders invisible. Write a flat hex composited over white.',
+        'hsla() colour' => 'Same failure mode as rgba(): it resolves to nothing and the element renders invisible. Write a flat hex instead.',
+        'Gradient' => 'Gradients are discarded when the stylesheet is parsed, leaving no background at all. Use a solid fill.',
+        'Numeric font-weight' => 'Only normal and bold exist in this engine. A numeric weight of 600 or above renders as bold and anything below renders as normal, so intermediate weights are lost.',
+        'Dingbat font' => 'ZapfDingbats, Symbol, Wingdings and Webdings are NOT installed in the render engine — the character falls back to a serif face and prints a literal "l" or "m" where a shape was intended. Use Unicode glyphs (&#9679; filled, &#9675; hollow, &#8226; bullet) sized with font-size.',
+        '@media query' => 'Media queries never match — the engine has no viewport — so any rule that only lives inside one never applies. Move it to the main stylesheet if you meant it.',
+        'Loop tag placed between rows' => 'A {#Relationship} tag sitting between <tr> elements is foster-parented out of the table by the HTML parser, so the row never repeats. Put {#Rel} in the first cell and {/Rel} in the last cell of the same row.'
+    };
+
     private static void runRendererCompatibilityCheck(String html, List<DocGenAiHtmlValidator.Finding> findings) {
         try {
             DocGenAiHtmlValidator.Result res = DocGenAiHtmlValidator.sanitize(html);
             for (DocGenAiHtmlValidator.Finding f : res.findings) {
+                String detail = REPORT_MODE_DETAIL.containsKey(f.rule) ? REPORT_MODE_DETAIL.get(f.rule) : f.detail;
                 findings.add(
                     new DocGenAiHtmlValidator.Finding(
                         'warning',
                         f.rule,
                         f.occurrences,
-                        'The PDF engine ignores this at render time — your file was not modified. ' + f.detail
+                        'The PDF engine ignores this at render time — your file was not modified. ' + detail
                     )
                 );
             }

--- a/force-app/main/default/classes/DocGenTemplateLinterTest.cls
+++ b/force-app/main/default/classes/DocGenTemplateLinterTest.cls
@@ -403,4 +403,90 @@ private class DocGenTemplateLinterTest {
 
         System.assert((Integer) res.get('warningCount') > 0, 'Hand-authored HTML must still get the fidelity report.');
     }
+
+    // -----------------------------------------------------------------------
+    // Oversized bodies. `System.LimitException: Regex too complicated` is NOT
+    // caught by `catch (Exception)`, so before the size gate a large body took
+    // the whole save down with it — the v3.55/v3.56 regression. These assert the
+    // gate itself, because the failure it prevents cannot be asserted directly:
+    // an uncatchable exception fails the test method rather than being caught.
+    // -----------------------------------------------------------------------
+
+    /** A CSS-dense body of a requested length, shaped like the reported templates. */
+    private static String bodyOfLength(Integer target) {
+        String cell = '<td style="border:1px solid #ccc;padding:4pt 6pt;font-size:9pt;font-weight:600">Item</td>';
+        String block = '<table style="width:100%;border-collapse:collapse"><tr>' + cell + cell + cell + '</tr></table>';
+        String html = '<html><head><style>body{font-family:Arial;font-size:10pt}</style></head><body>';
+        while (html.length() < target) {
+            html += block;
+        }
+        return html;
+    }
+
+    @isTest
+    static void oversizedBodySkipsTheReportInsteadOfThrowing() {
+        DocGenTemplateLinter.maxLintChars = 5000;
+        String big = bodyOfLength(20000);
+
+        Test.startTest();
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(big, accountTemplate('Name'));
+        Test.stopTest();
+
+        System.assertEquals(1, findings.size(), 'An oversized body reports exactly one advisory finding.');
+        System.assertEquals('Template too large to check', findings[0].rule, 'The gate must name itself.');
+        System.assert(
+            findings[0].detail.contains('saved normally'),
+            'The notice must tell the author their template still saved: ' + findings[0].detail
+        );
+        System.assertEquals(
+            null,
+            findRule(findings, 'Numeric font-weight'),
+            'No renderer-compatibility check may run above the gate — that is what throws.'
+        );
+    }
+
+    @isTest
+    static void bodyUnderTheGateIsStillFullyChecked() {
+        // Control for the gate: the same markup below the threshold must still
+        // be reported, or the fix would have silently disabled the feature.
+        DocGenTemplateLinter.maxLintChars = 100000;
+
+        Test.startTest();
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(
+            bodyOfLength(20000),
+            accountTemplate('Name')
+        );
+        Test.stopTest();
+
+        System.assertEquals(null, findRule(findings, 'Template too large to check'), 'The gate must not fire here.');
+        System.assertNotEquals(null, findRule(findings, 'Numeric font-weight'), 'Under the gate the checks still run.');
+    }
+
+    @isTest
+    static void reportModeNeverClaimsTheFileWasRepaired() {
+        // The validator is the Agentforce REPAIR pass, so its details describe
+        // edits it made. Reused verbatim here they contradicted themselves —
+        // "your file was not modified. Mapped 600 and above to bold" — which is
+        // what made the report read as untrustworthy.
+        String html =
+            '<html><head><style>.a{font-weight:600}.b{background:rgba(0,0,0,.5)}' +
+            '.c{background:linear-gradient(#fff,#000)}</style></head><body>{Name}</body></html>';
+
+        Test.startTest();
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenTemplateLinter.lint(html, accountTemplate('Name'));
+        Test.stopTest();
+
+        System.assert(!findings.isEmpty(), 'This body trips several renderer-compatibility rules.');
+        for (DocGenAiHtmlValidator.Finding f : findings) {
+            String d = f.detail.toLowerCase();
+            System.assert(
+                !d.contains('mapped ') &&
+                    !d.contains('composited the') &&
+                    !d.contains('replaced each') &&
+                    !d.contains('removed the font') &&
+                    !d.contains('substituted the'),
+                'Report-mode detail must not claim an edit was made: [' + f.rule + '] ' + f.detail
+            );
+        }
+    }
 }


### PR DESCRIPTION
Fixes the v3.55/v3.56 regression two customers reported in `#bug-reports` (elliottr, Gayle Grant). elliottr **downgraded production to v3.46** to get their template saved.

## What happens

Saving a large HTML template fails with `Regex too complex`. The template does not save.

## Root cause

Apex throws `System.LimitException: Regex too complicated` when a single `Matcher` exceeds its internal step budget. **`LimitException` is not caught by `catch (Exception)`.**

`DocGenController.saveHtmlTemplateBody` wraps the lint call in exactly that catch, on the stated assumption from #272/#285 that *"a lint failure can never fail a save."* That assumption does not hold — the exception escapes the catch, the transaction rolls back, and the `ContentVersion` insert that already succeeded is rolled back with it.

Reproduced against elliottr's real 383,163-char body in a scratch org. Two separate sites throw on it:

| Site | Pattern |
| --- | --- |
| `DocGenAiHtmlValidator.sanitize()` (report mode) | `(?i)\s*--[A-Za-z0-9_-]+\s*:[^;}]*;` and others |
| `DocGenTemplateLinter.cls:190` | `(?is)<(style\|script)\b[^>]*>.*?</\1\s*>` |

## Why rewriting the patterns is not the fix

The budget is spent by **input length**, not pattern authorship:

- a trivial `(?i)(?<![-\w])font-weight\s*:\s*([1-9]00)` throws on the same body
- meanwhile `DocGenDocxTemplateLinter`'s `<[wa]:t…>` patterns complete on a 423 KB `document.xml`

So the only reliable guard is to not start.

## The gate

Measured on the real body: full `lint()` completes at **130,000 chars** (300 ms CPU) and throws at **140,000**. The gate is set at **100,000** — ~25% under the lowest ceiling observed, because the ceiling is content-dependent, not just length-dependent.

Above the gate the author gets one advisory finding:

> This body is 383163 characters, above the 100000-character limit for the fidelity report, so it was not checked. Your template saved normally and will render normally — this is the report opting out, not a problem with your file.

## Also: report-mode wording

The validator is the Agentforce **repair** pass, so its details describe edits it made. Reused verbatim in report mode they contradicted themselves in one sentence:

> your file was not modified. **Mapped 600 and above to bold**

Rules that claim a repair now carry report-mode detail. Purely diagnostic rules (`calc()`, flex/grid, `position`, `@import`, `<svg>`, the un-repairable loop rules) pass through unchanged.

## Verification

- the real 383,163-char customer body now lints and returns instead of throwing, confirmed in a scratch org against the actual file
- `DocGenTemplateLinterTest` + `DocGenEmailTemplateTest` **55/55 pass** (3 new tests: the gate, the control below the gate, and no-repair-claims)
- `npm run format:check` clean
- `sf code-analyzer` 0 violations

## Deliberately not in scope

- `DocGenDocxTemplateLinter` completes but burns **2.7 s CPU** on a 423 KB `document.xml` — filed separately
- the validator's finding **quality** beyond the self-contradiction — filed separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)