### PR TITLE
fix(pptx): say PowerPoint cannot render to PDF instead of silently making a .pptx

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -285,6 +285,19 @@ Every path also asks for:
 - HTML (`.html` / `.htm` / `.zip`) template → output PDF only (see [§5.7](#57-html-templates-google-docs-notion-any-html-source))
 - PDF (`.pdf`) fillable template → output PDF only (PDF-to-PDF / AcroForm filling is currently in testing)
 - PowerPoint (`.pptx`) template → output PPTX only (PowerPoint→PDF is not supported by the Salesforce platform)
+
+> **⚠️ Changed in v3.57 — a PowerPoint template set to PDF now fails instead of quietly
+> producing a `.pptx`.** The Output Format picklist offers PDF for every template type,
+> but PowerPoint cannot render to it: `Blob.toPdf` only accepts Word source. Until v3.57
+> the value was read and then ignored — the generation reported success and handed back a
+> `.pptx`, with nothing to say the request had been dropped.
+>
+> It now errors, naming what to set instead. **If you have a PowerPoint template already
+> saved with Output Format = PDF, it will start failing on the next release.** Set its
+> Output Format to **Native (.pptx)**, or rebuild it as a Word or HTML template if you
+> genuinely need PDF output. Nothing else changes: PowerPoint templates set to Native are
+> unaffected.
+
 - Excel (`.xlsx` / `.xlsm`) template → output XLSX only (macro-enabled templates output `.xlsm`)
 
 > **One template → one output format.** Templates render in whatever format

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -11039,4 +11039,99 @@ private class DocGenMiscTests {
             'Macro-enabled template must save as .xlsm, got: ' + saved.PathOnClient
         );
     }
+
+    // ─── #336: PowerPoint + Output Format = PDF must SAY it cannot ───────────
+    //
+    // validateOutputFormatOverride already threw "PowerPoint templates cannot
+    // render to PDF" — but only when PDF arrived as an OVERRIDE argument. A
+    // template whose own Output_Format__c was PDF never reached that check: the
+    // value was read, ignored, and a .pptx came out with the generation
+    // reporting success. Two paths, the same impossible request, opposite
+    // handling.
+    //
+    // yuvraj hit exactly that: the picklist offered PDF, the record saved with
+    // PDF, and the output was silently something else.
+
+    /** A minimal .pptx with one slide, enough for the merge path to reach a format guard. */
+    private static void linkPptxToTemplate(Id tplId) {
+        Compression.ZipWriter zw = new Compression.ZipWriter();
+        zw.addEntry(
+            '_rels/.rels',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>'
+            )
+        );
+        zw.addEntry(
+            'ppt/slides/slide1.xml',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">' +
+                    '<p:cSld><p:spTree><p:sp><p:txBody><a:p xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">' +
+                    '<a:r><a:t>{Name}</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld></p:sld>'
+            )
+        );
+        linkWorkbookToTemplate(tplId, 'Deck.pptx', zw.getArchive());
+    }
+    @IsTest
+    static void powerPointTemplateWithPdfOutputSaysItCannot() {
+        DocGen_Template__c tpl = TestDataFactory.getTestTemplate();
+        tpl.Type__c = 'PowerPoint';
+        tpl.Output_Format__c = 'PDF';
+        tpl.Query_Config__c = 'Name';
+        Database.update(tpl, AccessLevel.SYSTEM_MODE);
+        linkPptxToTemplate(tpl.Id);
+        Account acc = TestDataFactory.getTestAccount();
+
+        Boolean threw = false;
+        String message = '';
+        Test.startTest();
+        try {
+            DocGenService.generateDocument(tpl.Id, acc.Id);
+        } catch (Exception e) {
+            threw = true;
+            message = e.getMessage();
+        }
+        Test.stopTest();
+
+        System.assertEquals(true, threw, 'A PowerPoint template asking for PDF must not silently produce a .pptx.');
+        System.assert(
+            message.contains('cannot render to PDF'),
+            'The error must name the actual limitation. Got: ' + message
+        );
+        System.assert(
+            message.contains('Native'),
+            'And it must say what to set instead, or the author is no better off. Got: ' + message
+        );
+    }
+
+    @IsTest
+    static void powerPointTemplateWithNativeOutputIsUnaffected() {
+        // Control: the supported combination must keep working. If this fails,
+        // the guard is too broad and has broken every PowerPoint template.
+        DocGen_Template__c tpl = TestDataFactory.getTestTemplate();
+        tpl.Type__c = 'PowerPoint';
+        tpl.Output_Format__c = 'Native';
+        tpl.Query_Config__c = 'Name';
+        Database.update(tpl, AccessLevel.SYSTEM_MODE);
+        linkPptxToTemplate(tpl.Id);
+        Account acc = TestDataFactory.getTestAccount();
+
+        Boolean threw = false;
+        Test.startTest();
+        try {
+            DocGenService.generateDocument(tpl.Id, acc.Id);
+        } catch (DocGenException e) {
+            // Any OTHER DocGenException is a fixture problem, not this guard —
+            // only fail on the one this change introduces.
+            if (e.getMessage().contains('cannot render to PDF')) {
+                threw = true;
+            }
+        } catch (Exception e) {
+            // Unrelated failure modes (missing file, etc.) are not what this asserts.
+        }
+        Test.stopTest();
+
+        System.assertEquals(false, threw, 'Native PowerPoint output must not trip the PDF guard.');
+    }
 }

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -706,6 +706,29 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             outputFormat = outputFormatOverride;
         }
 
