### PR TITLE
fix(designer): stop a second save replacing the author's stylesheet

### DIFF
--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -6798,9 +6798,17 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             return html;
         }
         try {
+            // Clean ONLY the body when the document has one (#319). Parsing the
+            // whole document and splicing the result back into <body> copies the
+            // head's <meta>/<title>/<style> into the body while leaving the head
+            // in place — duplicating them, and growing the file on every save.
+            const bodyRe = /(<body\b[^>]*>)([\s\S]*?)(<\/body\s*>)/i;
+            const bodyMatch = html.match(bodyRe);
+            const target = bodyMatch ? bodyMatch[2] : html;
+
             const tpl = document.createElement('template');
             // eslint-disable-next-line @lwc/lwc/no-inner-html -- deliberate manual-DOM canvas write; content passes _sanitizeStagedHtml / scopeHtmlForInlinePreview
-            tpl.innerHTML = html;
+            tpl.innerHTML = target;
             const root = tpl.content;
             for (const marker of root.querySelectorAll('.dg-drop-marker')) {
                 marker.remove();
@@ -6808,32 +6816,51 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this._unpillifyTags(root);
             const pv = root.querySelector('div.dg-pv');
             if (pv) {
-                // Preview-wrapped payload: keep only the page content, minus
-                // the injected scoped stylesheet.
+                // Preview-wrapped payload: drop the injected scoped stylesheet,
+                // then UNWRAP the preview div in place rather than reading only
+                // pv.innerHTML. Reading the inner HTML discards every sibling of
+                // the preview — which on a flattened document is where the
+                // author's <style>, <title> and <meta> are sitting (#319).
                 for (const styleEl of pv.querySelectorAll(':scope > style')) {
                     styleEl.remove();
                 }
-                // eslint-disable-next-line @lwc/lwc/no-inner-html -- deliberate manual-DOM canvas write; content passes _sanitizeStagedHtml / scopeHtmlForInlinePreview
-                const inner = pv.innerHTML.trim();
-                // Preserve an original shell if one wrapped the preview; else
-                // the content becomes the document body in a minimal shell.
-                const bodyRe = /(<body\b[^>]*>)[\s\S]*?(<\/body\s*>)/i;
-                const outer = html.replace(/[\s\S]*/, ''); // placeholder, replaced below
-                void outer;
-                if (bodyRe.test(html) && !/class="dg-pv"/.test(html.split(/<body\b[^>]*>/i)[0] || '')) {
-                    return html.replace(bodyRe, (m, open, close) => open + '\n' + inner + '\n' + close);
+                // insertBefore/remove, not replaceWith — LWS proxied nodes are
+                // missing ChildNode.replaceWith (the v3.39 lesson).
+                while (pv.firstChild) {
+                    pv.parentNode.insertBefore(pv.firstChild, pv);
                 }
-                return (
-                    '<!DOCTYPE html>\n<html>\n<head>\n<meta charset="utf-8" />\n<style>\n@page { size: Letter portrait; margin: 0.75in; }\nbody { font-family: Helvetica, Arial, sans-serif; font-size: 10.5pt; color: #1a1a1a; }\n</style>\n</head>\n<body>\n' +
-                    inner +
-                    '\n</body>\n</html>\n'
-                );
+                pv.remove();
             }
-            // No pv wrapper — serialize the cleaned fragment back out.
             const container = document.createElement('div');
-            container.appendChild(root.cloneNode(true));
+            container.appendChild(root);
             // eslint-disable-next-line @lwc/lwc/no-inner-html -- deliberate manual-DOM canvas write; content passes _sanitizeStagedHtml / scopeHtmlForInlinePreview
-            return container.innerHTML;
+            const cleaned = container.innerHTML.trim();
+
+            // Put the cleaned content back inside the AUTHOR'S OWN shell, and
+            // never fabricate one (#319).
+            //
+            // Two bugs used to live in these few lines, and they chained:
+            //
+            //  1. Parsing a full document into a <template> fragment discards
+            //     <!DOCTYPE>, <html>, <head> and <body> — they are ignored tokens
+            //     in that insertion mode. Serializing the fragment back therefore
+            //     returned a body with no shell. The author's <style> survived, so
+            //     nothing looked wrong yet.
+            //  2. On the NEXT save that shell-less body arrives wrapped in the
+            //     canvas's .dg-pv div, so `bodyRe.test(html)` is false, and the
+            //     old code fell through to a hardcoded
+            //     `<style>@page { size: Letter portrait }...</style>` shell —
+            //     silently replacing the author's entire stylesheet, and resetting
+            //     a Landscape template to Portrait.
+            //
+            // Splicing the cleaned BODY back into the original string, and
+            // otherwise returning the cleaned content untouched, fixes both: the
+            // shell is preserved when there is one, and no shell is invented when
+            // there is not.
+            if (bodyMatch) {
+                return html.replace(bodyRe, (m, open, inner, close) => open + '\n' + cleaned + '\n' + close);
+            }
+            return cleaned;
         } catch (e) {
             return html;
         }

--- a/scripts/qa/designer-shell-preservation-check.mjs
+++ b/scripts/qa/designer-shell-preservation-check.mjs
@@ -1,0 +1,159 @@
+/**
+ * Designer staging — the author's document shell and stylesheet survive a save.
+ *
+ *   node scripts/qa/designer-shell-preservation-check.mjs
+ *
+ * Issue #319. klugo reported that saving a template in the old designer "removes
+ * all the CSS. Basically removes the full <style>". The damage takes TWO saves,
+ * which is why it read as intermittent and why some templates were fine:
+ *
+ *   1. _sanitizeStagedHtml parses the body into a <template> fragment. A full
+ *      document loses <!DOCTYPE>, <html>, <head> and <body> there — they are
+ *      ignored tokens in that insertion mode. The author's <style> survives, so
+ *      nothing looks wrong yet.
+ *   2. On the next save the canvas wraps that shell-less body in its .dg-pv
+ *      preview div. The old code tested for a <body> to splice into, found none,
+ *      and fell through to a HARDCODED shell carrying
+ *      `@page { size: Letter portrait }` — replacing the author's entire
+ *      stylesheet and resetting a Landscape template to Portrait.
+ *
+ * The sanitizer only engages at all when the body carries `data-dg-tag`,
+ * `dg-pv` or `dg-drop-marker`, so tag pills leaking into the source (#322) are
+ * what arm it. That is modelled here too — a clean body must pass through
+ * untouched.
+ *
+ * This mirrors _sanitizeStagedHtml from docGenAdmin.js. Keep the two in step: if
+ * the component changes, change the model here and the assertions will tell you
+ * whether the behaviour still holds.
+ */
+
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+global.document = dom.window.document;
+
+let fail = 0;
+const ok = (c, m) => {
+    console.log((c ? '  ok  ' : ' FAIL ') + m);
+    if (!c) fail++;
+};
+
+/** Mirrors docGenAdmin._sanitizeStagedHtml. */
+function sanitizeStagedHtml(html) {
+    if (
+        !html ||
+        (html.indexOf('data-dg-tag') === -1 &&
+            html.indexOf('dg-pv') === -1 &&
+            html.indexOf('dg-drop-marker') === -1)
+    ) {
+        return html;
+    }
+    try {
+        const bodyRe = /(<body\b[^>]*>)([\s\S]*?)(<\/body\s*>)/i;
+        const bodyMatch = html.match(bodyRe);
+        const target = bodyMatch ? bodyMatch[2] : html;
+        const tpl = document.createElement('template');
+        tpl.innerHTML = target;
+        const root = tpl.content;
+        for (const marker of root.querySelectorAll('.dg-drop-marker')) {
+            marker.remove();
+        }
+        const pv = root.querySelector('div.dg-pv');
+        if (pv) {
+            for (const styleEl of pv.querySelectorAll(':scope > style')) {
+                styleEl.remove();
+            }
+            while (pv.firstChild) {
+                pv.parentNode.insertBefore(pv.firstChild, pv);
+            }
+            pv.remove();
+        }
+        const container = document.createElement('div');
+        container.appendChild(root);
+        const cleaned = container.innerHTML.trim();
+        if (bodyMatch) {
+            return html.replace(bodyRe, (m, open, inner, close) => open + '\n' + cleaned + '\n' + close);
+        }
+        return cleaned;
+    } catch (e) {
+        return html;
+    }
+}
+
+/** What the canvas does to a stored body before the next save stages it. */
+const wrapInPreview = (doc) =>
+    doc.replace(
+        /(<body\b[^>]*>)([\s\S]*?)(<\/body\s*>)/i,
+        (m, open, inner, close) => `${open}<div class="dg-pv"><style>.dg-pv{padding:1in}</style>${inner}</div>${close}`
+    );
+
+// klugo's template: Landscape Letter, author stylesheet in <head>, a tag pill in
+// the body because the visual editor has been used.
+const AUTHOR_DOC = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8" />
+<title>EC Project Closure - Landscape Letter</title>
+<style>
+@page { size: Letter landscape; margin: 0.75in; }
+body { font-family: Helvetica, Arial, sans-serif; color: #2C2C2C; }
+.fixed-page { width: 100%; height: 6.82in; position: relative; }
+</style>
+</head>
+<body>
+<div class="fixed-page"><span data-dg-tag="Name">{Name}</span></div>
+</body>
+</html>`;
+
+const survives = (out, label) => {
+    ok(/<html/i.test(out) && /<head/i.test(out) && /<body/i.test(out), `${label}: document shell intact`);
+    ok(out.includes('Letter landscape'), `${label}: author's @page landscape kept`);
+    ok(out.includes('.fixed-page'), `${label}: author's stylesheet kept`);
+    ok(!out.includes('Letter portrait'), `${label}: no fabricated portrait shell`);
+    ok(out.includes('{Name}'), `${label}: merge tag kept`);
+};
+
+console.log('\nthe two-save chain that destroyed the stylesheet (#319)');
+const save1 = sanitizeStagedHtml(AUTHOR_DOC);
+survives(save1, 'save 1');
+
+const save2 = sanitizeStagedHtml(wrapInPreview(save1));
+survives(save2, 'save 2');
+
+const save3 = sanitizeStagedHtml(wrapInPreview(save2));
+survives(save3, 'save 3');
+ok(save3 === save2, 'save 3 is byte-identical to save 2 (staging is idempotent)');
+
+console.log('\nrecovery from a body already flattened by the old code');
+// No shell at all — what an affected org already has stored. The stylesheet must
+// still be carried through rather than replaced, and no shell may be invented.
+const flattened = `<meta charset="UTF-8">
+<title>EC Project Closure - Landscape Letter</title>
+<style>@page { size: Letter landscape; } .fixed-page { width: 100%; }</style>
+<div class="dg-pv"><style>.dg-pv{padding:1in}</style><div class="fixed-page"><span data-dg-tag="Name">{Name}</span></div></div>`;
+const recovered = sanitizeStagedHtml(flattened);
+ok(recovered.includes('Letter landscape'), 'flattened body: author @page still carried');
+ok(recovered.includes('.fixed-page'), 'flattened body: author stylesheet still carried');
+ok(!recovered.includes('Letter portrait'), 'flattened body: no fabricated portrait shell');
+ok(!recovered.includes('dg-pv'), 'flattened body: preview wrapper unwrapped, not left behind');
+
+console.log('\nthe editor artifacts it exists to strip');
+const withArtifacts = AUTHOR_DOC.replace(
+    '<div class="fixed-page">',
+    '<div class="dg-drop-marker"></div><div class="fixed-page">'
+);
+const stripped = sanitizeStagedHtml(withArtifacts);
+ok(!stripped.includes('dg-drop-marker'), 'drop markers removed');
+ok(stripped.includes('.fixed-page'), 'and the stylesheet is still not collateral');
+
+const previewOnly = `<html><head><style>.keep{color:red}</style></head><body><div class="dg-pv"><style>.dg-pv{padding:1in}</style><p data-dg-tag="X">{X}</p></div></body></html>`;
+const unwrapped = sanitizeStagedHtml(previewOnly);
+ok(!unwrapped.includes('.dg-pv{'), "the preview's own scoped stylesheet is removed");
+ok(unwrapped.includes('.keep'), "the author's stylesheet beside it is not");
+
+console.log('\na clean body must not be touched at all');
+const clean = '<html><head><style>p{color:blue}</style></head><body><p>{Name}</p></body></html>';
+ok(sanitizeStagedHtml(clean) === clean, 'no pills, no markers, no preview wrapper — passes through byte-identical');
+
+console.log(fail ? `\n${fail} FAILED` : '\nshell preservation OK');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #319.

## For @untangleportwood — how to test this

The damage takes **two saves**, which is why it reads as intermittent. Testing it in one save will show nothing.

1. Take an HTML template with a real `<style>` block in its `<head>` — ideally one that sets `@page { size: Letter landscape }`, since the page orientation flipping to Portrait is the loudest symptom.
2. Open it in the **old designer** (not Canvas), and make an edit in the **Visual** tab so tag pills get into the document.
3. **Save as New Version.** Look at the Source tab — the CSS is still there, so it looks fine.
4. **Edit and save a second time.**
5. **Before this change:** the entire `<style>` block is gone, the doctype/`<html>`/`<head>` are gone, the `<title>` text is left behind as a bare line, and the Page control reads Portrait.
6. **After:** the shell and the stylesheet survive every save.

Also worth checking, because it is the part that helps people already affected: **a template whose CSS was already destroyed.** Re-saving it should now carry whatever stylesheet remains rather than replacing it again.

And the no-regression case: a template you have **never** opened in the Visual tab should save byte-identical. The sanitizer is a no-op unless the body carries editor markup.

## What klugo reported

> I'm using HTML (Source) to paste the code. So far, I've been able to do this for other templates but this one **even after saving it, it removes all the CSS. Basically removes the full `<style>`**

Their screenshots show a Landscape Letter template that comes back with no doctype, no `<head>`, no stylesheet, the `<title>` text stranded as a text node, and the Page control reset to Portrait.

## Root cause — the chain

`_sanitizeStagedHtml` is a **no-op** unless the body contains `data-dg-tag`, `dg-pv` or `dg-drop-marker`. So it only engages once the visual editor has been used and its **tag pills have leaked into the source** — which is #322, and Dave spotted it independently. Once it engages:

**Save 1 — the shell is destroyed, silently.** The full document was parsed into a `<template>` fragment and serialized back out. `<!DOCTYPE>`, `<html>`, `<head>` and `<body>` are *ignored tokens* in that insertion mode, so the shell was dropped. The `<style>` survived, so nothing looked wrong yet.

**Save 2 — the stylesheet is replaced.** The canvas wraps that shell-less body in `.dg-pv`. The old code looked for a `<body>` to splice into, found none, and fell through to:

```js
return '<!DOCTYPE html>…<style>@page { size: Letter portrait; margin: 0.75in; }…</style>…';
```

A hardcoded shell. That is the author's whole stylesheet gone, and the Portrait reset in the screenshot.

## The fix

Three changes, all in `_sanitizeStagedHtml`:

1. **Clean only the `<body>`** when the document has one. Parsing the whole document and splicing the result back into `<body>` copies the head's `<meta>`/`<title>`/`<style>` into the body while leaving the head in place — duplicating them and growing the file on every save. *This was a bug in my first attempt at the fix, caught by the idempotence assertion.*
2. **Unwrap `.dg-pv` in place** rather than reading `pv.innerHTML`, which discards every sibling of the preview — on a flattened document, exactly where the author's `<style>`, `<title>` and `<meta>` live. Uses `insertBefore`/`remove`, not `replaceWith`, which LWS proxied nodes do not have (the v3.39 lesson).
3. **Never fabricate a shell.** Splice into the author's own when there is one; return the cleaned content untouched when there is not.

## Verification

New `scripts/qa/designer-shell-preservation-check.mjs`, following the existing standalone-check convention — pure Node + jsdom, no org needed:

```
node scripts/qa/designer-shell-preservation-check.mjs
```

**25 assertions, all passing**, covering the two-save chain, a third save for idempotence, the already-flattened state klugo is actually in, the editor artifacts the sanitizer exists to strip, and a clean body that must pass through byte-identical.

Neighbouring checks unaffected: `canvas-inline-sanitize`, `canvas-serializer`, `canvas-import-fidelity`, `canvas-export-roundtrip`, `lws-download-route` all pass. `lwc-template-refs` reports 19 undefined references — **identical on unmodified main**, pre-existing false positives on merge-tag literals in help text. `npm run format:check` clean.

## Deliberately not in scope

The pill leak that arms this (#322). A body that never carried pills never reaches this code at all, so that is the change that makes the whole class impossible — but it is architectural. This stops the corruption now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)