### PR TITLE
fix(charts): reserve room for value labels so they stop clipping

### DIFF
--- a/force-app/main/default/lwc/docGenChartJs/docGenChartJs.js
+++ b/force-app/main/default/lwc/docGenChartJs/docGenChartJs.js
@@ -172,19 +172,44 @@ function valueLabelPlugin(style, buckets, fontPx) {
                 }
                 const label = `${b.count} (${b.percent}%)`;
                 const pos = element.tooltipPosition();
+                // Belt and braces on top of the layout reserve (#305): clamp to the
+                // canvas so a label can never be cut, whatever the data does to the
+                // axis. The reserve is what keeps it looking right; this is what
+                // keeps it legible if the reserve is ever a pixel short.
                 if (style === 'bar') {
                     ctx.textAlign = 'left';
                     ctx.textBaseline = 'middle';
-                    ctx.fillText(label, element.x + 6, pos.y);
+                    const maxX = chart.width - ctx.measureText(label).width - 2;
+                    ctx.fillText(label, Math.min(element.x + 6, maxX), pos.y);
                 } else {
                     ctx.textAlign = 'center';
                     ctx.textBaseline = 'bottom';
-                    ctx.fillText(label, pos.x, element.y - 6);
+                    const minY = (fontPx || 12) + 2;
+                    ctx.fillText(label, pos.x, Math.max(element.y - 6, minY));
                 }
             });
             ctx.restore();
         }
     };
+}
+
+/**
+ * Right-hand reserve for the horizontal bar's value labels, in canvas pixels (#305).
+ *
+ * The widest label the plugin will draw, measured in characters against the size
+ * it draws at. 0.62em per character is a deliberate over-estimate for a
+ * proportional face — over-reserving costs a little plot width, under-reserving
+ * clips the text, and only one of those is a bug.
+ */
+function valueLabelReserve(buckets, fontPx) {
+    let longest = 0;
+    for (const b of buckets || []) {
+        const len = `${b.count} (${b.percent}%)`.length;
+        if (len > longest) {
+            longest = len;
+        }
+    }
+    return Math.max(72, Math.ceil(longest * fontPx * 0.62) + 14);
 }
 
 /** Tick, legend and value-label size, in canvas pixels. */
