### PR TITLE
fix(canvas): a cleared rich-text box serializes empty, not its stale text (#295)

### DIFF
--- a/force-app/main/default/lwc/docGenCanvas/canvasModel.js
+++ b/force-app/main/default/lwc/docGenCanvas/canvasModel.js
@@ -1931,9 +1931,18 @@ function textToHtml(box) {
     // A box edited in the rich-text editor carries `html`, and that is what the author
     // actually sees. Serializing `text` here meant every bold, bullet and colour was
     // dropped on the way to the PDF while the canvas kept showing them — the editor
-    // silently stopped being WYSIWYG. `text` remains the fallback for boxes authored
-    // before the rich-text editor existed, and for a box whose html was cleared.
-    if (box.html != null && String(box.html).trim() !== '') {
+    // silently stopped being WYSIWYG. `text` remains the fallback ONLY for boxes
+    // authored before the rich-text editor existed (html == null) and never carries
+    // the live content once the editor has touched a box.
+    //
+    // html == '' is "the author cleared the box" — the editor writes an empty string on
+    // delete — and must serialize to nothing. Falling through to `text` there resurfaces
+    // stale content (the pre-edit import, or the literal placeholder 'Text'), which the
+    // canvas shows as empty so the loss is invisible until the PDF renders. See #295.
+    if (box.html != null) {
+        if (String(box.html).trim() === '') {
+            return ''; // authored-empty is empty — never resurrect `text`
+        }
         // Guarded so the serializer stays runnable without a DOM — scripts/qa/
         // canvas-serializer-check.mjs is a pure-Node guard on exactly these rules, and
         // a serializer that only runs in a browser cannot be checked before it ships.

--- a/scripts/qa/canvas-serializer-check.mjs
+++ b/scripts/qa/canvas-serializer-check.mjs
@@ -59,6 +59,14 @@ const rich = m.newTextBox(0.5, 5.2, 3, 0.4);
 rich.html = '<p><b>Rich</b> text with {Owner.Name} and a &#123;braced&#125; entity</p>';
 doc.artboards[0].boxes.push(rich);
 
+// #295: an author clearing a box in the rich-text editor writes html='' (not null).
+// That must serialize to nothing — falling through to `text` would resurrect stale
+// content the canvas shows as empty (the pre-edit import, or the 'Text' placeholder).
+const cleared = m.newTextBox(0.5, 5.6, 3, 0.4);
+cleared.html = '';
+cleared.text = 'STALE-CLEARED-BOX';
+doc.artboards[0].boxes.push(cleared);
+
 const logo = m.newImageBox(0.5, 0.2, 1.5, 0.75);
 logo.image.src = '/sfc/servlet.shepherd/version/download/068000000000001';
 logo.image.keepRatio = true;
@@ -288,6 +296,9 @@ const checks = [
     // showing what a format suffix looks like, and decoding it would turn the example
     // into a live merge tag that prints the record's data.
     ['escaped braces are NOT turned into live tags', /&#123;braced&#125;|&amp;#123;/.test(html)],
+    // #295: an empty html='' is authored-empty, not "fall back to text". The stale
+    // `text` on a cleared box must never serialize into the document.
+    ['a cleared box serializes empty, not its stale text', !html.includes('STALE-CLEARED-BOX')],
 
     // --- Images ------------------------------------------------------------
     // Flying Saucer computes a replaced element's size ONCE PER URL, so the same image


### PR DESCRIPTION
Fixes #295 — clearing a Canvas text box in the rich-text editor does not empty it; the box reverts to whatever text held before it was ever edited (the imported original, or the literal placeholder Text). The canvas shows empty; the old content reappears in the generated PDF.

## Root cause

The serializer's textToHtml used a box's html unless it was empty-string. An emptied rich-text editor writes html='' which falls through to the stale text fallback. text is set once and never updated by the UI (all six write sites target html), so it is stale by construction.

## Fix

Treat html === '' as authored-empty and return '', reserving the text fallback for html == null only (legacy boxes authored before the rich-text editor existed). Legacy boxes stay on their current path; only an edited box changes behavior.

## Verification

- Regression check added to `canvas-serializer-check.mjs`: a box with `html=''` and `text='STALE-CLEARED-BOX'` must not serialize the stale text. Confirmed it **fails against the pre-fix model** (1 FAILED) and passes with the fix — it defends the contract, not the implementation.
- Full serializer guard green (77 checks on this branch); Prettier clean on both files.

## Scope

`canvasModel.js` (`textToHtml`) + `canvas-serializer-check.mjs`. No other callsites touched.