### PR TITLE
fix(retriever): say when a child relationship is dropped (#332)

### DIFF
--- a/force-app/main/default/classes/DocGenDataRetriever.cls
+++ b/force-app/main/default/classes/DocGenDataRetriever.cls
@@ -38,6 +38,39 @@ public with sharing class DocGenDataRetriever {
     }
 
     /**
+     * Records that a child or grandchild relationship was dropped from the merge data
+     * because its query could not run for the running user.
+     *
+     * Every child query here runs in USER_MODE, which throws when the running user
+     * lacks FLS on any field in the select list — so a user who can see and edit the
+     * records perfectly well in the UI still loses the entire relationship if one
+     * field in Query Config is invisible to them. The catch that follows each query
+     * turns that into "this relationship has no records": the loop renders nothing,
+     * generation reports success, and nobody is told (#332).
+     *
+     * The drop itself is deliberate — a partial document beats a failed one, and
+     * changing that would break templates that render acceptably today. What was
+     * missing is the trace. Buffered by DocGenErrorLogger and flushed once at the end
+     * of generateDocument, so a template with many child nodes cannot spend the DML
+     * limit on diagnostics.
+     */
+    private static void logDroppedRelationship(String relationshipKey, String objectApiName, Exception cause) {
+        DocGenErrorLogger.warn(
+            'DocGenDataRetriever',
+            'childQuery',
+            'Relationship "' +
+                relationshipKey +
+                '" (' +
+                objectApiName +
+                ') was dropped from the document: its query failed for the running user, ' +
+                'so the loop rendered no rows. This is usually field-level security on a ' +
+                'field in Query Config — the user can often still see the records themselves. ' +
+                'Underlying error: ' +
+                (cause == null ? 'unknown' : cause.getMessage())
+        );
+    }
+
+    /**
      * Returns the query config version (1, 2, or 3) for a given fieldsConfig string.
      * Used by DocGenBatch to decide whether bulk caching is available.
      */
@@ -967,7 +1000,8 @@ public with sharing class DocGenDataRetriever {
                         }
                     }
                 } catch (Exception e) {
-                    // ProcessInstance subquery failed — skip this child relationship
+                    // ProcessInstance subquery failed — skip this child relationship (#332)
+                    logDroppedRelationship(child.dataMapKey(), child.objectApiName, e);
                     continue;
                 }
             } else {
@@ -993,7 +1027,11 @@ public with sharing class DocGenDataRetriever {
 
                     childResults = Database.query(childQuery, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection — all dynamic elements allowlist-validated against Schema.describeSObjects() field map; USER_MODE enforced
                 } catch (Exception e) {
-                    // Child query failed — skip this child relationship
+                    // Child query failed — skip this child relationship, but leave a
+                    // trace. USER_MODE throws when the running user lacks FLS on any
+                    // select-list field, so this is the common "the table is empty for
+                    // one user and fine for the admin" report (#332).
+                    logDroppedRelationship(child.dataMapKey(), child.objectApiName, e);
                     continue;
                 }
             }
@@ -1144,7 +1182,8 @@ public with sharing class DocGenDataRetriever {
                         }
                     }
                 } catch (Exception e) {
-                    // ProcessInstance bulk subquery failed — skip this child relationship
+                    // ProcessInstance bulk subquery failed — skip this child relationship (#332)
+                    logDroppedRelationship(child.dataMapKey(), child.objectApiName, e);
                     continue;
                 }
             } else {
@@ -1197,7 +1236,8 @@ public with sharing class DocGenDataRetriever {
 
                     childResults = Database.query(childQuery, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection — all dynamic elements allowlist-validated against Schema.describeSObjects() field map; USER_MODE enforced
                 } catch (Exception e) {
-                    // Bulk child query failed — skip this child relationship
+                    // Bulk child query failed — skip this child relationship (#332)
+                    logDroppedRelationship(child.dataMapKey(), child.objectApiName, e);
                     continue;
                 }
             }
@@ -1782,7 +1822,8 @@ public with sharing class DocGenDataRetriever {
                 try {
                     piResults = Database.query(piQuery, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection — all dynamic elements allowlist-validated against Schema.describeSObjects() field map; USER_MODE enforced
                 } catch (Exception e) {
-                    // ProcessInstance subquery failed — skip this relationship
+                    // ProcessInstance subquery failed — skip this relationship (#332)
+                    logDroppedRelationship(grandchildSpec.relationshipName, grandchildSpec.childObjectApiName, e);
                     continue;
                 }
 
@@ -1816,7 +1857,8 @@ public with sharing class DocGenDataRetriever {
                 try {
                     gcResults = Database.query(gcQuery, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection — all dynamic elements allowlist-validated against Schema.describeSObjects() field map; USER_MODE enforced
                 } catch (Exception e) {
-                    // Grandchild query failed — skip this relationship
+                    // Grandchild query failed — skip this relationship (#332)
+                    logDroppedRelationship(grandchildSpec.relationshipName, grandchildSpec.childObjectApiName, e);
                     continue;
                 }
             }

--- a/force-app/main/default/classes/DocGenRetrieverSilentDropTest.cls
+++ b/force-app/main/default/classes/DocGenRetrieverSilentDropTest.cls
@@ -1,0 +1,184 @@
+/**
+ * #332 — a child relationship the running user cannot fully read is dropped from the
+ * merge data, and the document still generates. That part is deliberate: a partial
+ * document beats a failed one. What was wrong is that it happened with no exception,
+ * no log, and no signal of any kind, so a Care Plan missing half its Goal Assignments
+ * looked exactly like a complete one.
+ *
+ * Every child query in DocGenDataRetriever runs in USER_MODE, which throws when the
+ * running user lacks FLS on ANY field in the select list. Six catch blocks turned that
+ * into "this relationship has no records" — in a 2,449-line class with zero logging.
+ *
+ * These tests pin both halves of the contract:
+ *   - the drop still happens, and generation still succeeds (PROOF 1-3)
+ *   - it now leaves a Warning row naming the relationship and the cause (PROOF 4)
+ *   - a healthy generation stays quiet, so the log does not become noise
+ *
+ * Note the V1 flat-config path does NOT behave this way — it surfaces a DocGenException
+ * for the same misconfiguration. The inconsistency between V1 and V3 is why this went
+ * unnoticed; only the V3 node-tree path is silent, and that is the path exercised here.
+ */
+@IsTest
+private class DocGenRetrieverSilentDropTest {
+    /**
+     * Minimum-access user granted object Read on Account + Contact, but NO field
+     * permissions. Wrapped in runAs(current user) so the setup-object DML does not
+     * trip MIXED_DML_OPERATION against the Account/Contact inserts.
+     */
+    private static User buildRestrictedUser() {
+        Profile p = [SELECT Id FROM Profile WHERE Name = 'Minimum Access - Salesforce' LIMIT 1];
+        User u = new User(
+            FirstName = 'Silent',
+            LastName = 'Drop',
+            Email = 'silentdrop@portwood.test',
+            Username = 'silentdrop-' + DateTime.now().getTime() + '@portwood.test',
+            Alias = 'sdrop',
+            ProfileId = p.Id,
+            TimeZoneSidKey = 'America/New_York',
+            LocaleSidKey = 'en_US',
+            EmailEncodingKey = 'UTF-8',
+            LanguageLocaleKey = 'en_US'
+        );
+        insert u;
+
+        PermissionSet ps = new PermissionSet(Name = 'DG332Probe', Label = 'DG332 Probe');
+        insert ps;
+        insert new List<ObjectPermissions>{
+            new ObjectPermissions(
+                ParentId = ps.Id,
+                SobjectType = 'Account',
+                PermissionsRead = true,
+                PermissionsViewAllRecords = true
+            ),
+            new ObjectPermissions(
+                ParentId = ps.Id,
+                SobjectType = 'Contact',
+                PermissionsRead = true,
+                PermissionsViewAllRecords = true
+            )
+        };
+        insert new PermissionSetAssignment(AssigneeId = u.Id, PermissionSetId = ps.Id);
+        return u;
+    }
+
+    @IsTest
+    static void childRelationshipIsDroppedSilentlyWhenAFieldIsNotReadable() {
+        User restricted;
+        System.runAs(new User(Id = UserInfo.getUserId())) {
+            restricted = buildRestrictedUser();
+        }
+
+        Account a = new Account(Name = 'Care Plan Account');
+        insert a;
+        insert new List<Contact>{
+            new Contact(LastName = 'Goal One', AccountId = a.Id, Email = 'g1@portwood.test'),
+            new Contact(LastName = 'Goal Two', AccountId = a.Id, Email = 'g2@portwood.test'),
+            new Contact(LastName = 'Goal Three', AccountId = a.Id, Email = 'g3@portwood.test')
+        };
+
+        // V3 node-tree config — the format that routes through processChildNodes and
+        // the catch at DocGenDataRetriever.cls:995. Selects Contact.Email, which is
+        // object-readable but NOT field-readable for this user.
+        String config =
+            '{"v":3,"nodes":[' +
+            '{"id":"root","object":"Account","fields":["Name"]},' +
+            '{"id":"kids","object":"Contact","parentNode":"root","lookupField":"AccountId",' +
+            '"relationshipName":"Contacts","fields":["LastName","Email"]}' +
+            ']}';
+
+        Map<String, Object> asAdmin = DocGenDataRetriever.getRecordData(a.Id, 'Account', config);
+        Map<String, Object> adminKids = (Map<String, Object>) asAdmin.get('Contacts');
+        Integer adminCount = (Integer) adminKids.get('totalSize');
+        System.assertEquals(3, adminCount, 'Admin baseline: all three child rows present');
+
+        Map<String, Object> asRestricted;
+        String caught = null;
+        Integer visibleToUser = -1;
+        Test.startTest();
+        System.runAs(restricted) {
+            // The user CAN see the child records — exactly craig's report.
+            visibleToUser = [SELECT COUNT() FROM Contact WHERE AccountId = :a.Id];
+
+            try {
+                asRestricted = DocGenDataRetriever.getRecordData(a.Id, 'Account', config);
+            } catch (Exception e) {
+                caught = e.getTypeName() + ' — ' + e.getMessage();
+            }
+        }
+        Test.stopTest();
+
+        System.assertEquals(3, visibleToUser, 'Restricted user can see all three children in a plain query');
+        System.assertEquals(null, caught, 'PROOF 1: generation does not fail — no error reaches the caller');
+
+        Object kidsRaw = asRestricted.get('Contacts');
+        Integer restrictedCount = kidsRaw == null ? -1 : (Integer) ((Map<String, Object>) kidsRaw).get('totalSize');
+
+        System.assertNotEquals(
+            3,
+            restrictedCount,
+            'PROOF 2: the restricted user does NOT get the three rows the admin got'
+        );
+        // The catch does `continue` BEFORE parentDataMap.put(child.dataMapKey(), …),
+        // so the relationship key is absent entirely rather than present-and-empty.
+        // A {#Contacts} loop over a missing key renders nothing at all.
+        System.assertEquals(
+            null,
+            kidsRaw,
+            'PROOF 3: the relationship key is absent from the merge map, not present-and-empty'
+        );
+
+        // PROOF 4 — the drop now leaves a trace. Generation still succeeds and still
+        // returns a partial document; the difference is that an admin can find out why.
+        DocGenErrorLogger.flush();
+        List<DocGen_Error_Log__c> logs = [
+            SELECT Severity__c, Context__c, Operation__c, Message__c
+            FROM DocGen_Error_Log__c
+            WHERE Context__c = 'DocGenDataRetriever' AND Operation__c = 'childQuery'
+        ];
+        System.assertEquals(1, logs.size(), 'PROOF 4: exactly one Warning row for the dropped relationship');
+        System.assertEquals('Warning', logs[0].Severity__c, 'Logged as a Warning, not an Error — generation succeeded');
+        System.assert(
+            logs[0].Message__c.contains('Contacts'),
+            'The log names the relationship that vanished. Got: ' + logs[0].Message__c
+        );
+        System.assert(
+            logs[0].Message__c.contains('Contact'),
+            'The log names the child object. Got: ' + logs[0].Message__c
+        );
+    }
+
+    /**
+     * The admin path must stay quiet — a relationship that resolves correctly should
+     * never produce a Warning row, or the log becomes noise nobody reads.
+     */
+    @IsTest
+    static void noWarningIsLoggedWhenEveryChildRelationshipResolves() {
+        Account a = new Account(Name = 'Fully Readable Account');
+        insert a;
+        insert new Contact(LastName = 'Goal One', AccountId = a.Id, Email = 'g1@portwood.test');
+
+        String config =
+            '{"v":3,"nodes":[' +
+            '{"id":"root","object":"Account","fields":["Name"]},' +
+            '{"id":"kids","object":"Contact","parentNode":"root","lookupField":"AccountId",' +
+            '"relationshipName":"Contacts","fields":["LastName","Email"]}' +
+            ']}';
+
+        Test.startTest();
+        Map<String, Object> data = DocGenDataRetriever.getRecordData(a.Id, 'Account', config);
+        DocGenErrorLogger.flush();
+        Test.stopTest();
+
+        Map<String, Object> kids = (Map<String, Object>) data.get('Contacts');
+        System.assertEquals(1, (Integer) kids.get('totalSize'), 'Admin gets the child row');
+        System.assertEquals(
+            0,
+            [
+                SELECT COUNT()
+                FROM DocGen_Error_Log__c
+                WHERE Context__c = 'DocGenDataRetriever' AND Operation__c = 'childQuery'
+            ],
+            'A healthy generation logs nothing'
+        );
+    }
+}

--- a/force-app/main/default/classes/DocGenRetrieverSilentDropTest.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenRetrieverSilentDropTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Fixes #332.

## What craig reported

> for certain records, the Goal Assignments don't show up in the PDF, even though they can view and edit them in Salesforce

The instinct on this one was "it's permissions," and that's right — but the permissions are working as designed. **The defect is that nothing says so.**

## The mechanism, proven

Every child query in `DocGenDataRetriever` runs in `USER_MODE`. `USER_MODE` throws a `QueryException` when the running user lacks FLS on **any** field in the select list — including a field they never see on a page layout and never asked for. Six catch blocks turn that into "this relationship has no records":

```apex
childResults = Database.query(childQuery, AccessLevel.USER_MODE);
} catch (Exception e) {
    // Child query failed — skip this child relationship
    continue;
}
```

The `continue` fires **before** `parentDataMap.put(child.dataMapKey(), …)`, so the relationship key is absent from the merge map entirely — not present-and-empty. A `{#GoalAssignments}` loop over a missing key renders nothing, `generateDocument` returns success, and the Care Plan comes out looking complete.

`DocGenDataRetriever.cls` is 2,449 lines and contained **zero logging of any kind**.

### Reproduced in a scratch org

`DocGenRetrieverSilentDropTest` builds a Minimum Access user with object Read on Account and Contact and **no** `FieldPermissions`, then runs a V3 config selecting `Contact.Email`:

| | Admin | Restricted user |
| --- | --- | --- |
| `SELECT COUNT()` on the children directly | 3 | **3** — they can see the records, exactly as craig described |
| Child rows in the merge map | 3 | **key absent** |
| Exception reaching the caller | none | **none** |

### One thing that isn't in the issue

**The V1 flat-config path already fails loudly.** The identical misconfiguration surfaces a `DocGenException` there ("Didn't understand relationship 'Contacts'"). Only the V3 node-tree path is silent. That inconsistency between the two config formats is almost certainly why this survived so long, and it's worth knowing before anyone reasons about this area again.

## What this PR changes

Adds `logDroppedRelationship(...)` and calls it from all six sites — child, bulk-child, grandchild, and both ProcessInstance paths (`:1000`, `:1027`, `:1182`, `:1236`, `:1822`, `:1857`).

**Deliberately non-breaking.** The drop still happens and the document still generates. A partial document beats a failed one, and making V3 throw to match V1 would turn a rendering document into a hard failure for anyone relying on current behavior. What changes is that it now leaves a trace:

> Relationship "Contacts" (Contact) was dropped from the document: its query failed for the running user, so the loop rendered no rows. This is usually field-level security on a field in Query Config — the user can often still see the records themselves. Underlying error: …

Routed through `DocGenErrorLogger.warn`, whose docs describe this exact category — "output that is wrong rather than absent." It buffers, dedupes on `context|operation|message`, caps at 25 entries, and is flushed once at the end of `generateDocument` (`DocGenService.cls:1316`), so a template with many child nodes cannot spend the DML limit on diagnostics.

## Tests

`DocGenRetrieverSilentDropTest` — 2 tests, both passing:

- `childRelationshipIsDroppedSilentlyWhenAFieldIsNotReadable` — pins all four properties: generation succeeds, the rows are gone, the key is absent rather than empty, and exactly one `Warning` row names the relationship and the cause.
- `noWarningIsLoggedWhenEveryChildRelationshipResolves` — a healthy generation logs nothing, so the Error Log doesn't become noise nobody reads.

The first test is also the regression guard for the V3-vs-V1 asymmetry above.

## Validation

- `DocGenRetrieverSilentDropTest` 2/2 pass
- `RunLocalTests` — **1983 pass / 0 fail / 77% org-wide**
- e2e-01..08 + 07-syntax1..5 — **269 assertions, 0 failures**
- `sf code-analyzer` (Security + AppExchange) on the changed class — **0 violations**
- `npm run format:check` — clean

## Scope note

This makes the failure **visible**, not impossible. It does not change who can read what, and it does not address the second half of the issue's suggestion — surfacing dropped relationships in the generation result so the person who clicked Generate sees a warning, rather than only an admin reading the Error Log. That's a worthwhile follow-up and a good `help wanted` candidate, but it needs plumbing through the controller and runner and doesn't belong in the same change.

Nor does it confirm craig's specific root cause — that still needs his data (which user context executes the generation, and whether the failing records differ from the working ones). If his cause turns out to be something else entirely, this fix is what will make it diagnosable instead of invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
