### PR TITLE
fix(lint): size-gate the DOCX fidelity report before CPU takes a save down

### DIFF
--- a/force-app/main/default/classes/DocGenDocxTemplateLinter.cls
+++ b/force-app/main/default/classes/DocGenDocxTemplateLinter.cls
@@ -47,6 +47,19 @@ public with sharing class DocGenDocxTemplateLinter {
      * failing check (or an unreadable archive) yields no findings from that
      * part, never an exception.
      */
+    /**
+     * Parts at or below this many characters are safe to lint. Above it, the
+     * report is skipped and says so — see the block comment in lint().
+     *
+     * Measured on a 423,598-char word/document.xml (the order of magnitude of a
+     * real long-form Word template): the full pass COMPLETES, but costs 2.7
+     * seconds of the 10,000 ms synchronous CPU budget — 27% of it, on a save
+     * that also has to insert a ContentVersion, re-query it, and finish
+     * saveTemplate. 200,000 keeps the report well inside a fifth of that.
+     */
+    @TestVisible
+    private static Integer maxLintChars = 200000;
+
     public static List<DocGenAiHtmlValidator.Finding> lint(Blob fileBytes) {
         List<DocGenAiHtmlValidator.Finding> findings = new List<DocGenAiHtmlValidator.Finding>();
         if (fileBytes == null) {
@@ -59,15 +72,51 @@ public with sharing class DocGenDocxTemplateLinter {
             // pair never appears to close across a part boundary it could not.
             for (Compression.ZipEntry e : reader.getEntries()) {
                 if (e.getName() == 'word/document.xml') {
-                    lintXml(reader.extract(e.getName()).toString(), true, findings);
+                    lintPart(reader.extract(e.getName()).toString(), true, findings);
                 } else if (e.getName().startsWith('ppt/slides/slide') && e.getName().endsWith('.xml')) {
-                    lintXml(reader.extract(e.getName()).toString(), false, findings);
+                    lintPart(reader.extract(e.getName()).toString(), false, findings);
                 }
             }
         } catch (Exception e) {
             String noop = e.getMessage(); // NOPMD — lint is advisory; one unreadable file must not sink the report
         }
         return findings;
+    }
+
+    /**
+     * Size gate (#317). MUST be a pre-check, not a try/catch.
+     *
+     * This report is advisory and is wrapped by its caller in
+     * `catch (Exception)` on the premise that it can never fail a save. That
+     * premise does not survive a governor limit: `System.LimitException` — CPU
+     * timeout included — is NOT caught by `catch (Exception)`, so it would
+     * escape, roll the transaction back, and take the author's upload with it.
+     * Exactly the failure #315 fixed on the HTML side, where the limit reached
+     * first was the regex budget rather than CPU.
+     *
+     * The DOCX patterns are anchored on a literal `<` and so fail fast per
+     * position; they do NOT hit the regex ceiling that the HTML validator does.
+     * What they do is spend real time: 2.7s on a 423KB document.xml. That is
+     * survivable alone and not survivable next to a slow neighbour, which is the
+     * whole argument for gating it rather than waiting for the first report.
+     */
+    private static void lintPart(String xml, Boolean isWordPart, List<DocGenAiHtmlValidator.Finding> findings) {
+        if (String.isNotBlank(xml) && xml.length() > maxLintChars) {
+            findings.add(
+                new DocGenAiHtmlValidator.Finding(
+                    'warning',
+                    'Template too large to check',
+                    1,
+                    'This template\'s XML is ' +
+                        xml.length() +
+                        ' characters, above the ' +
+                        maxLintChars +
+                        '-character limit for the fidelity report, so it was not checked. Your template uploaded normally and will generate normally — this is the report opting out, not a problem with your file.'
+                )
+            );
+            return;
+        }
+        lintXml(xml, isWordPart, findings);
     }
 
     private static void lintXml(String xml, Boolean isWordPart, List<DocGenAiHtmlValidator.Finding> findings) {

--- a/force-app/main/default/classes/DocGenDocxTemplateLinterTest.cls
+++ b/force-app/main/default/classes/DocGenDocxTemplateLinterTest.cls
@@ -447,4 +447,74 @@ private class DocGenDocxTemplateLinterTest {
             'non-Office uploads are outside this linter: ' + res.get('warnings')
         );
     }
+
+    // ─── #317: the size gate ─────────────────────────────────────────────────
+    //
+    // This report is advisory and its caller wraps it in catch (Exception) on
+    // the premise that it can never fail a save. That premise does not survive a
+    // governor limit — System.LimitException, CPU timeout included, is NOT
+    // caught by catch (Exception). Measured on a 423,598-char document.xml the
+    // pass COMPLETED but cost 2.7s of the 10,000ms budget, which is survivable
+    // alone and not survivable next to a slow neighbour.
+    //
+    // The gate has to be a pre-check for the same reason #315's does: you cannot
+    // catch your way out of an uncatchable exception.
+
+    /** A .docx whose word/document.xml is `target` characters or so. */
+    private static Blob docxWithBodyOfLength(Integer target) {
+        String para = '<w:p><w:r><w:t>Line item description for the reporting period</w:t></w:r></w:p>';
+        String body = '';
+        while (body.length() < target) {
+            body += para;
+        }
+        String xml =
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+            '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>' +
+            body +
+            '</w:body></w:document>';
+        Compression.ZipWriter zw = new Compression.ZipWriter();
+        zw.addEntry('word/document.xml', Blob.valueOf(xml));
+        return zw.getArchive();
+    }
+
+    @IsTest
+    static void oversizedPartSkipsTheReportInsteadOfBurningCpu() {
+        DocGenDocxTemplateLinter.maxLintChars = 5000;
+        Test.startTest();
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(docxWithBodyOfLength(30000));
+        Test.stopTest();
+
+        System.assertEquals(1, findings.size(), 'An oversized part reports exactly one advisory finding.');
+        System.assertEquals('Template too large to check', findings[0].rule, 'The gate must name itself.');
+        System.assert(
+            findings[0].detail.contains('uploaded normally'),
+            'The notice must tell the author their template still uploaded: ' + findings[0].detail
+        );
+    }
+
+    @IsTest
+    static void partUnderTheGateIsStillChecked() {
+        // Control for the gate: the same document below the threshold must still
+        // be linted, or the fix would have silently disabled the feature. This
+        // body has an unclosed loop, so a real finding is expected.
+        DocGenDocxTemplateLinter.maxLintChars = 200000;
+        String xml =
+            '<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+            '<w:body><w:p><w:r><w:t>{#Lines}</w:t></w:r></w:p></w:body></w:document>';
+        Compression.ZipWriter zw = new Compression.ZipWriter();
+        zw.addEntry('word/document.xml', Blob.valueOf(xml));
+
+        Test.startTest();
+        List<DocGenAiHtmlValidator.Finding> findings = DocGenDocxTemplateLinter.lint(zw.getArchive());
+        Test.stopTest();
+
+        Boolean gated = false;
+        for (DocGenAiHtmlValidator.Finding f : findings) {
+            if (f.rule == 'Template too large to check') {
+                gated = true;
+            }
+        }
+        System.assertEquals(false, gated, 'The gate must not fire under the threshold.');
+        System.assert(!findings.isEmpty(), 'An unclosed loop under the gate must still be reported.');
+    }
 }


### PR DESCRIPTION
Closes #317.

## For @untangleportwood — how to test this

1. Upload a **large** Word template — one whose `word/document.xml` is over ~200,000 characters. Check with:
   ```bash
   python3 -c "import zipfile; print(len(zipfile.ZipFile('yours.docx').read('word/document.xml')))"
   ```
2. **Before:** the upload works, but the fidelity report spends **2.7 seconds** of the 10-second CPU budget doing it.
3. **After:** it returns in **44 ms** with one advisory finding saying the template was too large to check and uploaded normally.
4. **No-regression:** a normal Word template (say 74 K `document.xml`) should still get its **full** report — unclosed loops, fragmented tags and all.

## Why it needed fixing before anyone reported it

Measured on a 423,598-char `document.xml`:

```
before:  2.7 SECONDS of the 10,000 ms synchronous CPU budget
after:      44 ms
```

That's **27% of the budget** on a save that also inserts a ContentVersion, re-queries it, and finishes `saveTemplate`. Survivable alone; not survivable next to a slow neighbour.

**The gate has to be a pre-check**, for the same reason #315's does: this report is advisory and its caller wraps it in `catch (Exception)` on the premise it can never fail a save — and `System.LimitException`, **CPU timeout included, is not caught by `catch (Exception)`**. You can't catch your way out of it; the transaction rolls back and the author's upload goes with it.

## Different mechanism from #315, same trap

The DOCX patterns are anchored on a literal `<` and fail fast per position, so they never hit the **regex** ceiling the HTML validator does. They just spend **time**. Two different limits, one uncatchable-exception problem.

## Verification

`DocGenDocxTemplateLinterTest` **22/22** on `docgen-verify` — 20 before, 2 new: the gate itself, and a control that an unclosed loop **under** the threshold is still reported, so the fix can't silently disable the feature.

Measured end-to-end against a real 423 K `document.xml` and a real 74 K one. `npm run format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)