@@ -339,11 +364,24 @@ function buildConfig(style, buckets, opts) {
             ...common,
             indexAxis: horizontal ? 'y' : 'x',
             // Leave room for the value labels the plugin draws past the bar end.
-            layout: { padding: horizontal ? { right: 72 } : { top: 24 } },
+            //
+            // This used to be a flat { right: 72 } / { top: 24 } (#305). The plugin
+            // draws with ctx.fillText in afterDatasetsDraw and contributes nothing
+            // to layout, so this padding is the ONLY reserve — and a fixed one
+            // cannot cover a label the author sized up: `fontSize=` goes to 48,
+            // where 24px of headroom is half a glyph. Scaled off the same tickPx
+            // the plugin draws with, and off the longest label it will actually
+            // produce, so the reserve tracks the text.
+            layout: { padding: horizontal ? { right: valueLabelReserve(buckets, tickPx) } : { top: tickPx * 1.7 } },
             scales: horizontal
                 ? {
                       x: {
                           beginAtZero: true,
+                          // Keep the longest bar off the axis ceiling, so its label
+                          // has somewhere to sit. Small integer data makes this bite:
+                          // Chart.js takes the data max as the top tick, so 2
+                          // responses gives a top tick of exactly 2.
+                          grace: '8%',
                           grid: { color: gridColor },
                           ticks: { color: '#475569', font: tickFont, precision: 0 }
                       },
@@ -353,6 +391,7 @@ function buildConfig(style, buckets, opts) {
                       x: { grid: { display: false }, ticks: { color: '#334155', font: tickFont } },
                       y: {
                           beginAtZero: true,
+                          grace: '8%',
                           grid: { color: gridColor },
                           ticks: { color: '#475569', font: tickFont, precision: 0 }
                       }

--- a/scripts/qa/chart-value-label-clip-check.mjs
+++ b/scripts/qa/chart-value-label-clip-check.mjs
@@ -1,0 +1,163 @@
+/**
+ * valueLabelPlugin — the count/percent label must never be clipped.
+ *
+ *   node scripts/qa/chart-value-label-clip-check.mjs
+ *
+ * Issue #305. The plugin draws "N (P%)" with ctx.fillText in afterDatasetsDraw
+ * and contributes nothing to layout, so Chart.js reserves no room for it:
+ *
+ *   - horizontal `bar`   — drawn at element.x + 6; when the longest bar reaches
+ *                          the axis max the value runs off the right edge and
+ *                          "2 (66.7%)" renders as "2 (66".
+ *   - vertical `column`  — drawn at element.y - 6; when the tallest bar equals
+ *                          the axis max there is nothing above it and the label
+ *                          is clipped at the top.
+ *
+ * `layout.padding` was already set (right: 72 / top: 24) but as FIXED canvas
+ * pixels, while `fontSize=` goes up to 48 — so the reserve was simply too small
+ * once an author sized the labels up.
+ *
+ * Small integer data reproduces it reliably: Chart.js picks the data max as the
+ * top tick, so 2 responses gives a top tick of exactly 2 and the bar touches the
+ * ceiling. Larger data usually escapes — 3,528 rounds up to a 4,000 tick and the
+ * label lands in the gap — which is why this looks intermittent in the field.
+ *
+ * Measures real pixels from the real bundled Chart.js. Skips if Playwright's
+ * browser is unavailable.
+ */
+
+import { readFileSync } from 'node:fs';
+
+let fail = 0;
+const ok = (c, m) => {
+    console.log((c ? '  ok  ' : ' FAIL ') + m);
+    if (!c) fail++;
+};
+
+let chromium;
+try {
+    ({ chromium } = await import('playwright'));
+} catch (e) {
+    console.log('  SKIP  playwright not installed');
+    process.exit(0);
+}
+
+const chartJs = readFileSync(
+    new URL('../../force-app/main/default/staticresources/DocGenChartJs.js', import.meta.url),
+    'utf8'
+);
+const rendererSrc = readFileSync(
+    new URL('../../force-app/main/default/lwc/docGenChartJs/docGenChartJs.js', import.meta.url),
+    'utf8'
+);
+
+let browser;
+try {
+    browser = await chromium.launch();
+} catch (e) {
+    console.log('  SKIP  chromium not available');
+    process.exit(0);
+}
+const page = await browser.newPage();
+await page.addScriptTag({ content: chartJs });
+// Load the SHIPPED renderer, with its LWC-only imports stubbed out.
+await page.addScriptTag({
+    content:
+        'window.DG = (function(){' +
+        rendererSrc
+            .replace(/^import .*$/gm, '')
+            .replace(/^export /gm, '') +
+        '; return { buildConfig: typeof buildConfig === "function" ? buildConfig : null, valueLabelPlugin: typeof valueLabelPlugin === "function" ? valueLabelPlugin : null, resolveTickPx: typeof resolveTickPx === "function" ? resolveTickPx : null };})();'
+});
+
+const hasRenderer = await page.evaluate(() => Boolean(window.DG && window.DG.buildConfig));
+if (!hasRenderer) {
+    console.log('  SKIP  could not load the shipped renderer in-page');
+    await browser.close();
+    process.exit(0);
+}
+
+/**
+ * Renders through the SHIPPED buildConfig + valueLabelPlugin and reports whether
+ * any label ink touches the canvas edge.
+ */
+const probe = (style, fontSize, counts) =>
+    page.evaluate(
+        ({ style, fontSize, counts }) => {
+            const total = counts.reduce((a, b) => a + b, 0);
+            const buckets = counts.map((c, i) => ({
+                key: 'K' + i,
+                key_label: 'Bucket ' + i,
+                count: c,
+                percent: Math.round((c * 1000) / total) / 10,
+                max_percent: Math.round((c * 1000) / Math.max(...counts)) / 10,
+                index: i + 1,
+                color: '#3b82f6'
+            }));
+            const opts = { style, width: 700, height: 250, fontSize: String(fontSize) };
+            const canvas = document.createElement('canvas');
+            canvas.width = 700;
+            canvas.height = 250;
+            const ctx = canvas.getContext('2d');
+            const config = window.DG.buildConfig(style, buckets, opts);
+            config.options.devicePixelRatio = 1;
+            config.plugins = [window.DG.valueLabelPlugin(style, buckets, window.DG.resolveTickPx(opts))];
+            const chart = new window.Chart(ctx, config);
+            chart.update('none');
+
+            const w = canvas.width;
+            const h = canvas.height;
+            const img = ctx.getImageData(0, 0, w, h).data;
+            const isInk = (x, y) => {
+                const i = (y * w + x) * 4;
+                return img[i + 3] > 40 && img[i] < 160 && img[i + 1] < 160 && img[i + 2] < 160;
+            };
+            let topEdge = false;
+            let rightEdge = false;
+            for (let x = 0; x < w; x++) {
+                if (isInk(x, 0)) topEdge = true;
+            }
+            for (let y = 0; y < h; y++) {
+                if (isInk(w - 1, y)) rightEdge = true;
+            }
+            chart.destroy();
+            return { topEdge, rightEdge };
+        },
+        { style, fontSize, counts }
+    );
+
+// The reported shape: the largest bucket IS the axis max, so the bar touches the ceiling.
+const TIGHT = [2, 1];
+const LARGE = [3528, 1200];
+
+console.log('\nhorizontal bar — label must not run off the right edge');
+for (const fs of [12, 27, 48]) {
+    const r = await probe('bar', fs, TIGHT);
+    ok(!r.rightEdge, `fontSize ${fs}: no ink on the right edge with the top bar at the axis max`);
+}
+{
+    const r = await probe('bar', 27, LARGE);
+    ok(!r.rightEdge, 'fontSize 27: still clean when the data rounds up to a higher tick');
+}
+
+console.log('\nvertical column — label must not clip at the top');
+for (const fs of [12, 27, 48]) {
+    const r = await probe('column', fs, TIGHT);
+    ok(!r.topEdge, `fontSize ${fs}: no ink on the top edge with the tallest bar at the axis max`);
+}
+{
+    const r = await probe('column', 27, LARGE);
+    ok(!r.topEdge, 'fontSize 27: still clean when the data rounds up to a higher tick');
+}
+
+console.log('\nand a title is no longer required to buy the room');
+{
+    // The current field workaround is `title=`, which forces a visible heading the
+    // author may not want and rasterizes it into the PNG. Without one must be fine.
+    const r = await probe('column', 27, TIGHT);
+    ok(!r.topEdge, 'a chart with no title= still reserves room for its value labels');
+}
+
+await browser.close();
+console.log(fail ? `\n${fail} FAILED` : '\nvalue-label clipping OK');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #305.

## For @untangleportwood — how to test this

The trigger is **small integer data**, not big data — which is why this looks intermittent.

1. Make a chart whose largest bucket **is** the axis maximum. Two responses does it: Chart.js takes the data max as the top tick, so the bar touches the ceiling.
2. Generate to PowerPoint or PDF, with `style=column` and again with `style=bar`.
3. **Before:** the value label is cut — `2 (66.7%)` renders as `2 (66` on a horizontal bar, or the top of the glyph is sliced off on a column. Worse the larger `fontSize=` is.
4. **After:** the label is fully inside the image at any `fontSize=` up to 48.

Also worth confirming: **a chart with no `title=` now works.** Adding `title=` was the workaround — it made Chart.js reserve a title block and push the plot down. If any of your templates carry a title purely for that reason, they no longer need it.

## Root cause

`valueLabelPlugin` draws `"N (P%)"` with `ctx.fillText` in `afterDatasetsDraw` and **contributes nothing to layout**, so Chart.js reserves no room for it.

`layout.padding` *was* set — `{ right: 72 }` / `{ top: 24 }` — but as **fixed canvas pixels**, while `fontSize=` goes up to 48. At 48px, 24px of headroom is half a glyph. The reserve never tracked the text it was reserving for.

## The fix

- **The reserve is computed from the same `tickPx` the plugin draws with**, and for the horizontal case from the longest label it will actually produce. 0.62em per character is a deliberate over-estimate — over-reserving costs a little plot width, under-reserving clips text, and only one of those is a bug.
- **`grace: '8%'` on the value axis**, so the longest bar never touches the ceiling.
- **The plugin clamps its own draw position to the canvas.** Belt and braces: the reserve is what keeps it looking right, the clamp is what keeps it legible if the reserve is ever a pixel short.

## Verification

```
node scripts/qa/chart-value-label-clip-check.mjs
```

Drives the **shipped** `buildConfig` and `valueLabelPlugin` through the real bundled Chart.js and reads the canvas edges for ink.

**Against `main` it fails 5 of 9** — column clipped at `fontSize` 27 and 48, bar clipped at 48, the rounded-up-tick bar case, and the no-title case. **With this change all 9 pass.** `chart-font-scale-check` still passes. `npm run format:check` clean.

## Conflicts with #347

That PR (#304/#307) edits the same file — it changes how `scale` supersamples and where the white ground is painted. Complementary; whichever merges second needs a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)