### PR TITLE
fix(parser): make the malformed-inverse-tag error readable

### DIFF
--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -3606,6 +3606,47 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         return mergeRunsInTags(xml);
     }
 
+    /**
+     * A malformed-inverse-tag message a human can act on (#327).
+     *
+     * The old message interpolated the raw key, and when Word has split the tag
+     * across formatting runs that key IS MARKUP — the whole
+     * `</w:t></w:r><w:r><w:rPr>…` blob lands in the middle of the sentence. jlay
+     * reported it as:
+     *
+     *   (Malformed inverse tag: missing closing "" for "" opened near
+     *    "/><w:color w:val="000000"/></w:rPr><w:t></w:t></w:r><w".)
+     *
+     * The quotes look EMPTY because the XML inside them was stripped in transit.
+     * Reproduced: an un-defragmented `{^Optional__c}` produces exactly that
+     * shape, so the report was a split tag all along — the message just made it
+     * unreadable, which cost a round trip to work out.
+     *
+     * Now: strip the markup, reconstruct what the author typed, and say what to
+     * do about it. A key that still contains '<' after stripping means the tag
+     * was split, which is a different fix from a genuinely missing closer.
+     */
+    private static String describeMalformedInverseTag(String key, String snippet, String lineInfo) {
+        String visible = key == null ? '' : key.replaceAll('<[^>]*>', '').trim();
+        Boolean wasSplit = key != null && key.contains('<');
+        if (wasSplit) {
+            return 'The inverse tag {^' +
+                visible +
+                '} is split across formatting runs' +
+                lineInfo +
+                ', so the merge engine cannot read it as one tag. Delete the whole tag in Word and retype it in one go, without backspacing or changing formatting mid-tag.';
+        }
+        return 'Malformed inverse tag: missing closing "{/' +
+            visible +
+            '}" for "{^' +
+            visible +
+            '}"' +
+            lineInfo +
+            '. Add the closing tag, or check it is inside the same table row — opened near "' +
+            snippet.replaceAll('<[^>]*>', ' ').replaceAll('\\s+', ' ').trim() +
+            '".';
+    }
+
     private static String mergeRunsInTags(String xml) {
         // De-fragment split merge tags first (so a {RepeatHeader} broken across runs is
         // contiguous), then apply the structural {RepeatHeader} → <w:tblHeader/> pass.
@@ -4349,17 +4390,7 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                         String lineInfo = currentTemplateType == 'HTML'
                             ? ' (line ' + (xml.substring(0, tagStartPos).countMatches('\n') + 1) + ')'
                             : '';
-                        throw new DocGenException(
-                            'Malformed inverse tag: missing closing "{/' +
-                                key +
-                                '}" for "{^' +
-                                key +
-                                '}"' +
-                                lineInfo +
-                                ' opened near "' +
-                                snippet +
-                                '".'
-                        );
+                        throw new DocGenException(describeMalformedInverseTag(key, snippet, lineInfo));
                     } else {
                         Integer contentStart = tagClose + 1;
                         Integer contentEnd = sectionEnd;

--- a/scripts/e2e-07-syntax5.apex
+++ b/scripts/e2e-07-syntax5.apex
@@ -260,6 +260,49 @@ try {
     System.debug('CURRENCY AGG :convert WITH LOCALE: FAIL — ' + e.getMessage());
 }
 
+// ── #327: a split inverse tag must name the tag, not dump XML ───────────────
+// jlay's report was unreadable because the message interpolated the raw key,
+// and when Word splits a tag that key IS markup. The quotes looked empty
+// because the XML inside them was stripped in transit.
+try {
+    String splitXml =
+        '<w:tbl><w:tr><w:tc><w:p><w:r><w:t>{#Lines}{^</w:t></w:r>' +
+        '<w:r><w:rPr><w:color w:val="000000"/></w:rPr><w:t></w:t></w:r>' +
+        '<w:r><w:t>Optional__c}</w:t></w:r></w:p></w:tc>' +
+        '<w:tc><w:p><w:r><w:t>{/Optional__c}{/Lines}</w:t></w:r></w:p></w:tc></w:tr></w:tbl>';
+    DocGenService.processXmlForTest(
+        splitXml,
+        new Map<String, Object>{ 'Lines' => new List<Object>{ new Map<String, Object>{ 'Optional__c' => false } } }
+    );
+    fail++;
+    System.debug('SPLIT INVERSE TAG: FAIL — expected a DocGenException');
+} catch (Exception e) {
+    String m = e.getMessage();
+    if (m.contains('{^Optional__c}') && m.contains('split across formatting runs') && !m.contains('<w:')) {
+        pass++;
+        System.debug('SPLIT INVERSE TAG: PASS — names the tag, no raw XML');
+    } else {
+        fail++;
+        System.debug('SPLIT INVERSE TAG: FAIL — got [' + m.left(160) + ']');
+    }
+}
+
+// A genuinely missing closer must still say so, and stay readable.
+try {
+    DocGenService.processXmlForTest('<p>{^Optional__c}body</p>', new Map<String, Object>());
+    fail++;
+    System.debug('MISSING INVERSE CLOSER: FAIL — expected a DocGenException');
+} catch (Exception e) {
+    String m = e.getMessage();
+    if (m.contains('{/Optional__c}') && !m.contains('<w:') && !m.contains('split across')) {
+        pass++;
+        System.debug('MISSING INVERSE CLOSER: PASS — asks for the closing tag');
+    } else {
+        fail++;
+        System.debug('MISSING INVERSE CLOSER: FAIL — got [' + m.left(160) + ']');
+    }
+}
+
 System.debug('========================================');
 System.debug(
     'E2E-07-SYNTAX5 — PASS: ' + pass + '  FAIL: ' + fail + (fail == 0 ? '  ALL TESTS PASSED' : '  FAILURES DETECTED')


### PR DESCRIPTION
Addresses #327 — **the message, not the root cause.** Read the scope note before merging.

## What jlay saw

```
(Malformed inverse tag: missing closing "" for "" opened near
 "/><w:color w:val="000000"/></w:rPr><w:t></w:t></w:r><w".)
```

**The quotes look empty. They aren't.** The message interpolated the raw key — and when Word has split a tag across formatting runs, that key *is markup*. The whole `</w:t></w:r><w:r><w:rPr>…` blob landed inside the sentence and was stripped in transit to Slack, leaving `""`.

Reproduced exactly: an un-defragmented `{^Optional__c}` produces a message of that precise shape.

**So the report was a split tag all along.** My earlier comment on the issue talked myself out of that reading and was wrong — what made it hard to see was the message itself.

## After

The two causes need different fixes, so they now read differently:

| cause | message |
|---|---|
| **split** | *"The inverse tag `{^Optional__c}` is split across formatting runs, so the merge engine cannot read it as one tag. Delete the whole tag in Word and retype it in one go, without backspacing or changing formatting mid-tag."* |
| **no closer** | *"Malformed inverse tag: missing closing `{/Flag}` for `{^Flag}`. Add the closing tag, or check it is inside the same table row — opened near `head {^Flag} hidden body`."* |

The `opened near` snippet is stripped of markup too, so it shows the author's text instead of XML.

## ⚠️ Scope — what this does NOT fix

**I could not reproduce the underlying failure.** `mergeRunsInTags` heals a split inverse tag in every shape I could construct — within a `<w:p>`, across two `<w:p>`, across two `<w:tc>` — and Word calls it on the main merge path. A contiguous inverse tag inside a loop row works fine. Every pre-decomposed `document.xml` read I audited is followed by `mergeRunsInTags`.

So jlay's template reaches a path where de-fragmentation doesn't run, or splits in a shape I haven't built. **Reproducing it needs his template.**

This is the honest half: whoever hits it next is told exactly which of the two problems they have, and if it's the split case they're told how to fix their template today. #327 should stay open for the root cause.

## Verification

2 new assertions in `e2e-07-syntax5` — a split tag naming the tag with no raw XML, and a genuinely missing closer still asking for the closing tag.

`syntax5` **12/0**, plus `syntax1` 35/0, `syntax2` 31/0, `syntax3` 18/0, `syntax4` 20/0.

**`syntax4` caught a real contract:** it asserts the message contains `opened near`, and my first wording capitalised it mid-rewrite. I reworded rather than changing the assertion — the existing contract is the one worth keeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)