### PR TITLE
fix(signature): stop handing a PDF template to the ZIP reader

### DIFF
--- a/force-app/main/default/classes/DocGenGuidedSigningTest.cls
+++ b/force-app/main/default/classes/DocGenGuidedSigningTest.cls
@@ -654,4 +654,102 @@ private class DocGenGuidedSigningTest {
         DocGenSignatureService.purgeFrozenSnapshotCv(null);
         DocGenSignatureService.purgeFrozenSnapshotCv(cvId);
     }
+
+    // ─── #330: a PDF template must not be handed to the ZIP reader ───────────
+    //
+    // extractTemplatePlainText branched on isHtmlBacked, which is HTML-or-Canvas
+    // only, so every other type — INCLUDING PDF — fell through to the
+    // pre-decomposed word/document.xml lookup. A PDF is never decomposed into
+    // that, so the lookup found nothing and dropped to
+    // getActiveTemplateDocumentXml, which does:
+    //
+    //     new Compression.ZipReader(cvs[0].VersionData)
+    //
+    // A PDF is not a ZIP. Apex throws compression.ZipException "Could not load
+    // Zip", which is what elliottr saw from BOTH the sender LWC and the Flow
+    // action — both reach it through createGuidedPdfSignatureRequest.
+
+    /** A minimal fillable PDF: catalog -> AcroForm -> two text widgets. */
+    private static Blob fillableAcroFormPdf() {
+        return Blob.valueOf(
+            '%PDF-1.4\n' +
+                '1 0 obj\n<< /Type /Catalog /Pages 2 0 R /AcroForm 3 0 R >>\nendobj\n' +
+                '2 0 obj\n<< /Type /Pages /Kids [4 0 R] /Count 1 >>\nendobj\n' +
+                '3 0 obj\n<< /Fields [5 0 R 6 0 R] >>\nendobj\n' +
+                '4 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Annots [5 0 R 6 0 R] >>\nendobj\n' +
+                '5 0 obj\n<< /FT /Tx /T (Name) /Subtype /Widget /Rect [10 10 200 30] >>\nendobj\n' +
+                '6 0 obj\n<< /FT /Tx /T (Owner.Email) /Subtype /Widget /Rect [10 40 200 60] /V (old) >>\nendobj\n' +
+                'xref\n0 7\n0000000000 65535 f \n0000000009 00000 n \n0000000076 00000 n \n' +
+                '0000000135 00000 n \n0000000184 00000 n \n0000000281 00000 n \n0000000357 00000 n \n' +
+                'trailer\n<< /Size 7 /Root 1 0 R >>\nstartxref\n0\n%%EOF\n'
+        );
+    }
+
+    private static DocGen_Template__c pdfTemplateWithBody(Blob body) {
+        DocGen_Template__c t = new DocGen_Template__c(
+            Name = 'PdfSig330',
+            Type__c = 'PDF',
+            Base_Object_API__c = 'Account',
+            Output_Format__c = 'PDF',
+            Query_Config__c = 'Name'
+        );
+        insert t;
+        ContentVersion cv = new ContentVersion(Title = 'pdf330', PathOnClient = 'pdf330.pdf', VersionData = body);
+        insert cv;
+        ContentVersion r = [SELECT Id, ContentDocumentId FROM ContentVersion WHERE Id = :cv.Id LIMIT 1];
+        insert new DocGen_Template_Version__c(
+            Template__c = t.Id,
+            Is_Active__c = true,
+            Content_Version_Id__c = r.Id,
+            Type__c = 'PDF'
+        );
+        insert new ContentDocumentLink(LinkedEntityId = t.Id, ContentDocumentId = r.ContentDocumentId, ShareType = 'V');
+        return t;
+    }
+
+    @IsTest
+    static void pdfTemplatePlacementScanDoesNotUnzipThePdf() {
+        DocGen_Template__c t = pdfTemplateWithBody(fillableAcroFormPdf());
+
+        Test.startTest();
+        List<DocGenSignatureSenderController.PlacementInfo> placements;
+        try {
+            placements = DocGenSignatureSenderController.getTemplateSignaturePlacements(t.Id);
+        } catch (Exception e) {
+            System.assert(
+                false,
+                'A PDF template must never reach the ZIP reader. Got: ' + e.getTypeName() + ' :: ' + e.getMessage()
+            );
+        }
+        Test.stopTest();
+
+        // A PDF positions signatures through AcroForm fields, not {@Signature_*}
+        // text tags, so "no text placements" is the correct answer here.
+        System.assertEquals(0, placements == null ? 0 : placements.size(), 'A PDF has no text-tag placements.');
+    }
+
+    @IsTest
+    static void signatureRequestSucceedsForAFillablePdfTemplate() {
+        DocGen_Template__c t = pdfTemplateWithBody(fillableAcroFormPdf());
+        Account a = new Account(Name = 'Acme 330');
+        insert a;
+        String signers = '[{"name":"Ada Test","email":"ada@example.com","roleName":"Signer 1","order":1}]';
+
+        Test.startTest();
+        List<DocGenSignatureSenderController.SignerResult> res;
+        try {
+            res = DocGenSignatureSenderController.createGuidedPdfSignatureRequest(
+                t.Id,
+                a.Id,
+                signers,
+                'Sequential',
+                null
+            );
+        } catch (Exception e) {
+            System.assert(false, 'Signature request on a PDF template threw: ' + e.getMessage());
+        }
+        Test.stopTest();
+
+        System.assertEquals(1, res == null ? 0 : res.size(), 'One signer in, one signer link out.');
+    }
 }

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -223,6 +223,36 @@ public with sharing class DocGenSignatureSenderController {
             return null;
 
         DocGen_Template_Version__c activeVersion = activeVersions[0];
+
+        // A PDF template has no WordprocessingML to scan, and must never reach the
+        // DOCX branch below (#330).
+        //
+        // The type test here is isHtmlBacked, which is HTML-or-Canvas only, so
+        // every other type — including PDF — fell through to the pre-decomposed
+        // word/document.xml lookup. A PDF is never decomposed into that, so the
+        // lookup found nothing and dropped to getActiveTemplateDocumentXml, which
+        // does:
+        //
+        //     new Compression.ZipReader(cvs[0].VersionData)
+        //
+        // A PDF is not a ZIP. Apex throws compression.ZipException "Could not
+        // load Zip", which is exactly what elliottr saw from BOTH the sender LWC
+        // and the Flow action — both reach here through
+        // createGuidedPdfSignatureRequest:
+        //
+        //   "when using either the docGenSignatureSender lwc or the DocGen:
+        //    Create Signature Request action in a flow I get the error:
+        //    'Error generating links: Could not load Zip Error on ZipFile
+        //    unknown archive'"
+        //
+        // Returning null means "no {@Signature_*} text tags", which is true: a
+        // PDF template positions signatures through its AcroForm fields, not
+        // through tags in a text stream. The caller already handles an empty
+        // placement list.
+        if (activeVersion.Template__r.Type__c == 'PDF') {
+            return null;
+        }
+
         if (DocGenService.isHtmlBacked(activeVersion.Template__r.Type__c)) {
             if (String.isBlank(activeVersion.Content_Version_Id__c))
                 return null;


### PR DESCRIPTION
Closes #330.

## For @untangleportwood — how to test this

1. Create a **PDF** template from a **fillable** PDF (Acrobat AcroForm).
2. Send it for signature — from the **`docGenSignatureSender` LWC** *and* from the **`DocGen: Create Signature Request`** Flow action. Both paths matter; both were broken.
3. **Before:** *"Error generating links: Could not load Zip Error on ZipFile unknown archive"*.
4. **After:** signature links generate.
5. Also worth trying a **non-fillable** PDF — that should now fail with *"PDF does not contain a reference-based AcroForm"*, which is correct and actionable.

No-regression: Word, HTML and Canvas templates should send for signature exactly as before.

## Root cause

Both entry points reach `createGuidedPdfSignatureRequest` → `getTemplateSignaturePlacements` → `extractTemplatePlainText`, which branches on:

```apex
if (DocGenService.isHtmlBacked(activeVersion.Template__r.Type__c))
```

**`isHtmlBacked` is HTML-or-Canvas only.** Every other type — including PDF — falls into the DOCX branch, which looks for a pre-decomposed `word/document.xml`. A PDF is never decomposed into one, so the lookup returns nothing and drops to `getActiveTemplateDocumentXml`:

```apex
new Compression.ZipReader(cvs[0].VersionData)
```

A PDF is not a ZIP. Confirmed in a scratch org that Apex throws exactly `compression.ZipException: Could not load Zip` for a PDF blob — elliottr's message.

## The fix

Return null early for `Type__c == 'PDF'`. **Not a workaround:** a PDF template positions signatures through its **AcroForm fields**, not through `{@Signature_*}` tags in a text stream — so *"no text-tag placements"* is the true answer, and the caller already handles an empty list.

## Verified against a real fillable PDF, not just the crash

```
main       ->  compression.ZipException :: Could not load Zip
with fix   ->  FILLABLE PDF TEMPLATE -> REQUEST OK, signers=1
```

This doesn't merely swap one error for another — **a fillable PDF template now generates signature links**, which is what elliottr was trying to do.

**Worth recording the intermediate state:** with the guard in place but tested against a *plain* PDF (`Blob.toPdf` output, no AcroForm), the flow fails with *"PDF does not contain a reference-based AcroForm"* — correct and actionable. So a non-fillable PDF is still refused, and now says why. I nearly stopped at that result and called the fix done; testing with an actual AcroForm is what showed the full path works.

## Verification

2 new tests in `DocGenGuidedSigningTest` — the placement scan not throwing on a PDF, and the full request succeeding for a fillable AcroForm template. **17/17** on `docgen-verify`. `npm run format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)