### PR TITLE
fix(email): guest-context emails never used the customer's saved templates

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -3077,6 +3077,56 @@ For each template you can edit the **subject** and **body**, preview it live wit
 
 > **Out of the box:** a default record for each template is created on install, so emails work immediately with zero setup. Delete a record to fall back to the built-in default.
 
+#### Changing a widget's wording or styling
+
+Each widget renders a fixed block of English text with **inline styles** — `{ActionButton}` always reads "Review & Sign Document," `{SecurityNote}` always says "This link is unique to you and will expire in _N_ hours." You cannot edit the text inside a widget, and because the widget's own inline styles win over any wrapper rule in most email clients, wrapping it in CSS won't recolor the button or relabel it either.
+
+**To change wording, stop using the widget and build the block yourself.** Every widget is assembled from ordinary merge tokens that you can place directly — so authoring your own gives you full control of both the words and the styling:
+
+| Instead of this widget | Use these tokens                      |
+| ---------------------- | ------------------------------------- |
+| `{ActionButton}`       | `{SignatureUrl}`                      |
+| `{DocumentInfo}`       | `{DocumentTitle}`, `{RoleName}`       |
+| `{SecurityNote}`       | `{SignatureUrl}`, `{ExpirationHours}` |
+| `{VerificationCode}`   | `{Pin}`, `{ExpirationMinutes}`        |
+
+A replacement for `{ActionButton}` with your own label and brand color — this is a plain `<a>`, so restyle it however you like:
+
+```html
+<table role="presentation" cellpadding="0" cellspacing="0" style="margin: 0 auto 24px auto">
+    <tr>
+        <td align="center" style="border-radius: 6px; background-color: #0b3d2e">
+            <a
+                href="{SignatureUrl}"
+                target="_blank"
+                style="display:inline-block;padding:14px 32px;color:#ffffff;font-size:16px;font-weight:bold;text-decoration:none;border-radius:6px;"
+                >Approve your agreement</a
+            >
+        </td>
+    </tr>
+</table>
+```
+
+And a replacement for `{SecurityNote}` in your own words:
+
+```html
+<p style="font-size: 13px; color: #706e6b; line-height: 1.5">
+    This link belongs to you alone and stops working after {ExpirationHours} hours. Trouble with the button? Paste this
+    into your browser:<br />
+    <a href="{SignatureUrl}" style="color: #0b3d2e">{SignatureUrl}</a>
+</p>
+```
+
+**To keep the widget but control what's around it,** wrap it — spacing, alignment and background of the surrounding container are yours, since those are properties of your element, not the widget's:
+
+```html
+<div style="background: #f7f9fa; padding: 20px; text-align: center; border-radius: 8px">{ActionButton}</div>
+```
+
+Use **Full custom HTML** layout mode (above) when you're replacing widgets wholesale, so Portwood adds no header/footer of its own around your markup.
+
+> **Which tokens are available depends on the email.** A token that isn't supplied for that email type renders as empty text and is then stripped. `{Pin}` / `{ExpirationMinutes}` exist only on the **Verification PIN** email; `{SignatureUrl}` / `{ExpirationHours}` / `{RoleName}` only on the emails that carry a signing link (Signature Request, Reminder). `{CompanyName}`, `{DocumentTitle}` and `{BrandColor}` are available everywhere. Use the live preview and **Send Test** on the Email Templates tab to confirm before saving.
+
 **Send-time customization.** When sending a single-template request (from the Signature Sender or the `Portwood: Create Signature Request` Flow action), you can type a **Custom Email Subject** and/or **Custom Email Message** that override the saved template for that one send. The subject supports merge tokens; the branded layout and signing button are always kept. Bulk/packet sends always use the saved templates.
 
 **Per-template default message (v3.28+).** Each Portwood Template has a **Default Email Message** field (Command Hub → template editor). When set, it becomes the `{Message}` text for signature requests sent from that template — pre-filled in the sender so you see exactly what will go out, and used automatically by Flow sends that leave the message blank. Resolution order: send-time custom message → template default → the email template's generic text. A quote template can say "Please see the attached proposal…" while an NDA template carries different copy, with no per-send typing.

