### PR TITLE
fix(designer): name BOTH Type picklists when an upgrade skipped a value

### DIFF
--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -34,6 +34,25 @@
                                         ></lightning-icon>
                                         {missingTypeValuesMessage}
                                     </p>
+                                    <p class="slds-text-body_small slds-var-m-top_x-small">
+                                        <template for:each={missingTypeFieldLinks} for:item="lnk">
+                                            <a
+                                                key={lnk.objectApiName}
+                                                href={lnk.url}
+                                                target="_blank"
+                                                rel="noopener"
+                                                class="slds-var-m-right_medium"
+                                                >Open {lnk.label} in Setup</a
+                                            >
+                                        </template>
+                                        <lightning-button
+                                            variant="brand"
+                                            label="Re-check"
+                                            title="Check the picklists again after adding the values"
+                                            onclick={handleRecheckTypeValues}
+                                            class="slds-var-m-left_x-small"
+                                        ></lightning-button>
+                                    </p>
                                 </div>
                             </template>
                             <!-- HTML-first authoring path picker -->

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -98,6 +98,9 @@ import DOCGEN_TEMPLATE_OBJECT from '@salesforce/schema/DocGen_Template__c';
 import NAME_FIELD from '@salesforce/schema/DocGen_Template__c.Name';
 import CATEGORY_FIELD from '@salesforce/schema/DocGen_Template__c.Category__c';
 import TYPE_FIELD from '@salesforce/schema/DocGen_Template__c.Type__c';
+// The version object carries its OWN restricted Type picklist — see #303.
+import DOCGEN_VERSION_OBJECT from '@salesforce/schema/DocGen_Template_Version__c';
+import VERSION_TYPE_FIELD from '@salesforce/schema/DocGen_Template_Version__c.Type__c';
 import BASE_OBJECT_FIELD from '@salesforce/schema/DocGen_Template__c.Base_Object_API__c';
 import QUERY_CONFIG_FIELD from '@salesforce/schema/DocGen_Template__c.Query_Config__c';
 import DESC_FIELD from '@salesforce/schema/DocGen_Template__c.Description__c';
@@ -4497,6 +4500,34 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     _typePicklist;
     @track _orgTypeValues = null;
 
+    // The SECOND restricted Type picklist (#303).
+    //
+    // Saving a template writes Type__c on DocGen_Template__c AND on the version
+    // record, and BOTH fields are restricted picklists carrying the same value
+    // set. The check above only ever read the template's, so the warning named
+    // one object — and an admin who followed it exactly still could not save:
+    //
+    //   "I added the 'Canvas' type manually which got me over the initial error
+    //    message ... the save failed ... Type: bad value for restricted
+    //    picklist field: Canvas"
+    //
+    // They fixed the field the message named and hit the one it did not.
+    @wire(getObjectInfo, { objectApiName: DOCGEN_VERSION_OBJECT })
+    versionObjectInfo;
+
+    @wire(getPicklistValues, {
+        recordTypeId: '$versionObjectInfo.data.defaultRecordTypeId',
+        fieldApiName: VERSION_TYPE_FIELD
+    })
+    wiredVersionTypePicklist(result) {
+        this._versionTypePicklist = result;
+        if (result && result.data && Array.isArray(result.data.values)) {
+            this._orgVersionTypeValues = result.data.values.map((v) => v.value);
+        }
+    }
+    _versionTypePicklist;
+    @track _orgVersionTypeValues = null;
+
     get typeOptions() {
         const fallback = Object.keys(TYPE_VALUE_HISTORY);
         // Until the wire resolves (and if it errors) keep the historical hardcoded
@@ -4520,18 +4551,101 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         return Object.keys(TYPE_VALUE_HISTORY).filter((v) => !this._orgTypeValues.includes(v));
     }
 
