### PR TITLE
fix(charts): degrade unsupported styles to CSS bars instead of printing an error

### DIFF
--- a/force-app/main/default/classes/DocGenChartTagExpander.cls
+++ b/force-app/main/default/classes/DocGenChartTagExpander.cls
@@ -345,17 +345,33 @@ public with sharing class DocGenChartTagExpander {
         } else if (style == 'stacked') {
             return renderStacked(title, chartBucketTag, opts.get('colSort'), opts);
         }
-        // Unreachable due to ALLOWED_STYLES guard above — `column`, `pie`,
-        // `donut` only render in HTML output via the `htmlRender=svg` opt-in
-        // branch above, since the CSS-bar renderers don't (yet) cover them.
-        // If an author writes a bare {Chart:Rel:Field:column} we surface an
-        // actionable error rather than silently falling through.
-        throw new ChartTagException(
-            'Style "' +
-                style +
-                '" is supported in HTML output only via `htmlRender=svg`. ' +
-                'Add `:htmlRender=svg` to the tag or pick a CSS-bar style (bar, pivot, clustered, stacked).'
-        );
+        // DEGRADE, never error (#306).
+        //
+        // `column`, `pie`, `donut`, `line` and `area` have no CSS-bar renderer.
+        // In a browser that is moot — the chart is rasterized and chartCvMap is
+        // populated, so any style works. Headless (Flow action, batch, scheduled
+        // job) there is no browser, chartCvMap is empty, and this branch is
+        // reached. It used to throw, and the caller printed the exception into
+        // the document — putting the raw merge tag in the middle of a
+        // client-facing PDF:
+        //
+        //   Chart error: Style "column" is supported in HTML output only via
+        //   `htmlRender=svg` ... at {Chart:Survey_Answers__r:Answer_8__c:column:...}
+        //
+        // Measured on a real headless run: seven charts, a 7-page PDF, ZERO
+        // embedded images and seven error blocks. Everything non-chart was
+        // correct.
+        //
+        // The advice that message gave was a dead end anyway: `htmlRender=svg`
+        // emits inline <svg>, which Flying Saucer silently drops, so it cannot
+        // help a PDF.
+        //
+        // A `column` drawn as CSS bars is the same data in the same order, read
+        // sideways. That is a far better document than an error block, and the
+        // author still gets their intended shape everywhere a browser is
+        // involved. `pie`/`donut` lose the part-of-whole framing, which is why
+        // the percentage stays on every bar.
+        return renderBar(title, chartBucketTag, opts);
     }
 
     /**

--- a/force-app/main/default/classes/DocGenChartTagExpanderTest.cls
+++ b/force-app/main/default/classes/DocGenChartTagExpanderTest.cls
@@ -402,15 +402,27 @@ private class DocGenChartTagExpanderTest {
     }
 
     @IsTest
-    static void htmlRenderSvg_bareColumnStyle_errorsWithoutOptIn() {
-        // {Chart:R:F:column} without htmlRender=svg has no CSS-bar renderer
-        // (column is SVG-only) — the expander surfaces an actionable error
-        // pointing the author at the opt-in rather than silently dropping
-        // the chart.
+    static void htmlRenderSvg_bareColumnStyle_degradesWithoutOptIn() {
+        // REVERSED in #306, deliberately. This used to assert that a bare
+        // {Chart:R:F:column} produced "an actionable error pointing the author at
+        // the opt-in". In a browser that branch is never reached — the chart is
+        // rasterized and chartCvMap is populated. Headless it is, and the caller
+        // printed the exception INTO the document: the raw merge tag, in a
+        // client-facing PDF. Seven charts produced seven error blocks and no
+        // images on a real Flow-action run.
+        //
+        // The advice was also unactionable for the format that hit it:
+        // htmlRender=svg emits inline <svg>, which Flying Saucer drops, so it can
+        // never help a PDF. Degrading to CSS bars gives the same data in the same
+        // order; an error block gives nothing.
         String input = '{Chart:Responses__r:A__c:column}';
         String out = DocGenChartTagExpander.expand(input, 'HTML');
-        System.assert(out.contains('Chart error'), 'Bare column style should render an error block. Got: ' + out);
-        System.assert(out.contains('htmlRender=svg'), 'Error should point the author at the htmlRender=svg opt-in.');
+        System.assert(!out.contains('Chart error'), 'A bare column must not render an error block. Got: ' + out);
+        System.assert(!out.contains('{Chart:'), 'The raw tag must never reach the document. Got: ' + out);
+        System.assert(
+            out.contains('{#ChartBucket:Responses__r:A__c'),
+            'It should degrade to the CSS-bar renderer. Got: ' + out
+        );
     }
 
     // ─── Task #23: HTML chart output via PNG-via-CV ──────────────────────────
@@ -664,5 +676,86 @@ private class DocGenChartTagExpanderTest {
             }
         }
         Test.stopTest();
+    }
+
+    // ─── #306: headless HTML degrades, it never prints an error ──────────────
+    //
+    // In a browser these styles are rasterized and chartCvMap is populated, so
+    // any style works. Headless — Flow action, batch, scheduled job — there is
+    // no browser, chartCvMap is empty, and a style with no CSS-bar renderer used
+    // to THROW. The caller printed that exception into the document, putting the
+    // raw merge tag in the middle of a client-facing PDF. Measured on a real
+    // headless run: seven charts, a 7-page PDF, zero images, seven error blocks.
+    //
+    // The advice the old message gave was a dead end anyway — htmlRender=svg
+    // emits inline <svg>, which Flying Saucer drops.
+
+    /** Every style with no CSS-bar renderer of its own. */
+    private static List<String> degradingStyles() {
+        return new List<String>{ 'column', 'pie', 'donut', 'line', 'area' };
+    }
+
+    @isTest
+    static void headlessHtmlDegradesUnsupportedStylesToBars() {
+        Test.startTest();
+        for (String style : degradingStyles()) {
+            String input = '{Chart:Responses__r:A__c:' + style + ':title=Commute mode}';
+            String out;
+            try {
+                out = DocGenChartTagExpander.expand(input, 'HTML');
+            } catch (Exception e) {
+                System.assert(false, style + ' must not throw headless — got: ' + e.getMessage());
+            }
+            System.assert(
+                !out.contains('{Chart:'),
+                style + ': the raw tag must never survive into the document. Got: ' + out
+            );
+            System.assert(
+                !out.containsIgnoreCase('htmlRender=svg'),
+                style + ': must not advise htmlRender=svg, which Flying Saucer drops. Got: ' + out
+            );
+            System.assert(
+                !out.containsIgnoreCase('Chart error'),
+                style + ': must not emit an error block. Got: ' + out
+            );
+            System.assert(
+                out.contains('{#ChartBucket:Responses__r:A__c'),
+                style + ': should degrade to the CSS-bar renderer. Got: ' + out
+            );
+            System.assert(out.contains('Commute mode'), style + ': the author title must survive the degrade.');
+        }
+        Test.stopTest();
+    }
+
+    @isTest
+    static void degradedChartKeepsItsPercentages() {
+        // pie/donut lose the part-of-whole framing when drawn as bars, so the
+        // percentage on each row is what carries that meaning across.
+        Test.startTest();
+        String out = DocGenChartTagExpander.expand('{Chart:Responses__r:A__c:donut}', 'HTML');
+        Test.stopTest();
+        System.assert(out.contains('{percent}'), 'A degraded donut must still show percentages. Got: ' + out);
+    }
+
+    @isTest
+    static void stylesWithTheirOwnCssRendererAreUnaffected() {
+        // Control: the degrade must not swallow the styles that already work.
+        Test.startTest();
+        for (String style : new List<String>{ 'bar', 'pivot', 'clustered', 'stacked' }) {
+            String opts = (style == 'bar') ? '' : ':groupBy=Dept__c';
+            String out = DocGenChartTagExpander.expand('{Chart:Responses__r:A__c:' + style + opts + '}', 'HTML');
+            System.assert(!out.contains('{Chart:'), style + ' still expands. Got: ' + out);
+        }
+        Test.stopTest();
+    }
+
+    @isTest
+    static void htmlRenderSvgStillWinsWhereItIsAsked() {
+        // The opt-in path is unchanged — degrading is the FALLBACK, not a
+        // replacement for an author who explicitly asked for SVG in a browser.
+        Test.startTest();
+        String out = DocGenChartTagExpander.expand('{Chart:Responses__r:A__c:column:htmlRender=svg}', 'HTML');
+        Test.stopTest();
+        System.assert(out.contains('<svg'), 'htmlRender=svg must still emit inline SVG. Got: ' + out);
     }
 }


