### PR TITLE
fix(currency): make :convert work on a plain field, not just aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,19 @@ Two small fixes where the editor promised something the PDF did not deliver.
   resolve to the base-14 bold faces (verified selecting Helvetica-Bold / Times-Bold /
   Courier-Bold in a real org).
 
+- **`:convert` was silently ignored on a plain currency field (#297).** It worked on
+  aggregates and nowhere else — on a plain field the `convert` segment landed in the
+  locale slot, was parsed as a bogus locale name and dropped, so
+  `{Amount:currency:EUR:convert}` on a USD-100 record printed `€100.00`: the euro symbol
+  with the dollar figure, wrong by the exchange rate with nothing in the document to flag
+  it. It now strips `:convert` before the locale slot and converts from the record's own
+  `CurrencyIsoCode` into the tag's target, reusing `DocGenCurrency.wantsConversion` /
+  `stripConvertSegment` so the plain-field and aggregate paths can't drift on what
+  `:convert` means. It composes with locale (`:EUR:de_DE:convert`) and the `auto` forms.
+  A record with no source currency passes through unconverted rather than having a rate
+  invented for it; a missing rate raises the same actionable error the aggregate path
+  already does.
+
 ## v3.55.0 — Element linking, named blocks, client-side charts
 
 Released 2026-08-08 · `04tVx0000010fXFIAY` · ancestor 3.54.0 · 1,957 tests, 78% coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,9 @@ Two small fixes where the editor promised something the PDF did not deliver.
   `:convert` means. It composes with locale (`:EUR:de_DE:convert`) and the `auto` forms.
   A record with no source currency passes through unconverted rather than having a rate
   invented for it; a missing rate raises the same actionable error the aggregate path
-  already does.
+  already does. Applies on the giant-query parent path (>2000 child rows) as well as the
+  normal path, and a stray `:convert` no longer leaks into a `{COUNT:…:currency:…}` tag's
+  formatting.
 
 ## v3.55.0 — Element linking, named blocks, client-side charts
 

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1621,6 +1621,7 @@ What to know:
 - **Advanced Currency Management dated rates are not used** — conversion applies your current static rate. See issue #273.
 - **Single-currency orgs are entirely unaffected.** None of this engages.
 - **Without `:convert`, nothing converts.** `{SUM:Lines.Amount:currency:EUR}` over EUR-only rows formats them as euros; it does not translate other currencies into euros.
+- **Beyond aggregates: `:convert` works on a plain currency field too (v3.57+).** `{Amount:currency:EUR:convert}` converts the record's own amount from its `CurrencyIsoCode` into the target ISO before formatting, and composes with locale (`:EUR:de_DE:convert`) and `auto`. A record with no source currency passes through unconverted; a missing rate raises the same "add it under Manage Currencies" error as above.
 
 #### Number formatting
 

--- a/force-app/main/default/classes/DocGenCurrencyTest.cls
+++ b/force-app/main/default/classes/DocGenCurrencyTest.cls
@@ -240,4 +240,81 @@ private class DocGenCurrencyTest {
         System.assertEquals(100, DocGenCurrency.convert(100, null, 'EUR'), 'unknown source passes through');
         System.assertEquals(null, DocGenCurrency.convert(null, 'USD', 'EUR'), 'null amount stays null');
     }
+
+    // ─── #297: :convert on a PLAIN field, not just aggregates ────────────────
+    //
+    // It worked on aggregates and nowhere else. On a plain field the segment
+    // landed in the LOCALE slot: {Amount:currency:EUR:convert} parsed `convert`
+    // as a locale name, failed to match one, and formatted with default
+    // separators. The symbol changed to euro and the NUMBER did not move, so a
+    // $100 record rendered as a euro figure that was wrong by the exchange rate,
+    // in the currency it claimed to be in, with nothing to indicate it.
+    //
+    // Measured against main before the fix:
+    //   {Amount:currency:EUR}          -> EUR100.00
+    //   {Amount:currency:EUR:convert}  -> EUR100.00   <-- identical; convert did nothing
+    //   {Amount:currency:auto:convert} -> $100.00
+
+    private static String render(String tag, Map<String, Object> data) {
+        return DocGenService.processXmlForTest('<p>' + tag + '</p>', data).replace('<p>', '').replace('</p>', '');
+    }
+
+    @IsTest
+    static void convertOnAPlainFieldActuallyConverts() {
+        stubRates(); // USD 1.0, EUR 0.5
+        Map<String, Object> data = row(100, 'USD');
+        Test.startTest();
+        String withConvert = render('{Amount:currency:EUR:convert}', data);
+        String without = render('{Amount:currency:EUR}', data);
+        Test.stopTest();
+
+        System.assert(withConvert.contains('50'), ':convert must apply the rate. Got: ' + withConvert);
+        System.assert(without.contains('100'), 'without :convert the amount is untouched. Got: ' + without);
+        System.assertNotEquals(
+            without,
+            withConvert,
+            ':convert produced the same output as no convert — the segment was swallowed again'
+        );
+    }
+
+    @IsTest
+    static void convertComposesWithAnExplicitLocale() {
+        stubRates();
+        Test.startTest();
+        String out = render('{Amount:currency:EUR:de_DE:convert}', row(100, 'USD'));
+        Test.stopTest();
+        System.assert(out.contains('50'), 'the rate applies with a locale present. Got: ' + out);
+        System.assert(out.contains(','), 'and the German decimal separator survives. Got: ' + out);
+    }
+
+    @IsTest
+    static void convertToTheRecordsOwnCurrencyIsANoOp() {
+        stubRates();
+        Test.startTest();
+        String out = render('{Amount:currency:USD:convert}', row(100, 'USD'));
+        Test.stopTest();
+        System.assert(out.contains('100'), 'converting USD to USD must not move the number. Got: ' + out);
+    }
+
+    @IsTest
+    static void convertWithNoSourceCurrencyLeavesTheAmountAlone() {
+        stubRates();
+        // No CurrencyIsoCode on the record: there is nothing to convert FROM, so
+        // the amount must pass through rather than have a rate invented for it.
+        Test.startTest();
+        String out = render('{Amount:currency:EUR:convert}', new Map<String, Object>{ 'Amount' => 100 });
+        Test.stopTest();
+        System.assert(out.contains('100'), 'no source currency means no conversion. Got: ' + out);
+    }
+
+    @IsTest
+    static void plainCurrencyFormsAreUnaffected() {
+        stubRates();
+        Test.startTest();
+        Map<String, Object> data = row(100, 'USD');
+        System.assert(render('{Amount:currency}', data).contains('100'), 'bare :currency unchanged');
+        System.assert(render('{Amount:currency:EUR}', data).contains('100'), 'ISO with no convert unchanged');
+        System.assert(render('{Amount:currency:EUR:de_DE}', data).contains('100'), 'ISO + locale unchanged');
+        Test.stopTest();
+    }
 }

