### PR TITLE
fix(preview): fall back to the file viewer when the sandbox refuses blob:

### DIFF
--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -12250,25 +12250,49 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 for (let i = 0; i < raw.length; i++) {
                     bytes[i] = raw.charCodeAt(i);
                 }
-                const url = URL.createObjectURL(new Blob([bytes], { type: 'application/pdf' }));
-                // Usually still inside the click's activation window, so this
-                // opens directly. (LWS neuters a pre-opened window's proxy —
-                // document.write/location are silent no-ops — so the tab must
-                // be opened WITH its URL.)
-                const win = window.open(url, '_blank');
-                if (!win) {
-                    // Popup blocked: arm the button for a synchronous open.
-                    this._pendingPreviewUrl = url;
-                    this.pdfPreviewReady = true;
-                    this.showToast(
-                        'Preview ready',
-                        'Your PDF is rendered — click "Open preview" to view it.',
-                        'success'
-                    );
+                // blob: is not universally openable (#321). Locker Service's
+                // SecureWindow.open permits only http:, https: and mailto: and
+                // THROWS on a blob: URL — it does not return null — so the
+                // popup-blocked recovery below was unreachable in exactly the
+                // orgs that needed it, and the author got a bare
+                // "PDF preview failed" carrying the raw platform message.
+                //
+                // On any failure here, fall through to the ContentVersion +
+                // native viewer path below. That is an ordinary https:
+                // navigation, it is already the route for payloads too large for
+                // Aura, and it works in every org. A slower preview beats none.
+                let deliveredInline = false;
+                try {
+                    const url = URL.createObjectURL(new Blob([bytes], { type: 'application/pdf' }));
+                    // Usually still inside the click's activation window, so this
+                    // opens directly. (LWS neuters a pre-opened window's proxy —
+                    // document.write/location are silent no-ops — so the tab must
+                    // be opened WITH its URL.)
+                    const win = window.open(url, '_blank');
+                    if (!win) {
+                        // Popup blocked: arm the button for a synchronous open.
+                        this._pendingPreviewUrl = url;
+                        this.pdfPreviewReady = true;
+                        this.showToast(
+                            'Preview ready',
+                            'Your PDF is rendered — click "Open preview" to view it.',
+                            'success'
+                        );
+                    }
+                    deliveredInline = true;
+                } catch (blobErr) {
+                    // NOPMD — the org's browser sandbox refused blob:; the
+                    // ContentVersion path below is the answer, not an error.
+                    const noop = blobErr && blobErr.message;
+                    void noop;
                 }
-                return;
+                if (deliveredInline) {
+                    return;
+                }
             }
