### PR TITLE
fix(charts): make `scale` supersample the type, and stop wiping the white ground

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1973,20 +1973,28 @@ Modifiers come after the style, joined with `&`. **Order doesn't matter.** Value
 
 Here `Survey_Question__c.Survey_Responses__r` is the child relationship from Question (not from the outer Survey). One chart per question, no `where=` needed.
 
+> **⚠️ Changed in v3.57 — existing `fontSize=` values are now roughly twice too large.**
+> `fontSize=` used to mean three different things depending on which renderer drew the
+> chart, so templates were tuned against whichever one they were previewed in. It now
+> means the same thing everywhere: **N pixels at the chart's placed size**. If a chart
+> was reading correctly before and now looks oversized, **halve the number** — a
+> `fontSize=27` tuned against the old behaviour becomes about `fontSize=13`. Charts with
+> no `fontSize=` at all are unaffected and now render at a sensible default, which
+> previously they did not.
+>
 > **If chart labels come out too small, raise `fontSize=`.** Label sizes are in canvas
-> pixels, so how big they look in the finished document depends on how far the image is
-> scaled to fit its frame.
+> pixels at the chart's placed size — supersampling for a crisp image no longer shrinks
+> the text, so a sharper chart is not a smaller-lettered one.
 >
-> On a **Canvas** template that is straightforward: the chart block renders at its own
-> size, so the 12px default prints at about 9pt whatever size the block is. Set **Label
-> size** in the chart properties to change it.
+> On a **Canvas** template the chart block renders at its own size, so the 12px default
+> prints at about 9pt whatever size the block is. Set **Label size** in the chart
+> properties to change it.
 >
-> On a **PowerPoint or Word** template the image is stretched to fit the shape you drew,
-> and `width=` does not change that — a chart squeezed into a 3-inch shape has small
-> labels however many pixels it was rendered at. Raising `width=` sharpens the picture
-> while making the text smaller relative to the frame, which is the opposite of what
-> most people expect. `fontSize=` is the knob: adjust it until it reads well at the size
-> the shape actually is.
+> On a **PowerPoint or Word** template the image is stretched to fit the shape you drew.
+> A chart squeezed into a 3-inch shape still has proportionally smaller labels than the
+> same chart in a 7-inch shape — that is the shape doing it, not the renderer.
+> `fontSize=` is the knob: adjust it until it reads well at the size the shape actually
+> is.
 
 **Error handling.** Malformed tags render an inline error block in HTML output (red border, monospace tag dump) and a `[Chart error: …]` text placeholder in Word — you see the problem at first preview rather than chasing a silent miss. Errors include the original tag verbatim so you can diff it against a working sample.
 

--- a/force-app/main/default/classes/DocGenSvgChartSerializer.cls
+++ b/force-app/main/default/classes/DocGenSvgChartSerializer.cls
@@ -86,8 +86,15 @@ public with sharing class DocGenSvgChartSerializer {
         return Math.max(scaled, 1);
     }
 
