### PR TITLE
fix(signatures): deliver the next-signer email on sequential signing …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,26 @@ Two small fixes where the editor promised something the PDF did not deliver.
   resolve to the base-14 bold faces (verified selecting Helvetica-Bold / Times-Bold /
   Courier-Bold in a real org).
 
+- **Sequential signing no longer stalls after the first signer (#379).** A
+  sequential request stopped dead at _In Progress_ once signer 1 finished — signer 2 was
+  never emailed and no error surfaced. Two independent causes, both fixed. First, the two
+  client-side finalize paths never handed off to `DocGenSignaturePdfTrigger` for a
+  non-final signer: `saveCompositedSignedPdf` (the guided draw/type path) had no publish
+  at all on that branch, and `savePdfSignature` (the flat-PDF path) gated its publish on
+  `snapshotBacked` alone. Since that trigger is the only sender of the next-signer email,
+  the chain never advanced; both now publish `DocGen_Signature_PDF__e` there the same way
+  `saveSignature` already did, and the trigger still gates PDF generation on
+  `remaining == 0` so an intermediate signer only fires notifications. Second, even once
+  the trigger ran the send was rejected: Reply-To was `UserInfo.getUserEmail()`, which
+  inside the platform-event trigger resolves to the Automated Process user
+  (`noreply@<orgId>`), and `Messaging.sendEmail` drops the whole message with
+  `INVALID_EMAIL_ADDRESS` — this also broke the pre-existing typed-name sequential path.
+  Reply-To and `{SenderName}` now come from the request creator (`CreatedBy`), falling
+  back to the running user when there is no request context or the creator has no email,
+  and a `noreply@` address is never set as Reply-To. Invisible to unit tests —
+  `Messaging.sendEmail` skips Reply-To validation in test context — so it was caught by
+  end-to-end sends in two orgs.
+
 ## v3.55.0 — Element linking, named blocks, client-side charts
 
 Released 2026-08-08 · `04tVx0000010fXFIAY` · ancestor 3.54.0 · 1,957 tests, 78% coverage

--- a/force-app/main/default/classes/DocGenGuidedSigningTest.cls
+++ b/force-app/main/default/classes/DocGenGuidedSigningTest.cls
@@ -636,6 +636,94 @@ private class DocGenGuidedSigningTest {
         System.assertEquals(null, DocGenSignatureService.saveFrozenSnapshotCv(null));
     }
 
+    @IsTest
+    static void sequentialComposite_handsOffToTriggerForNextSigner() {
+        // #379: on a Sequential request, finalising signer 1 through the client-composited
+        // path (saveCompositedSignedPdf) must publish DocGen_Signature_PDF__e so
+        // DocGenSignaturePdfTrigger emails the next pending signer. Before the fix this
+        // path published nothing on the !isComplete branch, so the envelope stalled at
+        // "In Progress" and signer 2 was never contacted.
+        DocGen_Settings__c st = DocGen_Settings__c.getOrgDefaults();
+        List<OrgWideEmailAddress> owas = [SELECT Id FROM OrgWideEmailAddress LIMIT 1];
+        st.Signature_OWA_Id__c = owas.isEmpty() ? '0D2000000000001AAA' : owas[0].Id;
+        st.Experience_Site_Url__c = 'https://example.my.salesforce-sites.com/sign';
+        upsert st;
+
+        Id tplId = createTaggedTemplate();
+        Account a = [SELECT Id FROM Account LIMIT 1];
+        DocGenSignatureSenderController.createGuidedPdfSignatureRequest(
+            tplId,
+            a.Id,
+            signersJson2(),
+            'Sequential',
+            null
+        );
+
+        List<DocGen_Signer__c> signers = [
+            SELECT Id, Secure_Token__c, Signature_Request__c, Signer_Email__c, Sort_Order__c
+            FROM DocGen_Signer__c
+            WHERE Signature_Request__r.Template__c = :tplId
+            ORDER BY Sort_Order__c ASC
+        ];
+        System.assertEquals(2, signers.size(), 'Two signers created');
+        for (DocGen_Signer__c s : signers) {
+            s.PIN_Verified_At__c = System.now();
+        }
+        update signers;
+        Id reqId = signers[0].Signature_Request__c;
+        Id nextSignerId = signers[1].Id;
+        String nextEmail = signers[1].Signer_Email__c;
+
+        Integer emailsBefore = Limits.getEmailInvocations();
+
+        Test.startTest();
+        DocGenSignatureController.SavePdfSignatureResult r = DocGenSignatureController.saveCompositedSignedPdf(
+            signers[0].Secure_Token__c,
+            EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.4 signer one only')),
+            true,
+            '1.1.1.1',
+            'JUnit/1.0',
+            null
+        );
+        // stopTest delivers the published DocGen_Signature_PDF__e → DocGenSignaturePdfTrigger,
+        // which on a Sequential request emails the next pending signer.
+        Test.stopTest();
+
+        System.assertEquals(false, r.isComplete, 'Signer 1 of 2 does not complete the request');
+
+        DocGen_Signer__c next = [SELECT Status__c FROM DocGen_Signer__c WHERE Id = :nextSignerId];
+        System.assertEquals('Pending', next.Status__c, 'Next signer still awaiting signature');
+        DocGen_Signature_Request__c req = [
+            SELECT Status__c, Email_Status__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :reqId
+        ];
+        System.assertEquals('In Progress', req.Status__c, 'Request left In Progress for the next signer');
+
+        if (!owas.isEmpty()) {
+            // Real OWA present (the QA org has one) → the sequential send runs and
+            // updateEmailStatus records the next signer's address. It must record a
+            // clean send, not a Reply-To failure: the trigger runs as the Automated
+            // Process user, so the send must resolve Reply-To from the request creator,
+            // not UserInfo (#379). (Messaging.sendEmail does not validate Reply-To in
+            // test context, so a real INVALID_EMAIL_ADDRESS only surfaces in e2e — this
+            // still guards against updateEmailStatus recording a FAILED for signer 2.)
+            System.assert(
+                req.Email_Status__c != null &&
+                    req.Email_Status__c.contains(nextEmail) &&
+                    !req.Email_Status__c.contains('FAILED'),
+                '#379: composite finalize of signer 1 must hand off so signer 2 (' +
+                    nextEmail +
+                    ') is emailed cleanly. Email_Status__c=' +
+                    req.Email_Status__c
+            );
+        } else {
+            // No real OWA (bare scratch org) → the send bails before writing status, but
+            // the publish + trigger hand-off is still exercised.
+            System.assert(Limits.getEmailInvocations() >= emailsBefore, '#379: sequential hand-off path exercised');
+        }
+    }
+
     // #156 storage lifecycle: a completed/declined/cancelled request reclaims its snapshot CV
     // (the Snapshot_Hash__c stays as tamper-evidence). purgeFrozenSnapshotCv deletes the file.
     @IsTest

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -2581,9 +2581,12 @@ public without sharing class DocGenSignatureController {
 
         // M2: publish the platform event so DocGenSignaturePdfTrigger enqueues the
         // finalizer (it gates on remaining==0 and Template__c) to produce the signed
-        // document + certificate PDF on the related record. The M1 flat-PDF path has no
-        // template to re-render, so it records audit + status only and never publishes.
-        if (snapshotBacked) {
+        // document + certificate PDF on the related record.
+        // Also publish for a NON-final signer on any path (#379): the trigger sends the
+        // "signer completed" notice and, on a Sequential request, the next signer's
+        // email. The M1 flat-PDF completion path still records audit + status only and
+        // never publishes — there is nothing to re-render.
+        if (snapshotBacked || !result.isComplete) {
             DocGen_Signature_PDF__e pdfEvent = new DocGen_Signature_PDF__e();
             pdfEvent.Request_Id__c = signer.Signature_Request__c;
             EventBus.publish(pdfEvent);
@@ -2952,6 +2955,25 @@ public without sharing class DocGenSignatureController {
                 System.debug(
                     LoggingLevel.WARN,
                     'Portwood: composited signer completion email failed: ' + signerNotifEx.getMessage()
+                );
+            }
+        } else {
+            // Not the last signer. This client-composited path stores the PDF directly
+            // and otherwise never publishes DocGen_Signature_PDF__e, so
+            // DocGenSignaturePdfTrigger never runs for it: on a Sequential request the
+            // next signer is never emailed and the envelope stalls at "In Progress"
+            // (#379), and the sender never gets the "signer completed" notice. Hand off
+            // to the trigger exactly as saveSignature does — it gates PDF generation on
+            // remaining == 0, so an intermediate signer only triggers notifications.
+            try {
+                DocGen_Signature_PDF__e pdfEvent = new DocGen_Signature_PDF__e();
+                pdfEvent.Request_Id__c = signer.Signature_Request__c;
+                /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+                EventBus.publish(pdfEvent);
+            } catch (Exception seqEx) {
+                System.debug(
+                    LoggingLevel.WARN,
+                    'Portwood: composited sequential hand-off publish failed: ' + seqEx.getMessage()
                 );
             }
         }

--- a/force-app/main/default/classes/DocGenSignatureEmailService.cls
+++ b/force-app/main/default/classes/DocGenSignatureEmailService.cls
@@ -152,8 +152,6 @@ public without sharing class DocGenSignatureEmailService {
 
         DocGen_Settings__c settings = DocGen_Settings__c.getOrgDefaults();
         String owaId = settings == null ? null : settings.Signature_OWA_Id__c;
-        String senderName = UserInfo.getName();
-        String senderEmail = UserInfo.getUserEmail();
 
         // OWA is required for signature emails — guest users cannot send without one,
         // and consistent branding requires all emails come from the same address.
@@ -162,6 +160,49 @@ public without sharing class DocGenSignatureEmailService {
             System.debug(LoggingLevel.ERROR, 'Portwood: ' + errMsg);
             updateEmailStatus(requestId, errMsg);
             return;
+        }
+
+        // Sender identity for the {SenderName} token and Reply-To. Resolve from the
+        // request CREATOR, not UserInfo — this method also runs from
+        // DocGenSignaturePdfTrigger as the Automated Process user (sequential signing,
+        // #379), whose non-routable noreply@<orgId> address makes Messaging.sendEmail
+        // reject the whole message on Reply-To. The running user is only the fallback
+        // when there is no request context (or the creator has no email).
+        String senderName = UserInfo.getName();
+        String senderEmail = UserInfo.getUserEmail();
+        if (requestId != null) {
+            try {
+                DocGenFlsGuard.guestAssertAccessible(
+                    DocGen_Signature_Request__c.sObjectType,
+                    new Set<String>{ 'CreatedById' }
+                );
+                /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+                DocGen_Signature_Request__c creatorRow = [
+                    SELECT CreatedById
+                    FROM DocGen_Signature_Request__c
+                    WHERE Id = :requestId
+                    WITH SYSTEM_MODE
+                    LIMIT 1
+                ]; // NOPMD
+                DocGenFlsGuard.guestAssertAccessible(User.sObjectType, new Set<String>{ 'Name', 'Email' });
+                /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+                User creator = [
+                    SELECT Name, Email
+                    FROM User
+                    WHERE Id = :creatorRow.CreatedById
+                    WITH SYSTEM_MODE
+                    LIMIT 1
+                ]; // NOPMD
+                if (String.isNotBlank(creator.Email)) {
+                    senderName = creator.Name;
+                    senderEmail = creator.Email;
+                }
+            } catch (Exception resolveEx) {
+                System.debug(
+                    LoggingLevel.WARN,
+                    'Portwood: could not resolve request creator for Reply-To: ' + resolveEx.getMessage()
+                );
+            }
         }
 
         // {ExpirationHours} reflects the request's actual signing window (stamped
@@ -211,7 +252,10 @@ public without sharing class DocGenSignatureEmailService {
             email.setOrgWideEmailAddressId(owaId);
 
             // Reply-to the creating user so signer replies reach a human, not the OWA.
-            if (String.isNotBlank(senderEmail)) {
+            // Never set a non-routable noreply@<orgId> address (the Automated Process
+            // user's, when this runs from the platform-event trigger) — Messaging.sendEmail
+            // rejects the whole message with INVALID_EMAIL_ADDRESS (#379).
+            if (String.isNotBlank(senderEmail) && !senderEmail.startsWithIgnoreCase('noreply@')) {
                 email.setReplyTo(senderEmail);
             }
 


### PR DESCRIPTION
## Summary

Sequential signature requests never delivered the email to signer 2 after signer 1 completed — the envelope silently stalled at *In Progress*, no error shown to anyone. Two independent root causes, both fixed here. Reported in the community Slack.

## Changes

- **`DocGenSignatureController.saveCompositedSignedPdf`** — the guided draw/type finalize path (used whenever a signer draws or types on the PDF signing page) never published `DocGen_Signature_PDF__e` on the `!isComplete` branch, so `DocGenSignaturePdfTrigger` — the only sender of the next-signer email — never ran. Now publishes on that branch, mirroring `saveSignature`. The trigger already gates PDF generation on `remaining == 0`, so an intermediate signer only triggers notifications, never a re-render.
- **`DocGenSignatureController.savePdfSignature`** — same gap on the flat-PDF path; publish guard widened from `if (snapshotBacked)` to `if (snapshotBacked || !result.isComplete)`.
- **`DocGenSignatureEmailService.sendRequestLikeEmails`** — once the trigger ran, the send still failed: Reply-To was `UserInfo.getUserEmail()`, which in the platform-event trigger is the **Automated Process** user (`noreply@<orgId>`). `Messaging.sendEmail` rejects that as a Reply-To (`INVALID_EMAIL_ADDRESS`) and drops the whole message — verified by probe in two separate orgs. This also broke the pre-existing typed-name sequential path. Now resolves `{SenderName}` + Reply-To from the request **creator** (`CreatedBy`, `WITH SYSTEM_MODE` + `DocGenFlsGuard` — same pattern as `sendSenderNotification` in this class), falls back to the running user only when there's no request context, and never sets a `noreply@` Reply-To.
- **`DocGenGuidedSigningTest`** — new test `sequentialComposite_handsOffToTriggerForNextSigner`.

`Messaging.sendEmail` doesn't validate Reply-To in test context, so cause #2 is invisible to unit tests — it was caught only by real end-to-end sends.

## Testing

- [x] E2E suite (`docgen-verify`): **13/14 `PASS  FAIL: 0`**. The one miss is `e2e-06` → `SEND PIN: Email limit exceeded` — the scratch org's 15-emails/day cap (env), not this change; passed 25/0 earlier with quota available.
- [x] Apex unit tests (`RunLocalTests`, `docgen-verify`): **2021 tests, org-wide coverage 79%**. Targeted signature suites (`DocGenGuidedSigningTest`, `DocGenSignatureTests`, `DocGenSignaturePdfTests`, `DocGenSignatureFlowActionTest`, `DocGenSarahFixesTest`, `DocGenSignatureSnapshotTest`, `DocGenVerificationTest`, `DocGenEmailTemplateTest`) — **415 tests, 100%**. The run's failures are 1 orphan class from unmerged #367 (not on this branch) + 3 pre-existing email-quota flakes — none from this change.
- [x] Tested manually — `docgen-verify` (Apex) **and** `PortwoodSandbox` end-to-end through the real signing UI: countersigner received the email, signed, completed 2-signature PDF delivered.
- [x] Added a unit test for the new behavior.

> `sf code-analyzer` not run (local env: JVM OOM + missing Python 3.10) — needs a maintainer pass.

## Related Issues

Fixes #379


## Checklist

- [x] No hardcoded IDs, URLs, or credentials
- [x] No `VersionData` in PDF image queries (image pipeline untouched)
- [x] SOQL uses the established internal-config-read pattern for this class — `WITH SYSTEM_MODE` + `DocGenFlsGuard.guestAssertAccessible` (the class is `without sharing` and runs in guest context; per CLAUDE.md internal reads must be SYSTEM_MODE)
- [x] No new external dependencies introduced