--- a/force-app/main/default/classes/DocGenEmailTemplateService.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateService.cls
@@ -211,6 +211,87 @@ global with sharing class DocGenEmailTemplateService {
     // Record loading (defensive — never throws to the caller)
     // =====================================================================
 
+    /**
+     * The active-template read, in its own `without sharing` scope.
+     *
+     * `WITH SYSTEM_MODE` bypasses CRUD/FLS but NOT record sharing — sharing is
+     * decided by the sharing keyword of the class the query runs in, and this
+     * class is `with sharing`. DocGen_Email_Template__c ships with
+     * sharingModel=ReadWrite but externalSharingModel=Private, so an internal
+     * sender sees every active record and a GUEST sender sees none: the query
+     * returned zero rows, defCache stayed empty, and getTemplate() silently fell
+     * back to builtInDef(). That is exactly why the two guest-context emails
+     * (Verification PIN, Completion Confirmation) arrived on the built-in
+     * default while the two internal-context ones (Signature Request, Reminder)
+     * used the customer's saved template.
+     *
+     * A guest sharing rule is not the fix — this is package-internal branding
+     * config with no per-record confidentiality model (internal OWD is already
+     * ReadWrite), and requiring every subscriber to hand-build a sharing rule
+     * for it would be a setup trap. The bypass is scoped to this one read rather
+     * than applied to the whole class, and FLS is still enforced by the
+     * guestAssertAccessible guard in loadActiveTemplates.
+     */
+    private without sharing class TemplateReader {
+        /**
+         * The logo asset behind {%asset:key} and Logo_Asset_Key__c, same story:
+         * DocGen_Asset__c is also sharingModel=ReadWrite / externalSharingModel=
+         * Private, so under `with sharing` a guest read returned nothing and the
+         * logo silently vanished from the guest emails — degrading quietly,
+         * because queryAssetPublicUrl treats "no rows" as "no logo".
+         */
+        private List<DocGen_Asset__c> readAssetByKey(String assetKey) {
+            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+            return [
+                SELECT
+                    Id,
+                    (
+                        SELECT ContentDocument.LatestPublishedVersionId
+                        FROM ContentDocumentLinks
+                        ORDER BY ContentDocument.CreatedDate DESC, ContentDocument.Id DESC
+                        LIMIT 1
+                    )
+                FROM DocGen_Asset__c
+                WHERE Asset_Key__c = :assetKey
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ]; // NOPMD ApexCRUDViolation - package-internal custom object; CRUD controlled by Portwood permission sets
+        }
+
+        private List<ContentDistribution> readDistribution(Id cvId) {
+            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+            return [
+                SELECT ContentDownloadUrl
+                FROM ContentDistribution
+                WHERE ContentVersionId = :cvId
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+        }
+
+        private List<DocGen_Email_Template__c> read() {
+            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+            return [
+                SELECT
+                    Type__c,
+                    Subject__c,
+                    Body_Html__c,
+                    Body_Plain__c,
+                    Brand_Color__c,
+                    Logo_Url__c,
+                    Logo_Url_Extended__c,
+                    Logo_Asset_Key__c,
+                    Logo_Height__c,
+                    Footer_Text__c,
+                    Layout_Mode__c
+                FROM DocGen_Email_Template__c
+                WHERE Is_Active__c = TRUE
+                WITH SYSTEM_MODE
+                ORDER BY LastModifiedDate DESC
+            ]; // NOPMD - package-internal object; CRUD via Portwood permission sets
+        }
+    }
+
     private static void loadActiveTemplates() {
         defCache = new Map<String, TemplateDef>();
         try {
@@ -234,25 +315,7 @@ global with sharing class DocGenEmailTemplateService {
                     'Is_Active__c'
                 }
             );
-            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-            List<DocGen_Email_Template__c> rows = [
-                SELECT
-                    Type__c,
-                    Subject__c,
-                    Body_Html__c,
-                    Body_Plain__c,
-                    Brand_Color__c,
-                    Logo_Url__c,
-                    Logo_Url_Extended__c,
-                    Logo_Asset_Key__c,
-                    Logo_Height__c,
-                    Footer_Text__c,
-                    Layout_Mode__c
-                FROM DocGen_Email_Template__c
-                WHERE Is_Active__c = TRUE
-                WITH SYSTEM_MODE
-                ORDER BY LastModifiedDate DESC
-            ]; // NOPMD - package-internal object; CRUD via Portwood permission sets
+            List<DocGen_Email_Template__c> rows = new TemplateReader().read();
             for (DocGen_Email_Template__c r : rows) {
                 if (r.Type__c == null || defCache.containsKey(r.Type__c)) {
                     continue; // first (most-recently-modified) active record per type wins
@@ -542,21 +605,7 @@ global with sharing class DocGenEmailTemplateService {
     private static String queryAssetPublicUrl(String assetKey) {
         try {
             DocGenFlsGuard.guestAssertAccessible(DocGen_Asset__c.sObjectType, new Set<String>{ 'Asset_Key__c' });
-            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-            List<DocGen_Asset__c> assets = [
-                SELECT
-                    Id,
-                    (
-                        SELECT ContentDocument.LatestPublishedVersionId
-                        FROM ContentDocumentLinks
-                        ORDER BY ContentDocument.CreatedDate DESC, ContentDocument.Id DESC
-                        LIMIT 1
-                    )
-                FROM DocGen_Asset__c
-                WHERE Asset_Key__c = :assetKey
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ]; // NOPMD ApexCRUDViolation - package-internal custom object; CRUD controlled by Portwood permission sets
+            List<DocGen_Asset__c> assets = new TemplateReader().readAssetByKey(assetKey);
             if (assets.isEmpty() || assets[0].ContentDocumentLinks.isEmpty()) {
                 return null;
             }
@@ -568,14 +617,7 @@ global with sharing class DocGenEmailTemplateService {
                 ContentDistribution.sObjectType,
                 new Set<String>{ 'ContentDownloadUrl', 'ContentVersionId' }
             );
-            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-            List<ContentDistribution> dists = [
-                SELECT ContentDownloadUrl
-                FROM ContentDistribution
-                WHERE ContentVersionId = :cvId
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ];
+            List<ContentDistribution> dists = new TemplateReader().readDistribution(cvId);
             return dists.isEmpty() ? null : dists[0].ContentDownloadUrl;
         } catch (Exception e) {
             System.debug(LoggingLevel.WARN, 'Portwood: logo asset resolution fell back to URL: ' + e.getMessage());


### PR DESCRIPTION
Fixes the bug tyler reported in `#bug-reports` (seen on v3.47, still present on current main).

## What happens

| Email | Sent by | Result |
| --- | --- | --- |
| Signature Request | internal user | ✅ customer's saved template |
| Signature Reminder | internal user | ✅ customer's saved template |
| Verification PIN | **guest** | ❌ falls back to built-in default |
| Completion Confirmation | **guest** | ❌ falls back to built-in default |

Adding a guest sharing rule on the template object changed nothing.

## Root cause

`WITH SYSTEM_MODE` bypasses CRUD/FLS but **not record sharing** — sharing is decided by the sharing keyword of the class the query runs in, and `DocGenEmailTemplateService` is `with sharing`.

`DocGen_Email_Template__c` ships:

```xml
<sharingModel>ReadWrite</sharingModel>
<externalSharingModel>Private</externalSharingModel>
```

So an internal sender sees every active record and a **guest sender sees none**. The query returned zero rows, `defCache` stayed empty, and `getTemplate()` fell back to `builtInDef()` — behaving exactly as designed for *"no record exists."*

That splits precisely along the reported line: the two guest-context types break, the two internal-context ones work.

tyler's diagnosis was right about the sharing boundary. His sharing rule didn't help because the FLS half already landed (`guestAssertAccessible` + `SYSTEM_MODE`); it was the class-level sharing keyword still enforcing.

## Fix

Move the read into a `without sharing` inner class — scoped to the one query rather than applied to the whole class, so the AppExchange posture is unchanged and FLS is still enforced by the existing guest guard.

A guest sharing rule is not the right answer here: this is package-internal branding config with no per-record confidentiality model (internal OWD is already `ReadWrite`), and requiring every subscriber to hand-build one would be a setup trap.

**Same flaw, same class, same guest path:** `queryAssetPublicUrl` reads `DocGen_Asset__c`, also `ReadWrite`/`Private` — so the **logo silently vanished from guest emails** too, since "no rows" reads as "no logo." Routed through the same reader.

## Also: UserGuide — changing widget wording

Several people have asked how to relabel the email widgets. Widget text is fixed and **inline-styled**, so wrapping it in CSS cannot relabel or recolor it. The real answer is to replace the widget with the raw tokens it's built from and author the block yourself.

UserGuide §10.14 now carries:

- a widget → tokens table (`{ActionButton}` → `{SignatureUrl}`, `{VerificationCode}` → `{Pin}`/`{ExpirationMinutes}`, etc.)
- working replacements for `{ActionButton}` and `{SecurityNote}`
- the wrap-for-layout pattern, for keeping the widget but controlling what's around it
- which tokens exist on which email type

## Verification

- `DocGenEmailTemplateTest` + `DocGenTemplateLinterTest` **55/55 pass**
- `npm run format:check` clean
- `sf code-analyzer` 0 violations

⚠️ **Not verified in a real guest / Experience Cloud context** — the sharing boundary can't be reproduced in a no-namespace scratch org, the same class of gap as the Flow Apex-Defined work. Worth confirming with tyler on a beta before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)