### PR DESCRIPTION
Closes #306.

## For @untangleportwood — how to test this

The trigger is **generating without a browser**, not a particular template.

1. Take an HTML→PDF template with a chart using `column`, `pie`, `donut`, `line` or `area`.
2. Generate it from the **runner** (browser). Works either way — that path rasterizes with Chart.js.
3. Now generate the same template **headlessly**: the Flow action, a batch, or a scheduled job.
4. **Before:** the PDF contains an error block with the raw merge tag printed into the document body.
5. **After:** it renders as a CSS bar chart — same data, same order.

No-regression: `bar`, `pivot`, `clustered` and `stacked` should be unchanged, and a tag that explicitly says `htmlRender=svg` should still emit inline SVG in a browser.

## What was in the PDF

```
Chart error: Style "column" is supported in HTML output only via
`htmlRender=svg`. Add `:htmlRender=svg` to the tag or pick a CSS-bar style
at {Chart:VMR_Tracker__Survey_Question_Answers__r:VMR_Tracker__Answer_8__c:column:title=...}
```

Measured on a real headless run: **seven charts, a 7-page PDF, zero embedded images, seven error blocks.** Everything non-chart was correct — aggregates, `{#ChartBucket}` tables, record loops, `{#IF}` conditionals.

## Root cause