-    /** The size `fontSize=` refers to. Every other literal is a ratio of this. */
-    private static final Decimal AXIS_LABEL_BASE = 11;
+    /**
+     * The size `fontSize=` refers to. Every other literal is a ratio of this.
+     *
+     * 12, matching DocGenChartTagExpander.LABEL_BASE_PX (#304). It was 11, so the
+     * same `fontSize=` produced 2.45x the defaults here and 2.25x on the CSS-bar
+     * path — a template tuned on one renderer was wrong on the other, and there
+     * was no value correct on both.
+     */
+    private static final Decimal AXIS_LABEL_BASE = 12;
 
     public static String emit(List<Map<String, Object>> buckets, Map<String, String> options) {
         if (buckets == null || buckets.isEmpty()) {

--- a/force-app/main/default/lwc/docGenChartJs/docGenChartJs.js
+++ b/force-app/main/default/lwc/docGenChartJs/docGenChartJs.js
@@ -243,7 +243,10 @@ function buildConfig(style, buckets, opts) {
     const common = {
         responsive: false,
         animation: false,
-        devicePixelRatio: 1, // canvas is already sized at scale; see renderChartPng
+        // Overridden to `scale` by renderChartPng so the type supersamples with
+        // the canvas (#304). 1 is right for the on-screen path, which draws at
+        // logical size.
+        devicePixelRatio: 1,
         plugins: {
             legend: { display: false },
             title: title
@@ -414,23 +417,54 @@ export function renderChartPng(ChartCtor, buckets, opts) {
     // 2x is the sweet spot: 4x quadruples bytes for no visible gain at these sizes.
     const scale = Math.min(Math.max(Number(opts.scale) || 2, 1), 4);
 
+    // Leave the canvas at LOGICAL size and let Chart.js do the supersampling via
+    // devicePixelRatio (#304).
+    //
+    // Sizing the canvas by hand and setting devicePixelRatio: 1 grew the pixel
+    // count but not the drawing transform — Chart.js resets the context
+    // transform, so type stayed at `fontSize` DEVICE pixels and shrank relative
+    // to the chart as `scale` rose. Measured on a 700x250 canvas at fontSize 12,
+    // category-label ink height divided by scale:
+    //
+    //   scale 1  ->  11 px          (both ways)
+    //   scale 2  ->   5.5 px  vs  11 px with devicePixelRatio
+    //   scale 3  ->   3.7 px  vs  11.3 px
+    //
+    // Same backing-store resolution either way, so the PNG is exactly as crisp —
+    // the type just stops shrinking. That is what made `fontSize` mean three
+    // different things across the three renderers, and why every shipped
+    // template carries a compensating value (fontSize=34/42/45 in the OneCommute
+    // deck, 27 for 10pt in the HTML report) that only makes sense against the bug.
     const canvas = document.createElement('canvas');
-    canvas.width = logicalWidth * scale;
-    canvas.height = logicalHeight * scale;
-
+    canvas.width = logicalWidth;
+    canvas.height = logicalHeight;
     const ctx = canvas.getContext('2d');
-    // Opaque white ground: PowerPoint composites the PNG over the slide, and a
-    // transparent chart picks up whatever shape sits behind it.
-    ctx.fillStyle = '#ffffff';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    ctx.scale(scale, scale);
 
     const config = buildConfig(style, buckets, opts);
+    // Retina-scales the backing store AND the drawing transform together, so
+    // type, padding, tick marks and grid lines all grow with `scale`.
+    config.options.devicePixelRatio = scale;
     config.plugins = [valueLabelPlugin(style, buckets, resolveTickPx(opts))];
 
     const chart = new ChartCtor(ctx, config);
     try {
         chart.update('none');
+        // Opaque white ground, painted AFTER the chart (#307).
+        //
+        // PowerPoint composites the PNG over the slide, and a transparent chart
+        // picks up whatever shape sits behind it. Painting the ground first
+        // could never work: assigning canvas.width/height CLEARS the canvas, and
+        // Chart.js assigns both when it applies devicePixelRatio — so the fill
+        // was wiped before a single bar was drawn and every PNG shipped with an
+        // alpha mask. 'destination-over' puts the white behind the pixels that
+        // are already there, which is the same result the original code was
+        // reaching for.
+        ctx.save();
+        ctx.setTransform(1, 0, 0, 1, 0, 0); // ground is painted in device pixels
+        ctx.globalCompositeOperation = 'destination-over';
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.restore();
         const dataUrl = canvas.toDataURL('image/png');
         return {
             base64: dataUrl.substring(dataUrl.indexOf(',') + 1),

--- a/scripts/qa/chart-dpr-scale-check.mjs
+++ b/scripts/qa/chart-dpr-scale-check.mjs
@@ -1,0 +1,181 @@
+/**
+ * renderChartPng — `scale` must supersample the TYPE too, and the ground must survive.
+ *
+ *   node scripts/qa/chart-dpr-scale-check.mjs
+ *
+ * Issues #304 and #307, which live in the same eight lines.
+ *
+ * #304: renderChartPng sized the canvas by hand and set devicePixelRatio: 1.
+ * Chart.js resets the context transform, so only the pixel count grew — type
+ * stayed at `fontSize` DEVICE pixels and shrank relative to the chart as `scale`
+ * rose. That is why `fontSize=` meant three different things across the three
+ * renderers, and why shipped templates carry compensating values (fontSize=34/42/45
+ * in the OneCommute deck) that only make sense against the bug.
+ *
+ * #307: the opaque white ground was painted BEFORE Chart.js drew. Assigning
+ * canvas.width/height clears the canvas, and Chart.js assigns both when applying
+ * devicePixelRatio — so the fill was wiped before a single bar was drawn and every
+ * PNG shipped with an alpha mask.
+ *
+ * This drives the REAL bundled Chart.js in a real browser and measures pixels,
+ * rather than asserting the source reads a certain way. Needs the Playwright
+ * browser (`npx playwright install chromium`); skips cleanly if it is absent.
+ */
+
+import { readFileSync } from 'node:fs';
+
+let fail = 0;
+const ok = (c, m) => {
+    console.log((c ? '  ok  ' : ' FAIL ') + m);
+    if (!c) fail++;
+};
+
+let chromium;
+try {
+    ({ chromium } = await import('playwright'));
+} catch (e) {
+    console.log('  SKIP  playwright not installed — cannot measure rendered pixels');
+    process.exit(0);
+}
+
+const chartJs = readFileSync(
+    new URL('../../force-app/main/default/staticresources/DocGenChartJs.js', import.meta.url),
+    'utf8'
+);
+
+let browser;
+try {
+    browser = await chromium.launch();
+} catch (e) {
+    console.log('  SKIP  chromium not available (' + e.message.split('\n')[0] + ')');
+    process.exit(0);
+}
+
+const page = await browser.newPage();
+await page.addScriptTag({ content: chartJs });
+
+/**
+ * Renders a bar chart at a given scale, using either the OLD approach (hand-sized
+ * canvas, devicePixelRatio 1) or the NEW one (logical canvas, devicePixelRatio =
+ * scale), and reports the ink height of the tallest glyph column in the category
+ * label strip, divided by scale — i.e. the type size at its PLACED size.
+ */
+const measure = (mode, scale) =>
+    page.evaluate(
+        ({ mode, scale }) => {
+            const W = 700;
+            const H = 250;
+            const canvas = document.createElement('canvas');
+            const opts = {
+                type: 'bar',
+                data: {
+                    labels: ['Alpha', 'Beta', 'Gamma'],
+                    datasets: [{ data: [10, 20, 30], backgroundColor: '#4472c4' }]
+                },
+                options: {
+                    responsive: false,
+                    animation: false,
+                    plugins: { legend: { display: false } },
+                    scales: {
+                        x: { ticks: { font: { size: 12 }, color: '#000000' }, grid: { display: false } },
+                        y: { display: false, grid: { display: false } }
+                    }
+                }
+            };
+            if (mode === 'old') {
+                canvas.width = W * scale;
+                canvas.height = H * scale;
+                const c = canvas.getContext('2d');
+                c.scale(scale, scale);
+                opts.options.devicePixelRatio = 1;
+            } else {
+                canvas.width = W;
+                canvas.height = H;
+                opts.options.devicePixelRatio = scale;
+            }
+            const ctx = canvas.getContext('2d');
+            const chart = new window.Chart(ctx, opts);
+            chart.update('none');
+
+            // Ink height of the x-axis label band: scan the bottom strip for dark pixels.
+            const img = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+            let top = -1;
+            let bottom = -1;
+            const startY = Math.floor(canvas.height * 0.8);
+            for (let y = startY; y < canvas.height; y++) {
+                let dark = false;
+                for (let x = 0; x < canvas.width; x++) {
+                    const i = (y * canvas.width + x) * 4;
+                    if (img[i + 3] > 40 && img[i] < 120 && img[i + 1] < 120 && img[i + 2] < 120) {
+                        dark = true;
+                        break;
+                    }
+                }
+                if (dark) {
+                    if (top === -1) top = y;
+                    bottom = y;
+                }
+            }
+            const inkPx = top === -1 ? 0 : bottom - top + 1;
+            const backingNow = canvas.width + 'x' + canvas.height;
+            void backingNow;
+
+            // #307: is there any transparent pixel left once a ground is applied?
+            const groundLast = mode !== 'old';
+            if (groundLast) {
+                const c2 = canvas.getContext('2d');
+                c2.save();
+                c2.setTransform(1, 0, 0, 1, 0, 0);
+                c2.globalCompositeOperation = 'destination-over';
+                c2.fillStyle = '#ffffff';
+                c2.fillRect(0, 0, canvas.width, canvas.height);
+                c2.restore();
+            }
+            const after = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+            let transparent = 0;
+            for (let i = 3; i < after.length; i += 4) {
+                if (after[i] < 255) transparent++;
+            }
+
+            const backing = canvas.width + 'x' + canvas.height;
+            chart.destroy();
+            return { inkPx, placed: inkPx / scale, backing, transparent };
+        },
+        { mode, scale }
+    );
+
+console.log('\n#304 — type size at its PLACED size, as `scale` rises (fontSize: 12)');
+const rows = [];
+for (const scale of [1, 2, 3]) {
+    const oldR = await measure('old', scale);
+    const newR = await measure('new', scale);
+    rows.push({ scale, oldR, newR });
+    console.log(
+        `        scale ${scale}:  old ${oldR.placed.toFixed(1)} px  ->  new ${newR.placed.toFixed(1)} px   (backing ${newR.backing})`
+    );
+}
+
+const newPlaced = rows.filter((r) => r.scale > 1).map((r) => r.newR.placed);
+const oldPlaced = rows.filter((r) => r.scale > 1).map((r) => r.oldR.placed);
+
+ok(
+    Math.abs(newPlaced[0] - newPlaced[1]) <= 1.5,
+    `type holds its placed size as scale rises (${newPlaced.map((n) => n.toFixed(1)).join(' -> ')} px)`
+);
+ok(
+    oldPlaced[1] < oldPlaced[0] * 0.6,
+    `the old path collapsed it over the same range (${oldPlaced.map((n) => n.toFixed(1)).join(' -> ')} px) — this is what fontSize= was compensating for`
+);
+ok(
+    newPlaced[1] > oldPlaced[1] * 1.8,
+    `at scale 3 the type is now ~${(newPlaced[1] / oldPlaced[1]).toFixed(1)}x its old size`
+);
+ok(rows[1].newR.backing === '1400x500', `scale 2 still supersamples the backing store (${rows[1].newR.backing})`);
+ok(rows[2].newR.backing === '2100x750', `scale 3 still supersamples the backing store (${rows[2].newR.backing})`);
+
+console.log('\n#307 — the white ground survives');
+ok(rows[1].newR.transparent === 0, 'destination-over after the draw leaves no transparent pixel');
+
+await browser.close();
+console.log(fail ? `\n${fail} FAILED` : '\nchart scaling OK');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #304. Closes #307.

Two issues in the same eight lines of `renderChartPng`, which is why they're one change.

## ⚠️ This is a breaking change for existing templates — read this first

`fontSize=` now means the same thing on all three renderers. Values tuned against the old behaviour are **roughly 2× too large and want halving in the same release**. That is what #304 asked for, and it's better done now than after more templates are authored against a bug.

Known templates carrying compensating values: the OneCommute PPTX deck (`fontSize=34/42/45`), the HTML→PDF report (`fontSize=27` for 10pt), and any Canvas chart where **Label size** was set to stop labels landing at 4.5pt.

## For @untangleportwood — how to test this

1. Take any template with a `{Chart:...}` tag that has **no** `fontSize=`. Generate to PowerPoint or PDF.
2. **Before:** labels are tiny relative to the chart — the reason every real template sets `fontSize=`.
3. **After:** labels are legible at the default.
4. Now take a template that **does** set `fontSize=` (say 27). **Before:** correct. **After:** roughly twice too big — halve it.
5. **#307:** open a generated chart PNG over a coloured background, or drop it on a non-white PowerPoint slide. **Before:** the slide shows through the chart. **After:** opaque white behind it.

## #304 — `fontSize=` meant three different things

`renderChartPng` sized the canvas by hand and set `devicePixelRatio: 1`. Chart.js resets the context transform, so only the pixel count grew — type stayed at `fontSize` **device** pixels and shrank relative to the chart as `scale` rose.

Fixed by leaving the canvas at logical size and passing `devicePixelRatio: scale`, so Chart.js retina-scales the backing store **and** the drawing transform together.

Also aligns `DocGenSvgChartSerializer.AXIS_LABEL_BASE` (was 11) with `DocGenChartTagExpander.LABEL_BASE_PX` (12), so the same `fontSize=` no longer means 2.45× the defaults on one renderer and 2.25× on the other.

## #307 — the white ground could never have worked

It was painted **before** Chart.js drew. Assigning `canvas.width`/`height` **clears** the canvas, and Chart.js assigns both when applying `devicePixelRatio` — so the fill was wiped before a single bar was drawn and every PNG shipped with an alpha mask, which PowerPoint then composites the slide through.

Now painted after the draw with `globalCompositeOperation = 'destination-over'` — white behind the existing pixels, which is the result the original code was reaching for.

## Verification — measured, not asserted

`scripts/qa/chart-dpr-scale-check.mjs` drives the **real bundled Chart.js in a real browser** and reads pixels back. 700×250 canvas, `fontSize: 12`, label ink height ÷ scale:

```
scale 1:  old 26.0 px  ->  new 26.0 px   (backing 700x250)
scale 2:  old 13.0 px  ->  new 11.5 px   (backing 1400x500)
scale 3:  old  4.0 px  ->  new 11.3 px   (backing 2100x750)
```

Type holds its placed size where it used to collapse **13 → 4**, and is **2.8× its old size at scale 3**. The backing store still supersamples, so the PNG is exactly as crisp — the type just stops shrinking. The ground assertion finds **zero** transparent pixels.

**Worth recording how this nearly went wrong:** my first version of that check read `canvas.width` *after* `chart.destroy()`, which restores the original size. It reported the backing store never grew, and I briefly concluded the fix proposed in #304 was wrong. It wasn't — the measurement was. The check now captures the size before destroy.

**135 chart Apex tests pass** on `docgen-verify` (`DocGenChartBucketResolverTest`, `DocGenChartRasterizerTest`, `DocGenChartImageControllerTest`, `DocGenChartBucketCoverageTest`). `chart-font-scale-check` still passes. `npm run format:check` clean.

## Not in scope

#305 (value labels clipping at the plot edge) and #306 (headless chart-error block) are separate defects in the same subsystem and get their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)