### PR TITLE
fix(upload): decode deflate without the browser API when it is unavailable

### DIFF
--- a/force-app/main/default/lwc/docGenAdmin/docGenZipReader.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenZipReader.js
@@ -1,12 +1,17 @@
 /**
  * Pure JavaScript ZIP reader.
  *
- * Uses the browser's native DecompressionStream for deflate — zero external
- * dependencies. Reads classic ZIPs (store + deflate) produced by Google Docs,
- * Notion, macOS, Windows, etc. Returns [{ name, data: Uint8Array }, ...].
+ * Zero external dependencies. Reads classic ZIPs (store + deflate) produced by
+ * Google Docs, Notion, macOS, Windows, etc. Returns [{ name, data: Uint8Array }, ...].
+ *
+ * Deflate is decoded by the browser's native DecompressionStream where it is
+ * available, and by the inline RFC 1951 decoder below where it is not (#320).
  */
 
-async function inflateRaw(compressed) {
+/**
+ * Native path. Fast, and what every modern browser will actually use.
+ */
+async function inflateRawNative(compressed) {
     const cs = new DecompressionStream('deflate-raw');
     const writer = cs.writable.getWriter();
     writer.write(compressed);
@@ -29,6 +34,245 @@ async function inflateRaw(compressed) {
         offset += chunk.length;
     }
     return out;
+}
+
+// --- Inline DEFLATE (RFC 1951) ------------------------------------------------
+//
+// `new DecompressionStream('deflate-raw')` is a browser API, and browser APIs are
+// not uniformly available to managed-package code: uploading a zip template
+// failed with a decompress error in SOME orgs and not others (#320). A zip whose
+// only member is an HTML file is deflated, so there was nothing to fall back on
+// and the upload dead-ended.
+//
+// This is the classic canonical-Huffman decoder (the algorithm zlib's `puff`
+// reference implementation uses), kept deliberately small and allocation-light.
+// It is only reached when the native API is missing or refuses, so it never
+// costs a modern browser anything.
+
+const LENGTH_BASE = [
+    3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258
+];
+const LENGTH_EXTRA = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0];
+const DIST_BASE = [
+    1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193, 257, 385, 513, 769, 1025, 1537, 2049, 3073, 4097, 6145,
+    8193, 12289, 16385, 24577
+];
+const DIST_EXTRA = [0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13];
+const CODE_LENGTH_ORDER = [16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15];
+const MAX_BITS = 15;
+
+/** Canonical Huffman table: symbol counts per code length, plus symbols in code order. */
+function buildHuffman(lengths) {
+    const count = new Array(MAX_BITS + 1).fill(0);
+    for (const len of lengths) {
+        if (len) {
+            count[len]++;
+        }
+    }
+    const offsets = new Array(MAX_BITS + 2).fill(0);
+    for (let len = 1; len <= MAX_BITS; len++) {
+        offsets[len + 1] = offsets[len] + count[len];
+    }
+    const symbols = new Array(lengths.length).fill(0);
+    for (let sym = 0; sym < lengths.length; sym++) {
+        if (lengths[sym]) {
+            symbols[offsets[lengths[sym]]++] = sym;
+        }
+    }
+    return { count, symbols };
+}
+
+function inflateRawJs(compressed) {
+    const src = compressed;
+    let pos = 0;
+    let bitBuf = 0;
+    let bitCount = 0;
+
+    const bits = (need) => {
+        let val = bitBuf;
+        while (bitCount < need) {
+            if (pos >= src.length) {
+                throw new Error('Truncated deflate stream.');
+            }
+            val |= src[pos++] << bitCount;
+            bitCount += 8;
+        }
+        bitBuf = val >>> need;
+        bitCount -= need;
+        return val & ((1 << need) - 1);
+    };
+
+    const decodeSymbol = (table) => {
+        let code = 0;
+        let first = 0;
+        let index = 0;
+        for (let len = 1; len <= MAX_BITS; len++) {
+            code |= bits(1);
+            const n = table.count[len];
+            if (code - first < n) {
+                return table.symbols[index + (code - first)];
+            }
+            index += n;
+            first = (first + n) << 1;
+            code <<= 1;
+        }
+        throw new Error('Invalid Huffman code in deflate stream.');
+    };
+
+    let out = new Uint8Array(Math.max(1024, src.length * 4));
+    let outLen = 0;
+    const push = (byte) => {
+        if (outLen === out.length) {
+            const grown = new Uint8Array(out.length * 2);
+            grown.set(out);
+            out = grown;
+        }
+        out[outLen++] = byte;
+    };
+
+    let fixedLit = null;
+    let fixedDist = null;
+    const fixedTables = () => {
+        if (!fixedLit) {
+            const litLengths = new Array(288);
+            for (let i = 0; i < 288; i++) {
+                litLengths[i] = i < 144 ? 8 : i < 256 ? 9 : i < 280 ? 7 : 8;
+            }
+            fixedLit = buildHuffman(litLengths);
+            fixedDist = buildHuffman(new Array(30).fill(5));
+        }
+        return [fixedLit, fixedDist];
+    };
+
+    for (;;) {
+        const isFinal = bits(1);
+        const type = bits(2);
+
+        if (type === 0) {
+            // Stored: discard the partial byte, then LEN/NLEN and raw bytes.
+            bitBuf = 0;
+            bitCount = 0;
+            if (pos + 4 > src.length) {
+                throw new Error('Truncated stored block in deflate stream.');
+            }
+            const len = src[pos] | (src[pos + 1] << 8);
+            pos += 4; // LEN then its one's complement, which we do not need to verify
+            if (pos + len > src.length) {
+                throw new Error('Truncated stored block in deflate stream.');
+            }
+            for (let i = 0; i < len; i++) {
+                push(src[pos++]);
+            }
+        } else if (type === 1 || type === 2) {
+            let litTable;
+            let distTable;
+            if (type === 1) {
+                [litTable, distTable] = fixedTables();
+            } else {
+                const hlit = bits(5) + 257;
+                const hdist = bits(5) + 1;
+                const hclen = bits(4) + 4;
+                const clLengths = new Array(19).fill(0);
+                for (let i = 0; i < hclen; i++) {
+                    clLengths[CODE_LENGTH_ORDER[i]] = bits(3);
+                }
+                const clTable = buildHuffman(clLengths);
+                const lengths = new Array(hlit + hdist).fill(0);
+                let i = 0;
+                while (i < lengths.length) {
+                    const sym = decodeSymbol(clTable);
+                    if (sym < 16) {
+                        lengths[i++] = sym;
+                    } else if (sym === 16) {
+                        if (i === 0) {
+                            throw new Error('Invalid code-length repeat in deflate stream.');
+                        }
+                        const prev = lengths[i - 1];
+                        let repeat = 3 + bits(2);
+                        while (repeat-- > 0 && i < lengths.length) {
+                            lengths[i++] = prev;
+                        }
+                    } else if (sym === 17) {
+                        let repeat = 3 + bits(3);
+                        while (repeat-- > 0 && i < lengths.length) {
+                            lengths[i++] = 0;
+                        }
+                    } else {
+                        let repeat = 11 + bits(7);
+                        while (repeat-- > 0 && i < lengths.length) {
+                            lengths[i++] = 0;
+                        }
+                    }
+                }
+                litTable = buildHuffman(lengths.slice(0, hlit));
+                distTable = buildHuffman(lengths.slice(hlit));
+            }
+
+            for (;;) {
+                const sym = decodeSymbol(litTable);
+                if (sym < 256) {
+                    push(sym);
+                } else if (sym === 256) {
+                    break;
+                } else {
+                    const li = sym - 257;
+                    if (li >= LENGTH_BASE.length) {
+                        throw new Error('Invalid length symbol in deflate stream.');
+                    }
+                    const length = LENGTH_BASE[li] + bits(LENGTH_EXTRA[li]);
+                    const di = decodeSymbol(distTable);
+                    if (di >= DIST_BASE.length) {
+                        throw new Error('Invalid distance symbol in deflate stream.');
+                    }
+                    const distance = DIST_BASE[di] + bits(DIST_EXTRA[di]);
+                    if (distance > outLen) {
+                        throw new Error('Distance beyond output start in deflate stream.');
+                    }
+                    let from = outLen - distance;
+                    for (let i = 0; i < length; i++) {
+                        push(out[from++]);
+                    }
+                }
+            }
+        } else {
+            throw new Error('Reserved deflate block type.');
+        }
+
+        if (isFinal) {
+            break;
+        }
+    }
+    return out.subarray(0, outLen);
+}
+
+/** Cached because the answer cannot change within a page. */
+let nativeInflateAvailable = null;
+function hasNativeInflate() {
+    if (nativeInflateAvailable === null) {
+        try {
+            // Constructing it is the only reliable probe: the constructor may
+            // exist but reject 'deflate-raw', and under a sandbox the global may
+            // not be exposed at all (a ReferenceError, which this also catches).
+            const probe = new DecompressionStream('deflate-raw');
+            nativeInflateAvailable = Boolean(probe);
+        } catch (e) {
+            nativeInflateAvailable = false;
+        }
+    }
+    return nativeInflateAvailable;
+}
+
+async function inflateRaw(compressed) {
+    if (hasNativeInflate()) {
+        try {
+            return await inflateRawNative(compressed);
+        } catch (e) {
+            // The probe passed but the stream still failed. Rather than fail the
+            // upload, fall through — the inline decoder needs no platform support.
+            nativeInflateAvailable = false;
+        }
+    }
+    return inflateRawJs(compressed);
 }
 
 function u16(bytes, offset) {

--- a/scripts/qa/zip-inflate-fallback-check.mjs
+++ b/scripts/qa/zip-inflate-fallback-check.mjs
@@ -1,0 +1,187 @@
+/**
+ * docGenZipReader — the inline DEFLATE fallback.
+ *
+ *   node scripts/qa/zip-inflate-fallback-check.mjs
+ *
+ * `new DecompressionStream('deflate-raw')` is a browser API, and browser APIs are
+ * not uniformly available to managed-package code: uploading a zip template
+ * failed with a decompress error in SOME orgs and not others (#320). A zip whose
+ * only member is an HTML file is deflated, so there was nothing to fall back on
+ * and the upload dead-ended.
+ *
+ * The fix feature-detects the native API and falls back to an inline RFC 1951
+ * decoder. This asserts that decoder byte-for-byte against the platform's own,
+ * across the block types and payload shapes a real template zip produces —
+ * because a decompressor that is subtly wrong is far worse than one that is
+ * missing: it would hand the merge engine corrupted HTML.
+ *
+ * Sibling of lws-download-route-check.mjs and locker-preview-route-check.mjs,
+ * which cover the same class of org-dependent sandbox failure elsewhere.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { deflateRawSync, inflateRawSync } from 'node:zlib';
+
+let fail = 0;
+const ok = (c, m) => {
+    console.log((c ? '  ok  ' : ' FAIL ') + m);
+    if (!c) fail++;
+};
+
+// Load the shipped reader as a module. It is an LWC file, so copy it out first.
+const src = readFileSync(
+    new URL('../../force-app/main/default/lwc/docGenAdmin/docGenZipReader.js', import.meta.url),
+    'utf8'
+);
+// Expose the internals this check needs without changing the component's API.
+const probe = src + '\nexport const __test = { inflateRawJs, hasNativeInflate, inflateRaw };\n';
+const tmp = '/tmp/docGenZipReader.check.' + Date.now() + '.mjs';
+writeFileSync(tmp, probe, 'utf8');
+const mod = await import(tmp);
+const { inflateRawJs } = mod.__test;
+
+const enc = new TextEncoder();
+const eq = (a, b) => a.length === b.length && a.every((v, i) => v === b[i]);
+
+// --- payload shapes a real template zip actually contains ---------------------
+const cases = [];
+
+cases.push(['empty payload', new Uint8Array(0)]);
+cases.push(['one byte', enc.encode('x')]);
+cases.push(['short ascii', enc.encode('<html><body>{Name}</body></html>')]);
+
+// Highly compressible: long runs exercise LZ77 back-references heavily.
+cases.push(['long repeated run', enc.encode('A'.repeat(70000))]);
+
+// A realistic template body — dynamic Huffman, mixed literals and matches.
+const tpl =
+    '<!DOCTYPE html><html><head><style>@page{size:Letter}body{font-family:Arial}' +
+    'table{border-collapse:collapse;width:100%}td{border:1px solid #ccc;padding:4pt}</style></head><body>' +
+    '<table>' +
+    '<tr><td>{Name}</td><td>{Amount__c}</td></tr>'.repeat(2000) +
+    '</table></body></html>';
+cases.push(['realistic html template', enc.encode(tpl)]);
+
+// Incompressible: deflate emits STORED blocks for this, which is a separate branch.
+const random = new Uint8Array(50000);
+let seed = 12345;
+for (let i = 0; i < random.length; i++) {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    random[i] = seed & 0xff;
+}
+cases.push(['incompressible bytes (stored blocks)', random]);
+
+// Large enough to span multiple deflate blocks.
+cases.push(['multi-block payload', enc.encode(tpl.repeat(3))]);
+
+// Non-ASCII, so a byte-level bug shows up as mojibake rather than silence.
+cases.push(['utf-8 multibyte', enc.encode('Grüße — 日本語 — {Client__r.Naïve} — €1 234,56'.repeat(500))]);
+
+console.log('\ninline decoder vs the platform decoder, byte for byte');
+for (const [name, original] of cases) {
+    const compressed = new Uint8Array(deflateRawSync(Buffer.from(original)));
+    let mine;
+    try {
+        mine = inflateRawJs(compressed);
+    } catch (e) {
+        ok(false, `${name} — threw: ${e.message}`);
+        continue;
+    }
+    const theirs = new Uint8Array(inflateRawSync(Buffer.from(compressed)));
+    ok(eq(mine, original), `${name} (${original.length}B) round-trips to the original`);
+    ok(eq(mine, theirs), `${name} matches the platform decoder exactly`);
+}
+
+console.log('\ncompression levels — each picks different block types');
+for (const level of [0, 1, 6, 9]) {
+    const original = enc.encode(tpl);
+    const compressed = new Uint8Array(deflateRawSync(Buffer.from(original), { level }));
+    let mine;
+    try {
+        mine = inflateRawJs(compressed);
+        ok(eq(mine, original), `level ${level} decodes correctly (${compressed.length}B compressed)`);
+    } catch (e) {
+        ok(false, `level ${level} threw: ${e.message}`);
+    }
+}
+
+console.log('\nreal .docx parts — what an Office template upload actually carries');
+try {
+    const docx = readFileSync(
+        new URL('../../docs/appexchange/Portwood_DocGen_Solution_Architecture_and_Usage_Guide.docx', import.meta.url)
+    );
+    const entries = await mod.readZip(new Uint8Array(docx));
+    ok(entries.length > 0, `readZip returned ${entries.length} entries end to end`);
+    const doc = entries.find((e) => e.name === 'word/document.xml');
+    ok(Boolean(doc), 'word/document.xml is present');
+    const text = new TextDecoder().decode(doc.data);
+    ok(text.startsWith('<?xml'), 'and decodes to well-formed XML');
+    ok(text.includes('</w:document>'), 'with its closing tag intact (nothing truncated)');
+} catch (e) {
+    ok(false, 'end-to-end readZip on a real .docx: ' + e.message);
+}
+
+console.log('\nthe actual #320 scenario — the sandbox refuses DecompressionStream');
+// Everything above proves the decoder is correct. This proves the ROUTING: with
+// the native API unavailable, a real .docx must still read, via the same public
+// entry point the upload handler calls.
+{
+    const savedCtor = globalThis.DecompressionStream;
+    let nativeCallsAttempted = 0;
+    globalThis.DecompressionStream = function () {
+        nativeCallsAttempted++;
+        throw new Error("Cannot construct 'DecompressionStream': blocked by the browser sandbox");
+    };
+    try {
+        // Fresh module instance so the cached feature-detect re-runs.
+        const tmp2 = '/tmp/docGenZipReader.blocked.' + Date.now() + '.mjs';
+        writeFileSync(tmp2, probe, 'utf8');
+        const blocked = await import(tmp2);
+        ok(blocked.__test.hasNativeInflate() === false, 'the feature detect reports the API unavailable');
+
+        const docx = readFileSync(
+            new URL('../../docs/appexchange/Portwood_DocGen_Solution_Architecture_and_Usage_Guide.docx', import.meta.url)
+        );
+        const entries = await blocked.readZip(new Uint8Array(docx));
+        ok(entries.length > 0, `readZip still returns ${entries.length} entries with no native API`);
+        const doc = entries.find((e) => e.name === 'word/document.xml');
+        const text = new TextDecoder().decode(doc.data);
+        ok(text.startsWith('<?xml') && text.includes('</w:document>'), 'and document.xml is intact');
+        ok(nativeCallsAttempted > 0, 'the native path was genuinely attempted and refused');
+
+        // An image-less zip — the shape Dave reported, where there is nothing
+        // stored to fall back on because the single HTML member is deflated.
+        const htmlOnly = new Uint8Array(
+            execSync('cd /tmp && rm -rf dgz && mkdir dgz && printf %s ' + JSON.stringify(tpl.slice(0, 4000)) +
+                ' > dgz/template.html && cd dgz && zip -q -X - template.html', { maxBuffer: 1 << 26, encoding: 'buffer' })
+        );
+        const htmlEntries = await blocked.readZip(htmlOnly);
+        ok(htmlEntries.length === 1 && htmlEntries[0].name === 'template.html', 'an image-less zip reads too');
+        ok(
+            new TextDecoder().decode(htmlEntries[0].data) === tpl.slice(0, 4000),
+            'and its HTML comes back byte-identical'
+        );
+    } finally {
+        globalThis.DecompressionStream = savedCtor;
+    }
+}
+
+console.log('\ncorrupt input must throw, never return silent garbage');
+const bad = [
+    ['truncated stream', new Uint8Array(deflateRawSync(Buffer.from(enc.encode(tpl)))).subarray(0, 40)],
+    ['reserved block type', Uint8Array.from([0x07, 0x00, 0x00, 0x00])],
+    ['empty input', new Uint8Array(0)]
+];
+for (const [name, bytes] of bad) {
+    let threw = false;
+    try {
+        inflateRawJs(bytes);
+    } catch (e) {
+        threw = true;
+    }
+    ok(threw, `${name} throws rather than returning partial output`);
+}
+
+console.log(fail ? `\n${fail} FAILED` : '\ninflate fallback OK');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #320.

## For @untangleportwood — how to test this

Like #321, this is **org-dependent**, not file-dependent.

1. In an org where zip template upload currently fails with a **decompress error**, upload a `.zip` containing an HTML template — with and without an `images/` folder.
2. **Before:** *"Upload Failed"* carrying the raw platform message. Nothing uploads.
3. **After:** it uploads and the template body is intact.

No-regression cases in a **normal** org, where the native path still runs:

- A zip **with** an `images/` folder — images should still extract and the `<img src>` rewrite should still happen.
- A **`.docx`** template upload, which goes through the same reader.
- Anything you can compare before/after: the decoded bytes should be identical, not merely "it worked".

## The archive format was never the cause

`readZip` was run in Node against every realistic shape:

| Archive | Result |
|---|---|
| `template.html` + `images/logo.png`, deflated | OK |
| `template.html` only, no image folder | OK |
| `template.html` only, `ZIP_STORED` | OK |
| macOS folder entry + `__MACOSX` sidecar | OK |
| real `ditto -c -k --sequesterRsrc`, with and without images | OK |
| real `zip -r` CLI, with and without images | OK |

All seven parsed correctly. **"Some orgs" was the clue** — same bytes, different result, means environment.

## Root cause

`docGenZipReader` constructed `new DecompressionStream('deflate-raw')` with **no feature detection and no fallback**. That is a browser API, and browser APIs are not uniformly available to managed-package code. This component has already been bitten twice — `0e9158e` (Office downloads failed in LWS orgs) and `408d806` (LWS blocks `createObjectURL` for `text/html`) — and #321 is the same class again from the *other* sandbox.

A zip whose only member is an HTML file is deflated, so there was nothing stored to fall back on and the upload dead-ended.

## The fix

An inline **RFC 1951** decoder — the canonical-Huffman algorithm from zlib's `puff` reference implementation, kept small and allocation-light — behind a cached feature detect. The native path still runs wherever it works, so a modern browser pays nothing. The fallback is reached only when the API is missing, refuses `deflate-raw`, or throws mid-stream. **Zero dependencies**, so the 100%-native property is intact.

## Verification

A *wrong* decompressor is far worse than a missing one — it would hand the merge engine corrupted HTML. So the check asserts **byte-for-byte equality against the platform's own decoder**, not merely that it ran:

```
node scripts/qa/zip-inflate-fallback-check.mjs
```

**33 assertions, all passing:**

- **8 payload shapes**, each compared to `node:zlib` output *and* to the original — empty, one byte, short ascii, a 70,000-byte repeated run (heavy LZ77 back-references), an 88 KB realistic HTML template, 50,000 incompressible bytes (which forces **STORED** blocks, a separate branch), a 264 KB multi-block payload, and UTF-8 multibyte where a byte-level bug surfaces as mojibake rather than silence.
- **Compression levels 0, 1, 6, 9** — each selects different block types.
- **End-to-end `readZip` on a real `.docx`**: 18 entries, `document.xml` well-formed with its closing tag intact.
- **The reported scenario**: with `DecompressionStream` stubbed to throw, a real `.docx` still reads and an image-less single-HTML zip comes back byte-identical — plus an assertion that the native path was *genuinely attempted and refused*, so the test cannot pass by accident.
- **Corrupt input** (truncated, reserved block type, empty) throws rather than returning partial output.

Against `main`, that same blocked-sandbox scenario fails with `blocked by the browser sandbox` — which is the bug.

`npm run format:check` clean.

⚠️ **Not reproduced first-hand** — it needs the affected org, and CLAUDE.md records that this class of bug is invisible in dev and scratch orgs. The archive-format hypothesis **is** ruled out by the table above, and the fallback removes the platform dependency whichever sandbox was responsible.

## Related

With this and #321, that is four org-dependent sandbox failures in this component. A single sweep of every `window.open` / `createObjectURL` / platform-global call in `docGenAdmin.js` is probably worth more than fixing the fifth one report-by-report. Also fixes the likely cause of #329, if that PDF path bottoms out in the same helper — worth checking once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)