+        // PowerPoint cannot render to PDF, and saying so is the whole fix (#336).
+        //
+        // validateOutputFormatOverride already throws "PowerPoint templates
+        // cannot render to PDF" — but ONLY when PDF arrives as an override
+        // argument. A template whose OWN Output_Format__c is PDF never reached
+        // that check: the value was read, ignored, and a .pptx came out with the
+        // generation reporting success.
+        //
+        // yuvraj hit exactly that and had no way to find out why: the picklist
+        // offered PDF, the record saved with PDF, and the output was silently
+        // something else. Two paths, the same impossible request, opposite
+        // handling — so the paths now agree.
+        //
+        // Deliberately an error rather than a silent correction to Native. The
+        // author asked for a PDF; handing them a .pptx and calling it success is
+        // what the report was about.
+        if (templateType == 'PowerPoint' && outputFormat == 'PDF') {
+            throw new DocGenException(
+                'PowerPoint templates cannot render to PDF. Set this template\'s Output Format to Native (.pptx), ' +
+                'or rebuild it as a Word or HTML template if you need PDF output.'
+            );
+        }
+
         // Designer live-preview: render caller-supplied draft HTML in place of
         // the saved body (HTML templates only). One-shot — cleared by the
         // controller in a finally block so it never leaks into a later merge.


### PR DESCRIPTION
Closes #336.

## For @untangleportwood — how to test this

1. Take a **PowerPoint** template and set its **Output Format** to **PDF**.
2. Generate.
3. **Before:** a `.pptx` comes out and the generation reports success. No indication anything was ignored.
4. **After:** a clear error — *"PowerPoint templates cannot render to PDF. Set this template's Output Format to Native (.pptx), or rebuild it as a Word or HTML template if you need PDF output."*
5. **No-regression:** a PowerPoint template with Output Format = **Native** must still generate normally.

⚠️ **Migration note:** any existing template already in this state will start failing instead of quietly producing `.pptx`. That's the point of the report — but it's worth knowing before release, since the failure is new even though the misconfiguration isn't.

## Root cause

The limitation is real and the code has said so since #117:

```apex
//   - PowerPoint templates cannot render to PDF (Blob.toPdf only handles Word source).
if (t.Type__c == 'PowerPoint' && outputFormatOverride == 'PDF') {
    throw new DocGenException('PowerPoint templates cannot render to PDF.');
}
```

**But that guard only fires when PDF arrives as an *override* argument.** A template whose own `Output_Format__c` is PDF never reached it — the value was read, ignored, and a `.pptx` came out reporting success. Two paths, the same impossible request, opposite handling.

yuvraj did nothing wrong: the picklist offered PDF, the record saved with PDF, and the output was silently something else. There was no way to discover the limitation short of asking in Slack — which is what happened.

## The choice made

**An error, not a silent correction to Native.** The author asked for a PDF; handing them a `.pptx` while reporting success *is* the bug. The message names what to set instead, so it's actionable where the silence wasn't.

## Verification

Two new tests in `DocGenMiscTests`: the impossible combination throwing with a message naming both the limitation **and** the fix, and a control that Native PowerPoint output is unaffected so the guard can't be too broad.

`DocGenControllerTests` **241/241** unchanged on `docgen-verify`. `npm run format:check` clean.

**Worth flagging:** my first cut of the test used a template with no file attached, so generation failed at *"No template file found"* before ever reaching the guard — a green-looking assertion that proved nothing. It now links a real minimal `.pptx` and exercises the actual path.

## Not in scope

Refusing the combination at **save time**, which the issue lists as its first option and which would stop a template being misconfigured at all. That's a controller/UI change — this makes the existing misconfiguration honest, including on records that already have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)