The three renderers cover different style sets. In a browser the chart is rasterized and `chartCvMap` is populated, so anything works. Headless there is no browser, `chartCvMap` is empty, and `column`/`pie`/`donut`/`line`/`area` fall through to a `throw` that the caller renders **into the document**.

The advice that message gave was a dead end for the format that hit it: `htmlRender=svg` emits inline `<svg>`, which **Flying Saucer silently drops** — noted in this class's own comments — so it can never help a PDF.

**The comment above the throw claimed it was "unreachable due to the ALLOWED_STYLES guard above".** It wasn't: `ALLOWED_STYLES` contains all five, so the guard passes them straight through. That wrong comment is why the branch was never revisited.

## The fix

Degrade to the CSS-bar renderer. A `column` drawn as bars is the same data in the same order, read sideways; an error block is nothing. The author still gets their intended shape everywhere a browser is involved.

`pie`/`donut` lose the part-of-whole framing, which is why the **percentage stays on every row** — asserted.

## Verification

`DocGenChartTagExpanderTest` **43/43** on `docgen-verify`: five new assertions per degrading style, a control that `bar`/`pivot`/`clustered`/`stacked` are untouched, that an explicit `htmlRender=svg` still wins, and that a degraded donut keeps its percentages. The same 11 assertions also pass run synchronously through anonymous Apex against `expand()` directly.

**This reverses `htmlRenderSvg_bareColumnStyle_errorsWithoutOptIn`**, which asserted the error block. It encoded the bug, and the reversal is the point — it now asserts the tag never reaches the document. Renamed accordingly.

`npm run format:check` clean.

## Note for anyone running these tests

The verify org's **async test queue wedged** at 71/114 and then wouldn't start a fresh run at all. Aborting stuck `ApexTestQueueItem` rows and re-running with **`--synchronous`** (one class at a time) worked. Worth knowing before assuming a hang is your change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)