--- a/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
@@ -751,6 +751,12 @@ public with sharing class DocGenGiantQueryAssembler implements Queueable {
                 if (csf != null) {
                     fieldPaths.add(csf);
                 }
+                // #297 — {Field:currency:X:convert} on a plain field converts from the
+                // record's own CurrencyIsoCode, so it must be queried and seeded into
+                // the miniMap the same way (schema validation drops it single-currency).
+                if (String.isNotBlank(m.group(2)) && DocGenCurrency.wantsConversion(m.group(2))) {
+                    fieldPaths.add('CurrencyIsoCode');
+                }
             }
 
             // Validate field paths against schema
@@ -875,6 +881,14 @@ public with sharing class DocGenGiantQueryAssembler implements Queueable {
                     String csf = currencyAutoSourceField(fmt);
                     if (csf != null && validFieldSet.contains(csf)) {
                         miniMap.put(csf, rec.get(csf));
+                    }
+                    // #297 — seed the record's own currency for {…:currency:X:convert}
+                    if (
+                        String.isNotBlank(fmt) &&
+                        DocGenCurrency.wantsConversion(fmt) &&
+                        validFieldSet.contains('CurrencyIsoCode')
+                    ) {
+                        miniMap.put('CurrencyIsoCode', rec.get('CurrencyIsoCode'));
                     }
                     try {
                         replacement = DocGenService.processXmlForTest('{' + path + ':' + fmt + '}', miniMap);

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -5954,6 +5954,36 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             return formatCurrencyDollarFallback(num);
         }
 
+        // `:convert` on a PLAIN field (#297).
+        //
+        // It worked on aggregates and nowhere else. On a plain field the segment
+        // landed in the LOCALE slot — `{Amount:currency:EUR:convert}` parsed
+        // `convert` as a locale name, failed to match one, and fell back to
+        // default separators. The symbol changed to € and the NUMBER did not
+        // move, so a $100 record rendered as "€100.00": a figure that is wrong
+        // by the exchange rate, in the currency it claims to be in, with nothing
+        // to indicate it. That is the worst shape a number bug can take in a
+        // document someone signs.
+        //
+        // Stripped before the locale slot is read, so it composes with every
+        // existing form: :currency:EUR:convert, :currency:EUR:de_DE:convert,
+        // :currency:auto:convert, :currency:auto=Field__c:convert.
+        // Reuses DocGenCurrency.wantsConversion / stripConvertSegment — the same
+        // parsing the aggregate path uses, so the two can never disagree about
+        // what `:convert` means.
+        if (DocGenCurrency.wantsConversion(String.join(segments, ':'))) {
+            segments = DocGenCurrency.stripConvertSegment(String.join(segments, ':')).split(':');
+            String fromIso = resolveCurrencyIso(data, null);
+            String targetIso = resolveConvertTarget(segments, data);
+            // No source or no target means there is nothing to convert BETWEEN.
+            // Leave the amount alone rather than inventing a rate — an
+            // unconverted number is wrong by a known amount; a guessed one is
+            // wrong by an unknown one.
+            if (String.isNotBlank(fromIso) && String.isNotBlank(targetIso) && fromIso != targetIso) {
+                num = DocGenCurrency.convert(num, fromIso, targetIso);
+            }
+        }
+
         String spec = segments[1].trim();
         String lowerSpec = spec.toLowerCase();
 
@@ -5973,6 +6003,28 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         String iso = spec.toUpperCase();
         String locale = segments.size() >= 3 ? segments[2].trim() : null;
         return formatCurrencyWithIso(num, iso, locale);
+    }
+
+    /**
+     * The ISO `:convert` should convert INTO, for a plain-field tag (#297).
+     *
+     * Mirrors how the segments are read below, so the target is whatever the tag
+     * would have formatted as: an explicit ISO, or the record's own code for the
+     * `auto` forms. Returns null when the tag names no currency at all, which is
+     * the case the caller treats as "nothing to convert between".
+     */
+    private static String resolveConvertTarget(List<String> segments, Map<String, Object> data) {
+        if (segments.size() < 2) {
+            return null;
+        }
+        String spec = segments[1].trim();
+        String lowerSpec = spec.toLowerCase();
+        if (lowerSpec == 'auto' || lowerSpec.startsWith('auto=')) {
+            String sourceField = lowerSpec == 'auto' ? null : spec.substring(spec.indexOf('=') + 1).trim();
+            return resolveCurrencyIso(data, sourceField);
+        }
+        String iso = spec.toUpperCase();
+        return CURRENCY_SYMBOLS.containsKey(iso) ? iso : null;
     }
 
     /** Backward-compat bare-:currency output: hardcoded $ with US separators. */

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -6330,7 +6330,14 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         } else if (fn == 'COUNT') {
             String countResult = String.valueOf(values.size());
             if (numberFormat != null && isNumericFormat(numberFormat)) {
-                return formatNumber(Decimal.valueOf(countResult), numberFormat, data);
+                // Strip `:convert` here too — the SUM/AVG/MIN/MAX path below does,
+                // and without it `{COUNT:Rel.Field:currency:EUR:convert}` leaks
+                // `convert` into the formatter's locale slot (#297).
+                return formatNumber(
+                    Decimal.valueOf(countResult),
+                    DocGenCurrency.stripConvertSegment(numberFormat),
+                    data
+                );
             }
             return countResult;
         } else {

--- a/scripts/e2e-07-syntax5.apex
+++ b/scripts/e2e-07-syntax5.apex
@@ -260,6 +260,47 @@ try {
     System.debug('CURRENCY AGG :convert WITH LOCALE: FAIL — ' + e.getMessage());
 }
 
+// #297 — :convert on a PLAIN field. The segment must be stripped before the
+// locale slot is read (else `convert` parses as a locale name and the number
+// formats with default separators under a changed currency symbol — silent
+// corruption). A record with no source currency passes through unconverted but
+// must still format as the target currency, not fall back to plain separators.
+try {
+    r = DocGenService.processXmlForTest(
+        '<w:t>{Amount:currency:EUR:convert}</w:t>',
+        new Map<String, Object>{ 'Amount' => 1234.5 }
+    );
+    if (r.contains('€') && r.contains('1,234.50') && !r.containsIgnoreCase('convert')) {
+        pass++;
+        System.debug('CURRENCY PLAIN :convert NO SOURCE PASSES THROUGH: PASS — ' + r);
+    } else {
+        fail++;
+        System.debug('CURRENCY PLAIN :convert NO SOURCE PASSES THROUGH: FAIL — ' + r);
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('CURRENCY PLAIN :convert NO SOURCE PASSES THROUGH: FAIL — ' + e.getMessage());
+}
+
+// #297 — :convert composes with an explicit locale on a plain field: the
+// segment is consumed and de_DE separators still apply.
+try {
+    r = DocGenService.processXmlForTest(
+        '<w:t>{Amount:currency:EUR:de_DE:convert}</w:t>',
+        new Map<String, Object>{ 'Amount' => 1234.5 }
+    );
+    if (r.contains('1.234,50') && !r.containsIgnoreCase('convert')) {
+        pass++;
+        System.debug('CURRENCY PLAIN :convert WITH LOCALE: PASS — ' + r);
+    } else {
+        fail++;
+        System.debug('CURRENCY PLAIN :convert WITH LOCALE: FAIL — ' + r);
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('CURRENCY PLAIN :convert WITH LOCALE: FAIL — ' + e.getMessage());
+}
+
 System.debug('========================================');
 System.debug(
     'E2E-07-SYNTAX5 — PASS: ' + pass + '  FAIL: ' + fail + (fail == 0 ? '  ALL TESTS PASSED' : '  FAILURES DETECTED')


### PR DESCRIPTION
Closes #297.

## For @untangleportwood — how to test this

Needs a **multi-currency org** with an active rate between two currencies.

1. Take a record whose `CurrencyIsoCode` is USD with an Amount of 100.
2. Put both of these in a template:
   ```
   {Amount:currency:EUR}
   {Amount:currency:EUR:convert}
   ```
3. **Before:** both print the **same number** with a euro symbol — `:convert` did nothing.
4. **After:** the second shows the converted figure; the first still shows 100.

Also worth checking: `{Amount:currency:auto:convert}`, `{Amount:currency:EUR:de_DE:convert}` (German separators *and* conversion), and that plain `{Amount:currency:EUR}` is unchanged.

If the org has **no active rate** between the two, you'll get a loud error telling you to add them under Setup → Manage Currencies. That's deliberate — see below.

## What was happening

`:convert` was implemented for aggregates and silently ignored everywhere else. On a plain field the segment landed in the **locale slot**: `convert` was parsed as a locale name, failed to match one, and formatted with default separators.

Measured against `main`, on a record holding **USD 100**:

```
{Amount:currency:EUR}          -> €100.00
{Amount:currency:EUR:convert}  -> €100.00   <-- identical; convert did nothing
{Amount:currency:auto:convert} -> $100.00
```

**The symbol changed and the number didn't.** A $100 record rendered as a euro figure that's wrong by the exchange rate, in the currency it claims to be in, with nothing in the document to indicate it. That's why this carries `severity:silent-corruption` rather than being a missing feature.

## The fix

Strips the segment before the locale slot is read, and converts from the record's own `CurrencyIsoCode` into the tag's target. Composes with every existing form: `:currency:EUR:convert`, `:currency:EUR:de_DE:convert`, `:currency:auto:convert`, `:currency:auto=Field__c:convert`.

Uses the existing `DocGenCurrency.wantsConversion` / `stripConvertSegment` rather than hand-rolling the parse — they already existed for the aggregate path, and sharing them means the two paths **cannot drift** on what `:convert` means. My first cut duplicated that logic; using the helpers is smaller and is why `:CONVERT` casing and `:EUR:de_DE:convert` work with no extra code.

**Deliberate edge-case choices:**
- **No source currency on the record** → the amount passes through unconverted rather than having a rate invented for it.
- **Source and target but no active rate** → `DocGenCurrency` throws its existing actionable error. Loud, and consistent with the aggregate path. Better a failed generation than a confident wrong number.

## Verification

`DocGenCurrencyTest` **18/18** on `docgen-verify`. Five new tests: the rate actually applying, composing with an explicit locale, converting to the record's own currency being a no-op, no-source-currency passing through, and a control that the three non-convert forms are untouched.

**Against `main` the two conversion tests fail (89% pass); with the fix they pass** — they defend the behaviour, not the implementation.

`npm run format:check` clean.

## Conflicts with #312

That PR adds an `:iso` segment to the same `formatCurrency`. The two compose conceptually — `:currency:SEK:iso:convert` should mean both — but touch adjacent lines. Whichever merges second needs a rebase, and the **combined form deserves a test** at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)