-            // Too large for the Aura payload — ContentVersion + native viewer.
+            // ContentVersion + native viewer. Reached when the PDF is too large
+            // for the Aura payload, OR when the org's browser sandbox refused the
+            // blob: URL above (#321). Plain https:, so it is the portable route.
             const res2 = await previewDraftPdf({
                 templateId: this.editTemplateId,
                 recordId: this.editTemplateTestRecordId,

--- a/scripts/qa/locker-preview-route-check.mjs
+++ b/scripts/qa/locker-preview-route-check.mjs
@@ -1,0 +1,142 @@
+/**
+ * handlePdfPreview — browser-sandbox routing.
+ *
+ *   node scripts/qa/locker-preview-route-check.mjs
+ *
+ * Locker Service's SecureWindow.open permits only http:, https: and mailto:. A
+ * blob: URL is refused with "secure.windowopen() only acceptable types are
+ * http:, https: and mailto:" — and it THROWS rather than returning null, so the
+ * popup-blocked recovery beneath it was unreachable in exactly the orgs that
+ * needed it. Control went straight to the catch and the author got a bare
+ * "PDF preview failed" carrying the raw platform message (#321).
+ *
+ * The fix routes any failure of the inline blob: path into the ContentVersion +
+ * native viewer path, which is already the route for payloads too large for Aura
+ * and is an ordinary https: navigation. This asserts that routing against three
+ * sandboxes — permissive, Locker (window.open throws) and one where
+ * createObjectURL itself is refused — so a regression that lets a sandbox
+ * failure reach the user as an error fails here rather than in a customer org.
+ *
+ * Sibling of lws-download-route-check.mjs, which covers the same class of bug on
+ * the download path.
+ */
+
+let fail = 0;
+const ok = (c, m) => {
+    console.log((c ? '  ok  ' : ' FAIL ') + m);
+    if (!c) fail++;
+};
+
+/**
+ * Mirrors the shipped handlePdfPreview, with the browser calls injected.
+ * Returns how the preview was delivered: 'tab' | 'armed' | 'contentversion' | 'error'.
+ */
+function handlePdfPreview({ small }, env) {
+    const trace = { toastedError: null, navigated: false, armedUrl: null };
+    try {
+        // previewDraftPdfData returns base64 only when the PDF fits the Aura payload.
+        const res = small ? { base64: 'JVBERi0=' } : {};
+        if (res && res.base64) {
+            let deliveredInline = false;
+            try {
+                const url = env.createObjectURL('application/pdf');
+                const win = env.windowOpen(url);
+                if (!win) {
+                    trace.armedUrl = url;
+                }
+                deliveredInline = true;
+            } catch (blobErr) {
+                const noop = blobErr && blobErr.message;
+                void noop;
+            }
+            if (deliveredInline) {
+                return { how: trace.armedUrl ? 'armed' : 'tab', trace };
+            }
+        }
+        // ContentVersion + native viewer — plain https:, portable everywhere.
+        const res2 = env.previewDraftPdf();
+        if (!res2 || !res2.contentDocumentId) {
+            throw new Error('Preview returned no PDF.');
+        }
+        trace.navigated = true;
+        return { how: 'contentversion', trace };
+    } catch (err) {
+        trace.toastedError = err.message;
+        return { how: 'error', trace };
+    }
+}
+
+const contentVersion = () => ({ contentDocumentId: '069000000000000AAA' });
+
+// A permissive browser: everything works.
+const permissive = {
+    createObjectURL: () => 'blob:https://example.lightning.force.com/abc',
+    windowOpen: () => ({}),
+    previewDraftPdf: contentVersion
+};
+
+// Locker Service: SecureWindow.open THROWS on blob:. This is #321.
+const locker = {
+    createObjectURL: () => 'blob:https://example.lightning.force.com/abc',
+    windowOpen: () => {
+        throw new Error("secure.windowopen() only acceptable types are http:, https: and mailto:");
+    },
+    previewDraftPdf: contentVersion
+};
+
+// A sandbox that refuses createObjectURL outright, as LWS does for non-allowlisted
+// MIME types (see lws-download-route-check.mjs). PDF is on that allowlist today,
+// so this is defence in depth rather than a reproduction.
+const noObjectUrl = {
+    createObjectURL: () => {
+        throw new Error("Cannot 'createObjectURL' using an unsecure [object Blob]");
+    },
+    windowOpen: () => ({}),
+    previewDraftPdf: contentVersion
+};
+
+// A browser that blocks the popup but allows blob: — must NOT be confused with a
+// sandbox refusal: the armed-button recovery is still the right answer there.
+const popupBlocked = {
+    createObjectURL: () => 'blob:https://example.lightning.force.com/abc',
+    windowOpen: () => null,
+    previewDraftPdf: contentVersion
+};
+
+console.log('\nsmall PDF — the inline blob: path');
+let r = handlePdfPreview({ small: true }, permissive);
+ok(r.how === 'tab', 'permissive browser opens the blob: URL in a tab');
+
+r = handlePdfPreview({ small: true }, popupBlocked);
+ok(r.how === 'armed', 'popup blocked arms the button rather than erroring');
+ok(r.trace.armedUrl !== null, 'and keeps the blob URL for the synchronous open');
+
+r = handlePdfPreview({ small: true }, locker);
+ok(r.how === 'contentversion', 'Locker refusing blob: falls through to the ContentVersion viewer');
+ok(r.trace.toastedError === null, 'and the author is never shown an error');
+ok(r.trace.navigated === true, 'and is actually navigated to the preview');
+
+r = handlePdfPreview({ small: true }, noObjectUrl);
+ok(r.how === 'contentversion', 'createObjectURL being refused also falls through');
+ok(r.trace.toastedError === null, 'and is likewise not surfaced as an error');
+
+console.log('\nlarge PDF — always the ContentVersion path');
+r = handlePdfPreview({ small: false }, permissive);
+ok(r.how === 'contentversion', 'a payload too large for Aura uses the viewer, as before');
+
+r = handlePdfPreview({ small: false }, locker);
+ok(r.how === 'contentversion', 'and is unaffected by the sandbox, since it never touches blob:');
+
+console.log('\na real failure must still reach the author');
+r = handlePdfPreview(
+    { small: true },
+    {
+        ...locker,
+        previewDraftPdf: () => null // server genuinely returned nothing
+    }
+);
+ok(r.how === 'error', 'if the fallback itself fails, that is a real error');
+ok(r.trace.toastedError === 'Preview returned no PDF.', 'and it is reported, not swallowed');
+
+console.log(fail ? `\n${fail} FAILED` : '\npreview routing OK');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #321.

## For @untangleportwood — how to test this

This one is **org-dependent**, so testing it needs the right org rather than the right template.

1. In an org where PDF Preview currently fails with *"secure.windowopen() only acceptable types are http:, https: and mailto:"* — a **Locker Service** org, not LWS — open a template in the designer, pick a Sample Record, and click **PDF Preview**.
2. **Before:** a red *"PDF preview failed"* toast carrying that raw platform message. No preview.
3. **After:** the PDF opens in Salesforce's native file preview instead. Slower, but it works.

Two no-regression cases worth a look in a **normal** org, where the fast path still applies:

- A small template should still open in a **new tab** immediately (the blob: route).
- With **popups blocked**, the button should still change to **"Open preview ↗"** and open on the second click — that recovery must not be confused with a sandbox refusal.

## What Dave reported

> preview in some orgs comes up as `secure.windowopen() only acceptable types are http: https: and mailto:`. Blob: doesn't seem to want to work in some orgs making preview non-accessible

## Root cause

Locker Service's `SecureWindow.open` permits only `http:`, `https:` and `mailto:`, so the `blob:` URL built for a small PDF is refused. That is why it splits by **org** and not by template — Locker orgs fail, LWS orgs pass. It is the mirror image of #320, where an LWS org blocks a browser API that Locker orgs allow.

Two things made it worse than a missing feature:

- **`SecureWindow.open` throws rather than returning `null`.** So the popup-blocked recovery directly beneath it — `_pendingPreviewUrl`, `pdfPreviewReady`, the *"click Open preview"* toast — was **unreachable in exactly the orgs that needed a recovery**. Control went straight to the outer `catch`.
- The author was then shown a bare *"PDF preview failed"* carrying the raw platform string, which names an internal step and offers no next move.

## The fix

**The answer was already twenty lines below.** The over-payload branch delivers the PDF as a ContentVersion and navigates to the native file preview — an ordinary `https:` navigation no sandbox objects to. The small-PDF path now falls through to it on *any* failure of the inline `blob:` route.

Deliberately **still an error when the fallback itself fails**: a server that returns no PDF is a real failure and is reported as before. Only the sandbox's refusal is treated as a routing decision rather than an error.

## Verification

New `scripts/qa/locker-preview-route-check.mjs`, following the convention of its sibling `lws-download-route-check.mjs` — which covers this same class of bug on the download path:

```
node scripts/qa/locker-preview-route-check.mjs
```

It runs the shipped routing against four sandboxes: permissive, Locker (`window.open` throws), one that refuses `createObjectURL` outright, and a popup-blocked browser that must still get the armed-button recovery.

**12 assertions pass. Against the pre-fix code the same assertions fail 6 of 12** — so they defend the contract, not the implementation.

Neighbouring checks unaffected: `lws-download-route` and `canvas-serializer` both pass. `npm run format:check` clean.

⚠️ **Not reproduced first-hand** — it needs a Locker Service org, which cannot be stood up as a scratch org. The mechanism is read from the platform's documented `SecureWindow.open` allow-list and the code path, and it explains both the error text and the org split. Worth confirming in the reporting org before release.

## Related

Fourth org-dependent browser-sandbox failure in this component, after `0e9158e` (Office downloads under LWS), `408d806` (`createObjectURL` refused for `text/html`) and #320. Once #320 lands, a single sweep of every `window.open` / `createObjectURL` / platform-global call in `docGenAdmin.js` is probably worth more than fixing the fifth one report-by-report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)