-    get hasMissingTypeValues() {
-        return this.missingTypeValues.length > 0;
+    /** Values missing from the VERSION object's Type picklist (#303). */
+    get missingVersionTypeValues() {
+        if (!this._orgVersionTypeValues || !this._orgVersionTypeValues.length) {
+            return [];
+        }
+        return Object.keys(TYPE_VALUE_HISTORY).filter((v) => !this._orgVersionTypeValues.includes(v));
     }
 
+    get hasMissingTypeValues() {
+        return this.missingTypeValues.length > 0 || this.missingVersionTypeValues.length > 0;
+    }
+
+    /**
+     * Names EVERY field that needs the value, not just the first one (#303).
+     *
+     * The old message named only "Portwood Template > Type". Saving also writes
+     * the version record's own restricted Type picklist, so an admin who did
+     * exactly what the message said still hit
+     * "Type: bad value for restricted picklist field: Canvas" on save.
+     */
     get missingTypeValuesMessage() {
-        const missing = this.missingTypeValues.map((v) => `${v} (added in v${TYPE_VALUE_HISTORY[v]})`).join(', ');
+        const describe = (v) => `${v} (added in v${TYPE_VALUE_HISTORY[v]})`;
+        const onTemplate = this.missingTypeValues;
+        const onVersion = this.missingVersionTypeValues;
+        const all = Array.from(new Set([...onTemplate, ...onVersion]));
+
+        const fields = [];
+        if (onTemplate.length) {
+            fields.push('Portwood Template > Type');
+        }
+        if (onVersion.length) {
+            fields.push('Portwood Template Version > Type');
+        }
+
         return (
-            `This org's Template Type picklist is missing: ${missing}. ` +
-            'That means the package upgrade did not fully apply its schema. ' +
-            'Re-run the package upgrade, or add the missing values to the ' +
-            'Portwood Template > Type field in Setup. Until then those template types cannot be created.'
+            `This org's Type picklist is missing: ${all.map(describe).join(', ')}. ` +
+            'That means the package upgrade did not fully apply its schema — a restricted ' +
+            'picklist value never reaches an org that was already installed before that value ' +
+            'existed, and no later upgrade brings it. ' +
+            `Add the missing values to ${fields.join(' AND ')} in Setup — ` +
+            (fields.length > 1
+                ? 'BOTH fields are needed, because saving writes the type to the template and to its version. '
+                : '') +
+            'Until then those template types cannot be created.'
         );
+    }
+
+    /**
+     * Direct Setup links for every field that is short a value (#303).
+     *
+     * Apex cannot add a picklist value — the Apex Metadata API exposes only
+     * CustomMetadata and Layout, not CustomField/ValueSet — so this is an admin
+     * task by necessity. The least we can do is take them to the exact field
+     * rather than describing where it lives. Object API names come from the wire,
+     * so these carry the package namespace in a subscriber org.
+     */
+    get missingTypeFieldLinks() {
+        const links = [];
+        const base = '/lightning/setup/ObjectManager/';
+        const tmplApi = this.templateObjectInfo && this.templateObjectInfo.data && this.templateObjectInfo.data.apiName;
+        const versApi = this.versionObjectInfo && this.versionObjectInfo.data && this.versionObjectInfo.data.apiName;
+        if (this.missingTypeValues.length && tmplApi) {
+            links.push({
+                objectApiName: tmplApi,
+                label: 'Portwood Template > Type',
+                url: base + tmplApi + '/FieldsAndRelationships/view'
+            });
+        }
+        if (this.missingVersionTypeValues.length && versApi) {
+            links.push({
+                objectApiName: versApi,
+                label: 'Portwood Template Version > Type',
+                url: base + versApi + '/FieldsAndRelationships/view'
+            });
+        }
+        return links;
+    }
+
+    /** Re-read both picklists after the admin has added the values. */
+    handleRecheckTypeValues() {
+        Promise.all([refreshApex(this._typePicklist), this._refreshVersionTypePicklist()])
+            .then(() => {
+                if (this.hasMissingTypeValues) {
+                    this.showToast('Still missing', this.missingTypeValuesMessage, 'warning');
+                } else {
+                    this.showToast('Schema is complete', 'Every template type is available now.', 'success');
+                }
+            })
+            .catch(() => {
+                this.showToast('Could not re-check', 'Reload the page to check again.', 'warning');
+            });
+    }
+
+    _refreshVersionTypePicklist() {
+        return this._versionTypePicklist ? refreshApex(this._versionTypePicklist) : Promise.resolve();
     }
 
     get outputFormatOptions() {

--- a/scripts/qa/missing-picklist-guidance-check.mjs
+++ b/scripts/qa/missing-picklist-guidance-check.mjs
@@ -1,0 +1,114 @@
+/**
+ * Designer — the missing-Type-picklist warning names EVERY field that needs a value.
+ *
+ *   node scripts/qa/missing-picklist-guidance-check.mjs
+ *
+ * Issue #303. imax-vaughn upgraded to v3.56, found the `Canvas` type absent,
+ * followed the warning exactly — "add the missing values to the Portwood
+ * Template > Type field in Setup" — and STILL could not save:
+ *
+ *   "Type: bad value for restricted picklist field: Canvas"
+ *
+ * Saving writes Type__c on DocGen_Template__c AND on DocGen_Template_Version__c.
+ * Both are restricted picklists carrying the same value set, verified against a
+ * fresh org:
+ *
+ *   DocGen_Template__c.Type__c         restricted=true  (Word … Canvas)
+ *   DocGen_Template_Version__c.Type__c restricted=true  (Word … Canvas)
+ *
+ * The warning only ever read the first one, so an admin could do exactly what it
+ * said and hit the field it did not mention. Dave measured the propagation rule
+ * in ca57070: a restricted picklist value never reaches an org installed before
+ * that value existed, and no later upgrade brings it — so either field can be
+ * short, independently, depending on when that org was installed.
+ *
+ * This asserts the guidance, which is the whole fix: Apex cannot add a picklist
+ * value (the Apex Metadata API exposes only CustomMetadata and Layout), so
+ * telling the admin precisely what to do is all the product can do.
+ */
+
+let fail = 0;
+const ok = (c, m) => {
+    console.log((c ? '  ok  ' : ' FAIL ') + m);
+    if (!c) fail++;
+};
+
+const TYPE_VALUE_HISTORY = { HTML: '1.66.0', Excel: '2.30.0', PDF: '3.03.0', Canvas: '3.54.0' };
+
+/** Mirrors the docGenAdmin getters. */
+function guidance(orgTemplateValues, orgVersionValues) {
+    const missingOn = (vals) =>
+        !vals || !vals.length ? [] : Object.keys(TYPE_VALUE_HISTORY).filter((v) => !vals.includes(v));
+    const onTemplate = missingOn(orgTemplateValues);
+    const onVersion = missingOn(orgVersionValues);
+    const has = onTemplate.length > 0 || onVersion.length > 0;
+    const all = Array.from(new Set([...onTemplate, ...onVersion]));
+    const fields = [];
+    if (onTemplate.length) fields.push('Portwood Template > Type');
+    if (onVersion.length) fields.push('Portwood Template Version > Type');
+    const message =
+        `This org's Type picklist is missing: ${all.map((v) => `${v} (added in v${TYPE_VALUE_HISTORY[v]})`).join(', ')}. ` +
+        'That means the package upgrade did not fully apply its schema — a restricted ' +
+        'picklist value never reaches an org that was already installed before that value ' +
+        'existed, and no later upgrade brings it. ' +
+        `Add the missing values to ${fields.join(' AND ')} in Setup — ` +
+        (fields.length > 1
+            ? 'BOTH fields are needed, because saving writes the type to the template and to its version. '
+            : '') +
+        'Until then those template types cannot be created.';
+    return { has, message, fields };
+}
+
+const FULL = ['Word', 'PowerPoint', 'Excel', 'HTML', 'PDF', 'Canvas'];
+const NO_CANVAS = ['Word', 'PowerPoint', 'Excel', 'HTML', 'PDF'];
+
+console.log('\nthe reported case: Canvas missing from BOTH picklists');
+{
+    const g = guidance(NO_CANVAS, NO_CANVAS);
+    ok(g.has, 'the warning fires');
+    ok(g.fields.length === 2, 'and names both fields');
+    ok(g.message.includes('Portwood Template > Type'), 'names the template field');
+    ok(g.message.includes('Portwood Template Version > Type'), 'names the version field');
+    ok(g.message.includes('BOTH fields are needed'), 'and says explicitly that both are needed');
+    ok(g.message.includes('Canvas (added in v3.54.0)'), 'and names the value with the version that introduced it');
+}
+
+console.log('\nthe reported case, halfway fixed — this is where imax-vaughn got stuck');
+{
+    // They added Canvas to the template object, as the old message told them to.
+    const g = guidance(FULL, NO_CANVAS);
+    ok(g.has, 'the warning STILL fires after fixing only the template field');
+    ok(g.fields.length === 1, 'and now names exactly one remaining field');
+    ok(g.message.includes('Portwood Template Version > Type'), 'the version field — the one the old message never mentioned');
+    ok(!g.message.includes('Portwood Template > Type in Setup'), 'and no longer points at the field already fixed');
+}
+
+console.log('\nthe reverse asymmetry is handled too');
+{
+    const g = guidance(NO_CANVAS, FULL);
+    ok(g.has, 'warns when only the template field is short');
+    ok(g.fields.length === 1 && g.fields[0] === 'Portwood Template > Type', 'and names just that one');
+}
+
+console.log('\na fully upgraded org stays quiet');
+{
+    const g = guidance(FULL, FULL);
+    ok(!g.has, 'no warning when both picklists are complete');
+}
+
+console.log('\nolder gaps still reported, and de-duplicated across the two fields');
+{
+    const g = guidance(['Word', 'PowerPoint', 'Excel'], ['Word', 'PowerPoint', 'Excel', 'HTML']);
+    ok(g.message.includes('PDF (added in v3.03.0)'), 'PDF is reported');
+    ok(g.message.includes('HTML (added in v1.66.0)'), 'HTML is reported');
+    ok((g.message.match(/PDF \(added/g) || []).length === 1, 'and each value is listed once, not once per field');
+}
+
+console.log('\nwires not resolved yet must not raise a false alarm');
+{
+    ok(!guidance(null, null).has, 'null picklists (still loading) are silent');
+    ok(!guidance([], []).has, 'empty picklists are silent');
+}
+
+console.log(fail ? `\n${fail} FAILED` : '\npicklist guidance OK');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #303.

## For @untangleportwood — how to test this

Needs an org **upgraded from v3.53 or earlier** (a fresh install has every value and won't show this).

1. Open the designer. If a Type value is missing you get the warning.
2. **Before:** it named only *"Portwood Template > Type"*. Fix that field, and creating a Canvas template works — but **saving still fails** with `Type: bad value for restricted picklist field: Canvas`, with nothing telling you why.
3. **After:** the warning names **both** fields, says explicitly that both are needed, gives a direct Setup link to each, and a **Re-check** button that re-reads them and confirms.
4. Add the value to **one** field and hit Re-check — the warning should persist and now name only the remaining field.
5. Add it to both — Re-check should report *"Schema is complete"*.

To simulate without an old org: remove `Canvas` from either `Type` picklist in a scratch org and reload.

## What imax-vaughn hit

> the "Canvas" type on the Portwood Template object did not exist, so I **added the "Canvas" type manually** which got me over the initial error message … I created a canvas template, made a trivial edit then attempted to save. **The save failed** … `Type: bad value for restricted picklist field: Canvas`

They did exactly what the warning said and still couldn't save.

## Root cause

**There are two restricted Type picklists, and saving writes both.** Verified against a fresh org:

```
DocGen_Template__c.Type__c          restricted=true  (Word … Canvas)
DocGen_Template_Version__c.Type__c  restricted=true  (Word … Canvas)
```

The warning read only the first and named only the first. Fixing that field cleared the *create*-time error and left the *save*-time one, with nothing pointing at the field still short.

Dave's measurement in `ca57070` is what makes this reachable: a restricted picklist value **never** reaches an org installed before that value existed, and no later upgrade brings it. So either field can be short **independently**, depending on when that org was installed.

## The fix

Reads both picklists, reports the union of what's missing, names every field that needs the value, and says explicitly that both are needed and why. Adds a **direct Setup link per affected field** — object API names come from the wire, so they carry the package namespace in a subscriber org — and a **Re-check** button that re-reads both rather than leaving the admin to reload and guess.

## Why this is guidance and not a repair button

**Apex cannot add a picklist value.** Measured, not assumed:

```
Metadata.CustomField              : null
Metadata.ValueSet                 : null
Metadata.CustomValue              : null
Metadata.CustomMetadata           : Metadata.CustomMetadata
Metadata.Layout                   : Metadata.Layout
```

The Apex Metadata API covers **custom metadata records and page layouts only** — which also rules out doing it from the post-install script, same API.

I had proposed exactly that repair button in #324, citing `DocGenButtonAdminController` as precedent without noticing it deploys a *different metadata type*. **#324 is corrected and retitled** so nobody starts on a dead end. The remaining route is the Tooling API over HTTP, which is a callout and therefore a policy decision rather than something to slip in.

## Verification

```
node scripts/qa/missing-picklist-guidance-check.mjs
```

**17 assertions**, including the **halfway-fixed state imax-vaughn was actually stuck in** — template field fixed, version field still short — where the warning must persist and name only what remains. Also the reverse asymmetry, de-duplication across the two fields, and staying silent while the wires are still resolving.

Deployed to `docgen-verify`. `lwc-template-refs` unchanged at the pre-existing 19 (identical on `main`). `npm run format:check` clean.

## Not covered

Whether making `Type__c` **unrestricted** would let an upgraded org write the value without it being present. Field *attribute* changes propagate where new *values* do not, so it may be the real cure — but it needs a genuine v3.53 → current upgrade to confirm, and I'm not claiming it until someone runs that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)