### PR TITLE
docs: state the RTL limitation in PDF output honestly

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -2590,6 +2590,11 @@ Or in tabular form for surveys / inspection forms (the inverse section `{^Field}
 - **Wingdings / Webdings glyphs** other than checkboxes — Flying Saucer can't render them at all. Portwood translates the common checkbox/check codepoints (Wingdings F0A8, F0FE, F0FD, F0FB, F0FC, F0A2; Wingdings 2 F050–F053, F0A3, F0A4); anything else falls back to a neutral □ placeholder.
 - **Emoji** (😀 🎉 etc.) — out of Arial Unicode MS coverage, render as tofu in PDF. Use the Unicode symbols above instead.
 - **Custom decorative fonts** (script, brand, etc.) — generate as DOCX and open in Word. See [§14.2](#142-pdf-font-limitations).
+- **Arabic, Hebrew and other right-to-left scripts in PDF output.** The glyphs are present in Arial Unicode MS, but the PDF engine applies neither of the two things RTL text needs, so the output is wrong in a way that is easy to miss if you don't read the script:
+    - **No contextual shaping.** Arabic letters change form depending on their neighbours. The engine draws one isolated glyph per character, so words come out as disconnected letterforms rather than joined script. Measured: the letter **ب** renders as the same glyph whether it is initial or medial.
+    - **No bidirectional reordering.** Characters are drawn in the order they appear in your file, left to right. `dir="rtl"` makes no difference — a PDF generated with it is byte-identical to one without.
+
+    **For RTL documents, generate as DOCX** and let Word do the shaping — that is why the same template looks correct in Word and wrong in PDF. Setting `font-family: 'Arial Unicode MS'` is still required for the glyphs to appear at all, but it does not fix the shaping or the direction.
 
 ### 7.15 Classic Approvals related list — `{#Approvals}` (v1.92+)
 


### PR DESCRIPTION
Documents #338. **No code change** — see below for why.

## What I measured

Rendered `مرحبا بالعالم` through `Blob.toPdf` in three font stacks, pulled the PDFs back, and decoded the content streams.

**Only Arial Unicode MS carries the glyphs:**

```
generic-sans        989 bytes    no embedded font       renders nothing
times               988 bytes    no embedded font       renders nothing
arial-unicode-ms  67,373 bytes   WOIVUD+ArialUnicodeMS  embedded
```

**But the font is not the fix**, because the engine then fails at both things RTL text needs:

**1. No contextual shaping.** 13 source characters → 13 glyphs, one each:

```
 pos  char  U+     glyph
   3   ب     0628   0xAC     <- medial in مرحبا
   6   ب     0628   0xAC     <- initial in بالعالم
```

Same glyph in both positions. In real Arabic those are different forms — words come out as disconnected letterforms.

**2. No bidirectional reordering.** Glyphs follow the source in **logical order, left to right**, and a paragraph carrying `dir="rtl"` produced output **byte-identical** to one without it. `dir` is ignored entirely.

## Why no code change

The shaping engine is simply absent. There is no configuration, font choice or markup an author can use to work around it — which is exactly what sachin.h732 was asking, and the honest answer is "not supported, use DOCX."

That's now in the UserGuide's *"What does NOT work"* list, naming both missing pieces, pointing RTL documents at DOCX output, and still noting that `Arial Unicode MS` is required for the glyphs to appear at all.

## This makes #299 much more valuable than it looks

**fontkit carries an OpenType layout engine (GSUB/GPOS)** — the shaping this path lacks. So #299 isn't "nicer fonts": it's **the only route to correct Arabic, Hebrew, Thai or Devanagari PDFs**. Commented there so it's weighed properly when prioritised.

#338 retitled and moved to Backlog as a documented limitation rather than a bug awaiting a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)