### PR TITLE
Fix/377 html data uri images blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,34 @@ Two small fixes where the editor promised something the PDF did not deliver.
 
 ### Fixed
 
+- **Inline (`data:` URI) images in HTML templates now render instead of coming out blank
+  (#377).** `Blob.toPdf` (Flying Saucer) silently drops `<img src="data:image/…;base64,…">`
+  — the page renders with an empty gap where the image should be — and a large inline
+  blob also trips a "Regex too complicated" limit further down the HTML pipeline. The
+  Designer's upload flow already extracts inline images to ContentVersions client-side,
+  but a "self-contained" body that reaches storage another way did not: a **cross-org
+  template-bundle import** (the reported case), LLM generation, or a direct
+  `saveHtmlTemplateBody` call. New `DocGenService.materialiseInlineHtmlImages` pulls each
+  inline image into a `docgen_html_img_<templateId>_<sha256>` ContentVersion — the title
+  prefix the image picker, the clone re-key, and the signature image allowlist already
+  match on — and rewrites the `<img src>` to the relative
+  `/sfc/servlet.shepherd/version/download/<cvId>` form the renderer can fetch. Images are
+  deduplicated by content hash, so the same logo is one file across every template and
+  every render.
+
+    It runs at **save** time — `saveHtmlTemplateBody` and the bundle importer — because
+    `Blob.toPdf`'s server-side image fetch cannot see a ContentVersion inserted in the
+    same transaction as the `toPdf` call (a committed image embeds at full size; a
+    same-transaction one renders blank — established by isolating the two). `mergeHtml-`
+    `Template` calls it too, as a self-healing fallback for a body that never passed a
+    write path (a file attached straight to the record, a metadata deploy, or a body
+    stored before this change): that first render still shows blank images, but the CVs
+    are now committed, so every later render resolves them. The scan is `indexOf`-based,
+    never a whole-string `Matcher`, so a hundreds-of-KB payload does not throw; malformed
+    base64 and a DML failure both leave the affected `data:` URI in place rather than
+    erroring; and a ~5 MB total-decoded cap keeps a pathological body from a mid-run heap
+    crash. A body with no `data:image/` marker is returned untouched at zero cost.
+
 - **Canvas bold is no longer a silent no-op on `'Arial Unicode MS'` (#281).** The PDF
   engine (`Blob.toPdf`/Flying Saucer) embeds Arial Unicode MS with no bold face, so a
   bold box set to it printed regular while the canvas showed bold — WYSIWYG said

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -536,7 +536,7 @@ HTML templates let you author in any tool that produces HTML — Google Docs is 
 - **Apple Pages** — File → Export To → HTML
 - **Hand-written HTML** — any text editor
 
-For single-file uploads (`.html` / `.htm`), Portwood scans for inline `<img src="data:image/...">` URIs — common in Notion / ChatGPT / rich-text paste output — and extracts each to a ContentVersion with the `src` rewritten. `Blob.toPdf` can't decode data URIs directly, so this conversion is what makes those images render.
+Portwood scans the template body (and the Header / Footer HTML) for inline `<img src="data:image/...">` URIs — common in Notion / ChatGPT / rich-text paste output — and extracts each to a ContentVersion with the `src` rewritten. `Blob.toPdf` can't decode data URIs directly, so this conversion is what makes those images render. It runs on save whichever way the body arrives — a `.html` / `.htm` upload, a cross-org template-bundle import, or Generate-with-AI — and self-heals on render for a body that somehow reached storage without it (v3.57+).
 
 #### 5.7.3 CSS rules — what works, what doesn't, and an LLM prompt
 
@@ -1032,7 +1032,7 @@ Example footer HTML:
 Three ways to get images into an HTML template:
 
 1. **Google Docs zip** — images inserted in the Google Doc are bundled into the `.zip` and extracted automatically on upload.
-2. **Inline data URIs** — `<img src="data:image/png;base64,...">` in the HTML (Notion / ChatGPT / pasted rich text) is scanned on upload; each is saved as its own ContentVersion and the `src` is rewritten.
+2. **Inline data URIs** — `<img src="data:image/png;base64,...">` in the HTML (Notion / ChatGPT / pasted rich text) is scanned on save — upload, template-bundle import, or Generate-with-AI alike — and each is saved as its own ContentVersion with the `src` rewritten (v3.57+ extends this beyond the upload path).
 3. **`{%Image:N}` / `{%FieldName}` merge tags** — same syntax as Word templates. Renders the Nth record-attached image, or a ContentVersion ID stored in a field. Emits `<img src="/sfc/...">` at merge time.
 
 #### 5.7.7 Loops in tables

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -3444,6 +3444,16 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             throw new DocGenException('saveHtmlTemplateBody is for HTML-backed templates only.');
         }
 
+        // #377 — pull any `data:` URI images out into ContentVersions and rewrite
+        // <img src> to relative /sfc/ URLs BEFORE the body is stored (and before
+        // any whole-body regex below, which a large inline base64 blob would trip).
+        // Blob.toPdf can't render inline base64, and it can't fetch a CV created in
+        // the same transaction as the render — so this has to happen here, at save
+        // time. The Designer's upload path already does this client-side; this
+        // covers every other caller (AI generation, a direct API save). No-op when
+        // the body has no inline images.
+        htmlContent = DocGenService.materialiseInlineHtmlImages(templateId, htmlContent);
+
         // Refuse to overwrite a real body with an empty one.
         //
         // The Designer seeds a placeholder scaffold ("Start typing your document
@@ -7860,14 +7870,21 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                     : tmpl.Name;
                 cv.PathOnClient = tmpl.Name + '.' + (String) fileData.get('fileExtension');
                 Blob bodyBytes = EncodingUtil.base64Decode((String) fileData.get('base64'));
-                // For HTML templates, rewrite embedded shepherd URLs in the body
-                // bytes BEFORE upload (ContentVersion.VersionData is immutable
-                // post-insert). Word/Excel/PowerPoint templates carry their
-                // image references inside docx-internal relationships, not
-                // shepherd URLs, so they pass through untouched.
-                if (DocGenService.isHtmlBacked(tmpl.Type__c) && !cvIdMap.isEmpty()) {
+                // For HTML templates, rewrite the body bytes BEFORE upload
+                // (ContentVersion.VersionData is immutable post-insert):
+                //   1. re-key exported shepherd image URLs to the newly-inserted CVs
+                //   2. #377 — pull any `data:` URI images (a "self-contained" export)
+                //      out into ContentVersions and rewrite <img src> to /sfc/ URLs,
+                //      so Blob.toPdf can actually render them. Must happen here at
+                //      import time — a CV created during a render is invisible to
+                //      Blob.toPdf's fetch in that same transaction.
+                // Word/Excel/PowerPoint templates carry image references inside
+                // docx-internal relationships, not shepherd URLs, so they pass
+                // through untouched.
+                if (DocGenService.isHtmlBacked(tmpl.Type__c)) {
                     String htmlBody = bodyBytes.toString();
-                    String rewrittenBody = rewriteShepherdCvIds(htmlBody, cvIdMap);
+                    String rewrittenBody = cvIdMap.isEmpty() ? htmlBody : rewriteShepherdCvIds(htmlBody, cvIdMap);
+                    rewrittenBody = DocGenService.materialiseInlineHtmlImages(tmpl.Id, rewrittenBody);
                     if (rewrittenBody != htmlBody) {
                         bodyBytes = Blob.valueOf(rewrittenBody);
                     }

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -2697,10 +2697,23 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             if (fields.containsKey('Record_Filter__c')) {
                 template.Record_Filter__c = (String) fields.get('Record_Filter__c');
             }
+            // #377 — a data: URI pasted into the header/footer band renders blank
+            // in Blob.toPdf; pull it into a CV at save time. Written back into the
+            // fields map so the version snapshot below (which reads from `fields`,
+            // not from `template`) also stores the materialised markup. templateId
+            // is null on first create — the render-path fallback covers that.
             if (fields.containsKey('Header_Html__c')) {
+                fields.put(
+                    'Header_Html__c',
+                    DocGenService.materialiseInlineHtmlImages(templateId, (String) fields.get('Header_Html__c'))
+                );
                 template.Header_Html__c = (String) fields.get('Header_Html__c');
             }
             if (fields.containsKey('Footer_Html__c')) {
+                fields.put(
+                    'Footer_Html__c',
+                    DocGenService.materialiseInlineHtmlImages(templateId, (String) fields.get('Footer_Html__c'))
+                );
                 template.Footer_Html__c = (String) fields.get('Footer_Html__c');
             }
             // 1.68 — page orientation, size, margins
@@ -7842,14 +7855,24 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 }
             }
 
-            // 1.6. If any asset URLs were referenced in Header_Html__c or
-            // Footer_Html__c, rewrite them to point at the newly-inserted CVs.
-            if (!cvIdMap.isEmpty()) {
-                String rewrittenHeader = rewriteShepherdCvIds(tmpl.Header_Html__c, cvIdMap);
-                String rewrittenFooter = rewriteShepherdCvIds(tmpl.Footer_Html__c, cvIdMap);
-                if (rewrittenHeader != tmpl.Header_Html__c || rewrittenFooter != tmpl.Footer_Html__c) {
-                    tmpl.Header_Html__c = rewrittenHeader;
-                    tmpl.Footer_Html__c = rewrittenFooter;
+            {
+                // 1.6. Rewrite the Header_Html__c / Footer_Html__c fields on the new
+                // template. Word templates carry HTML header/footer bands too, so this
+                // is NOT gated on isHtmlBacked:
+                //   1. re-key any exported shepherd asset URLs to the newly-inserted CVs
+                //   2. #377 — pull any `data:` URI images (a self-contained export
+                //      carries them in the bands too, not just the body) out into
+                //      ContentVersions so Blob.toPdf can render them. No-op on a band
+                //      with no inline image.
+                String h0 = tmpl.Header_Html__c;
+                String f0 = tmpl.Footer_Html__c;
+                String h1 = cvIdMap.isEmpty() ? h0 : rewriteShepherdCvIds(h0, cvIdMap);
+                String f1 = cvIdMap.isEmpty() ? f0 : rewriteShepherdCvIds(f0, cvIdMap);
+                h1 = DocGenService.materialiseInlineHtmlImages(tmpl.Id, h1);
+                f1 = DocGenService.materialiseInlineHtmlImages(tmpl.Id, f1);
+                if (h1 != h0 || f1 != f0) {
+                    tmpl.Header_Html__c = h1;
+                    tmpl.Footer_Html__c = f1;
                     /* code-analyzer-suppress ApexFlsViolation */
                     Database.update(tmpl, AccessLevel.USER_MODE);
                 }

--- a/force-app/main/default/classes/DocGenInlineImageTest.cls
+++ b/force-app/main/default/classes/DocGenInlineImageTest.cls
@@ -191,4 +191,90 @@ private class DocGenInlineImageTest {
         );
         System.assertEquals(1, imgCvCount(t), 'fallback commits the image CV for subsequent renders');
     }
+
+    @IsTest
+    static void saveTemplate_materialisesHeaderAndFooterBands() {
+        Id t = newHtmlTemplate();
+
+        Test.startTest();
+        DocGenController.saveTemplate(
+            new Map<String, Object>{
+                'Id' => t,
+                'Name' => 'InlineImg hdr/ftr',
+                'Type__c' => 'HTML',
+                'Base_Object_API__c' => 'Account',
+                'Output_Format__c' => 'PDF',
+                'Header_Html__c' => '<div><img src="data:image/png;base64,' +
+                PNG_1PX +
+                '"> hdr</div>',
+                'Footer_Html__c' => '<div><img src="data:image/png;base64,' +
+                PNG_1PX +
+                '"> ftr</div>'
+            },
+            false,
+            null
+        );
+        Test.stopTest();
+
+        DocGen_Template__c saved = [SELECT Header_Html__c, Footer_Html__c FROM DocGen_Template__c WHERE Id = :t];
+        System.assert(
+            !saved.Header_Html__c.contains('data:image'),
+            'header band materialised: ' + saved.Header_Html__c
+        );
+        System.assert(!saved.Footer_Html__c.contains('data:image'), 'footer band materialised');
+        System.assert(
+            saved.Header_Html__c.contains('/sfc/servlet.shepherd/version/download/'),
+            'header points at a CV URL'
+        );
+        System.assertEquals(1, imgCvCount(t), 'identical header+footer image dedupes to one CV');
+    }
+
+    @IsTest
+    static void bundleImport_materialisesBodyAndHeaderFooter() {
+        // A "self-contained" export: body + header + footer all carry data: URIs.
+        Id src = newHtmlTemplate();
+        update new DocGen_Template__c(
+            Id = src,
+            Header_Html__c = '<div><img src="data:image/png;base64,' + PNG_1PX + '"> {Name}</div>',
+            Footer_Html__c = '<div><img src="data:image/png;base64,' + PNG_1PX + '"></div>'
+        );
+        ContentVersion cv = new ContentVersion(
+            Title = 'docgen_html_body_' + src + '_' + Datetime.now().getTime(),
+            PathOnClient = 'b.html',
+            VersionData = Blob.valueOf(
+                '<html><body><h1>{Name}</h1><img src="data:image/png;base64,' + PNG_1PX + '"></body></html>'
+            ),
+            FirstPublishLocationId = src
+        );
+        insert cv;
+        insert new DocGen_Template_Version__c(
+            Template__c = src,
+            Content_Version_Id__c = [SELECT Id FROM ContentVersion WHERE Id = :cv.Id LIMIT 1]
+            .Id,
+            Is_Active__c = true
+        );
+
+        Test.startTest();
+        String bundle = DocGenController.exportTemplate(src);
+        System.assert(bundle.contains('data:image'), 'export carries the inline images verbatim');
+        Id imported = DocGenController.importTemplate(bundle);
+        Test.stopTest();
+
+        DocGen_Template__c it = [SELECT Header_Html__c, Footer_Html__c FROM DocGen_Template__c WHERE Id = :imported];
+        DocGen_Template_Version__c iv = [
+            SELECT Content_Version_Id__c
+            FROM DocGen_Template_Version__c
+            WHERE Template__c = :imported AND Is_Active__c = TRUE
+            LIMIT 1
+        ];
+        String importedBody = [SELECT VersionData FROM ContentVersion WHERE Id = :iv.Content_Version_Id__c LIMIT 1]
+            .VersionData.toString();
+
+        System.assert(!importedBody.contains('data:image'), 'imported body is materialised');
+        System.assert(!it.Header_Html__c.contains('data:image'), 'imported header is materialised');
+        System.assert(!it.Footer_Html__c.contains('data:image'), 'imported footer is materialised');
+        System.assert(importedBody.contains('/sfc/servlet.shepherd/version/download/'), 'body points at CV URLs');
+        // Body + header + footer all use the same 1x1 PNG → one deduped CV.
+        System.assertEquals(1, imgCvCount(imported), 'identical images dedupe to one CV on the imported template');
+    }
 }

--- a/force-app/main/default/classes/DocGenInlineImageTest.cls
+++ b/force-app/main/default/classes/DocGenInlineImageTest.cls
@@ -1,0 +1,194 @@
+/**
+ * #377 — inline (data:) image materialisation for HTML templates.
+ *
+ * Blob.toPdf can't render `data:` URI images and can't fetch a ContentVersion
+ * created in the same transaction as the render, so DocGenService.materialise-
+ * InlineHtmlImages pulls each inline image into a docgen_html_img_* CV at SAVE
+ * time. mergeHtmlTemplate also calls it as a self-healing render fallback.
+ */
+@IsTest
+private class DocGenInlineImageTest {
+    // 1x1 transparent PNG.
+    private static final String PNG_1PX = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+    @TestSetup
+    static void setup() {
+        insert new Account(Name = 'Inline Img Co');
+    }
+
+    private static Id newHtmlTemplate() {
+        DocGen_Template__c t = new DocGen_Template__c(
+            Name = 'InlineImg ' + Datetime.now().getTime(),
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF',
+            Base_Object_API__c = 'Account',
+            Query_Config__c = 'Name'
+        );
+        insert t;
+        return t.Id;
+    }
+
+    private static Integer imgCvCount(Id templateId) {
+        return [SELECT COUNT() FROM ContentVersion WHERE Title LIKE :('docgen_html_img_' + templateId + '_%')];
+    }
+
+    @IsTest
+    static void materialise_rewritesDataUriAndCreatesCv() {
+        Id t = newHtmlTemplate();
+        String html = '<html><body><img src="data:image/png;base64,' + PNG_1PX + '"></body></html>';
+
+        Test.startTest();
+        String out = DocGenService.materialiseInlineHtmlImages(t, html);
+        Test.stopTest();
+
+        System.assert(!out.contains('data:image'), 'data: URI should be gone: ' + out);
+        System.assert(
+            out.contains('/sfc/servlet.shepherd/version/download/'),
+            'src should be rewritten to a relative CV URL: ' + out
+        );
+        System.assertEquals(1, imgCvCount(t), 'one docgen_html_img_ CV should be created');
+    }
+
+    @IsTest
+    static void materialise_secondCallReusesCv() {
+        Id t = newHtmlTemplate();
+        String html = '<html><body><img src="data:image/png;base64,' + PNG_1PX + '"></body></html>';
+
+        Test.startTest();
+        String first = DocGenService.materialiseInlineHtmlImages(t, html);
+        Integer afterFirst = imgCvCount(t);
+        String second = DocGenService.materialiseInlineHtmlImages(t, html);
+        Test.stopTest();
+
+        System.assertEquals(1, afterFirst, 'first call creates the CV');
+        System.assertEquals(1, imgCvCount(t), 'second call must reuse it, not insert again');
+        System.assertEquals(first, second, 'same input → same rewritten output');
+    }
+
+    @IsTest
+    static void materialise_handlesSingleQuotesAndJpeg() {
+        Id t = newHtmlTemplate();
+        String html = '<div><img src=\'data:image/jpeg;base64,' + PNG_1PX + '\' /></div>';
+
+        Test.startTest();
+        String out = DocGenService.materialiseInlineHtmlImages(t, html);
+        Test.stopTest();
+
+        System.assert(!out.contains('data:image'), 'single-quoted data: URI should be rewritten');
+        System.assertEquals(1, imgCvCount(t), 'CV created for the jpeg');
+        System.assert(
+            [SELECT PathOnClient FROM ContentVersion WHERE Title LIKE :('docgen_html_img_' + t + '_%') LIMIT 1]
+                .PathOnClient.endsWith('.jpg'),
+            'jpeg subtype should map to a .jpg extension'
+        );
+    }
+
+    @IsTest
+    static void materialise_malformedBase64_leftInPlace() {
+        Id t = newHtmlTemplate();
+        String html = '<img src="data:image/png;base64,@@@ not valid base64 @@@">';
+
+        Test.startTest();
+        String out = DocGenService.materialiseInlineHtmlImages(t, html);
+        Test.stopTest();
+
+        System.assertEquals(html, out, 'undecodable payload is left untouched, no throw');
+        System.assertEquals(0, imgCvCount(t), 'no CV for a malformed image');
+    }
+
+    @IsTest
+    static void materialise_noInlineImages_isIdentity() {
+        Id t = newHtmlTemplate();
+        String html = '<html><body><img src="/sfc/servlet.shepherd/version/download/068000000000000AAA"><p>x</p></body></html>';
+
+        Test.startTest();
+        String out = DocGenService.materialiseInlineHtmlImages(t, html);
+        Test.stopTest();
+
+        System.assertEquals(html, out, 'a body with no data: URI is returned unchanged');
+        System.assertEquals(0, imgCvCount(t), 'nothing created');
+    }
+
+    @IsTest
+    static void materialise_nullTemplate_isIdentity() {
+        String html = '<img src="data:image/png;base64,' + PNG_1PX + '">';
+        Test.startTest();
+        System.assertEquals(html, DocGenService.materialiseInlineHtmlImages(null, html));
+        System.assertEquals('', DocGenService.materialiseInlineHtmlImages(newHtmlTemplate(), ''));
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void saveHtmlTemplateBody_stripsDataUris() {
+        Id t = newHtmlTemplate();
+        String body = '<html><body><h1>Policy</h1><img src="data:image/png;base64,' + PNG_1PX + '"></body></html>';
+
+        Test.startTest();
+        Map<String, Object> res = DocGenController.saveHtmlTemplateBody(t, 'policy.html', body);
+        Test.stopTest();
+
+        Id bodyCvId = (Id) res.get('contentVersionId');
+        String stored = [SELECT VersionData FROM ContentVersion WHERE Id = :bodyCvId LIMIT 1].VersionData.toString();
+        System.assert(!stored.contains('data:image'), 'stored body must not carry inline base64');
+        System.assert(stored.contains('/sfc/servlet.shepherd/version/download/'), 'stored body uses a CV URL');
+        System.assertEquals(1, imgCvCount(t), 'image extracted to a CV at save time');
+    }
+
+    @IsTest
+    static void saveHtmlTemplateBody_largeInlineImage_noRegexCrash() {
+        Id t = newHtmlTemplate();
+        // ~800 KB of valid base64 — big enough to trip "Regex too complicated" in
+        // the whole-body regex passes if the data: URI were left in the body.
+        String bigB64 = EncodingUtil.base64Encode(Blob.valueOf('x'.repeat(600000)));
+        String body =
+            '<html><head><style>p{color:red}</style></head><body>' +
+            '<img src="data:image/png;base64,' +
+            bigB64 +
+            '"><p>ok</p></body></html>';
+
+        Test.startTest();
+        Map<String, Object> res = DocGenController.saveHtmlTemplateBody(t, 'big.html', body);
+        Test.stopTest();
+
+        String stored = [
+                SELECT VersionData
+                FROM ContentVersion
+                WHERE Id = :(Id) res.get('contentVersionId')
+                LIMIT 1
+            ]
+            .VersionData.toString();
+        System.assert(!stored.contains('data:image'), 'large inline image extracted');
+        System.assert(stored.length() < 5000, 'stored body is small once the blob is gone: ' + stored.length());
+    }
+
+    @IsTest
+    static void render_fallbackMaterialisesBodyThatBypassedWritePaths() {
+        Id t = newHtmlTemplate();
+        // Attach the body straight as the version CV — no saveHtmlTemplateBody.
+        String body = '<html><body><img src="data:image/png;base64,' + PNG_1PX + '"></body></html>';
+        ContentVersion cv = new ContentVersion(
+            Title = 'docgen_html_body_' + t + '_' + Datetime.now().getTime(),
+            PathOnClient = 'raw.html',
+            VersionData = Blob.valueOf(body),
+            FirstPublishLocationId = t
+        );
+        insert cv;
+        insert new DocGen_Template_Version__c(
+            Template__c = t,
+            Content_Version_Id__c = [SELECT Id FROM ContentVersion WHERE Id = :cv.Id LIMIT 1]
+            .Id,
+            Is_Active__c = true
+        );
+        Account a = [SELECT Id FROM Account LIMIT 1];
+
+        Test.startTest();
+        DocGenService.generatePdfBlob(t, a.Id);
+        Test.stopTest();
+
+        System.assert(
+            !DocGenService.lastRenderedHtml.contains('data:image'),
+            'render fallback rewrites the body in-memory'
+        );
+        System.assertEquals(1, imgCvCount(t), 'fallback commits the image CV for subsequent renders');
+    }
+}

--- a/force-app/main/default/classes/DocGenInlineImageTest.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenInlineImageTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -770,6 +770,7 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             currentOutputFormat = 'PDF';
             return mergeHtmlTemplate(
                 mr,
+                templateId,
                 base64File,
                 recordDataMap,
                 draftHeaderHtmlOverride != null ? draftHeaderHtmlOverride : (String) dataMap.get('headerHtml'),
@@ -9893,6 +9894,7 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
     // =====================================================================
     private static MergeResult mergeHtmlTemplate(
         MergeResult mr,
+        Id templateId,
         String base64File,
         Map<String, Object> recordDataMap,
         String headerHtml,
@@ -9901,6 +9903,20 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
     ) {
         Blob htmlBlob = EncodingUtil.base64Decode(base64File);
         String rawHtml = htmlBlob.toString();
+
+        // #377 — self-healing fallback for a body that reached the renderer still
+        // carrying `data:` URI images (never passed a write path — a file attached
+        // straight to the record, a metadata deploy, or a body stored before the
+        // fix). Runs BEFORE any whole-body regex, so it also defuses the
+        // "Regex too complicated" a large inline blob would trip in
+        // stripStyleAndScriptBlocks. Images become blank on THIS render (the CVs
+        // are inserted in this transaction, and Blob.toPdf can't see them yet);
+        // every later render resolves them. Idempotent — a body already on /sfc/
+        // URLs skips out at zero cost.
+        InlineImageContext inlineImgCtx = new InlineImageContext(templateId);
+        rawHtml = materialiseInlineHtmlImages(rawHtml, inlineImgCtx);
+        headerHtml = materialiseInlineHtmlImages(headerHtml, inlineImgCtx);
+        footerHtml = materialiseInlineHtmlImages(footerHtml, inlineImgCtx);
 
         String sourceStyles = extractHtmlStyleBlocks(rawHtml);
         String bodyContent = extractHtmlBodyContent(rawHtml);
@@ -9981,6 +9997,206 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         }
         return html.replaceAll('(?is)<style[^>]*>.*?</style\\s*>', '')
             .replaceAll('(?is)<script[^>]*>.*?</script\\s*>', '');
+    }
+
+    // ---------------------------------------------------------------------------
+    // #377 — inline (data:) image materialisation
+    //
+    // Blob.toPdf (Flying Saucer) silently drops `data:` URI images, and a large
+    // inline base64 blob also trips a "Regex too complicated" limit further down
+    // the HTML pipeline. The Designer upload path already extracts inline images to
+    // ContentVersions client-side (docGenAdmin._processAndSaveHtmlBody), but a body
+    // that reaches storage another way — a cross-org template-bundle import, LLM
+    // generation, a direct saveHtmlTemplateBody call — still carries them.
+    //
+    // materialiseInlineHtmlImages() pulls each `data:` image out into a
+    // `docgen_html_img_<templateId>_<sha256>` ContentVersion (the title prefix
+    // listHtmlTemplateImages / the clone re-key / the signature image allowlist
+    // already match on) and rewrites the <img src> to the relative
+    // /sfc/servlet.shepherd/version/download/<cvId> form Blob.toPdf can fetch.
+    //
+    // It MUST run at *save* time, in a transaction that commits before any render:
+    // Blob.toPdf's server-side image fetch cannot see a ContentVersion inserted in
+    // the same transaction as the toPdf call. mergeHtmlTemplate calls it too, as a
+    // self-healing fallback for bodies that never passed a write path — that first
+    // render still shows blank images, but the CVs are now committed so every later
+    // render (a separate transaction) resolves them.
+    // ---------------------------------------------------------------------------
+
+    /** Per-transaction context: shared hash→CV cache + heap budget across body/header/footer. */
+    private class InlineImageContext {
+        final Id templateId;
+        final Map<String, Id> cvIdByTitle = new Map<String, Id>();
+        Boolean existingLoaded = false;
+        Integer decodedBytesUsed = 0;
+
+        InlineImageContext(Id templateId) {
+            this.templateId = templateId;
+        }
+    }
+
+    // Total decoded bytes one call is allowed to pull out of `data:` URIs. Heap
+    // guard: the caller already holds the full HTML string. Images over the cap
+    // keep their `data:` URI (and render blank) rather than risking a mid-run
+    // heap crash.
+    private static final Integer MAX_INLINE_IMAGE_DECODED_BYTES = 5 * 1024 * 1024;
+
+    /**
+     * Rewrites every `<img src="data:image/...;base64,...">` in `html` to a
+     * relative /sfc/ ContentVersion URL, creating one CV per distinct image
+     * (keyed by SHA-256, reused across templates and renders). Returns `html`
+     * unchanged when it carries no `data:image/` marker or `templateId` is null.
+     * Never throws — malformed base64 and DML failures leave the affected
+     * `data:` URI in place.
+     */
+    public static String materialiseInlineHtmlImages(Id templateId, String html) {
+        return materialiseInlineHtmlImages(html, new InlineImageContext(templateId));
+    }
+
+    private static String materialiseInlineHtmlImages(String html, InlineImageContext ctx) {
+        if (String.isBlank(html) || ctx.templateId == null || !html.contains('data:image/')) {
+            return html;
+        }
+
+        // Pass 1 — locate each  src="data:image/<subtype>;base64,<payload>"  (also
+        // single-quoted) and record the quoted-value bounds for the Pass 3 splice.
+        // indexOf only: a single image can be hundreds of KB and a Matcher over it
+        // throws "Regex too complicated".
+        List<Integer> valStarts = new List<Integer>();
+        List<Integer> valEnds = new List<Integer>();
+        List<String> subtypes = new List<String>();
+        List<String> payloads = new List<String>();
+        Integer cursor = 0;
+        while (true) {
+            Integer sc = html.indexOf('src=', cursor);
+            if (sc == -1) {
+                break;
+            }
+            Integer qi = sc + 4;
+            String quote = (qi < html.length()) ? html.substring(qi, qi + 1) : '';
+            if (quote != '"' && quote != '\'') {
+                cursor = qi + 1;
+                continue;
+            }
+            Integer valStart = qi + 1;
+            Integer valEnd = html.indexOf(quote, valStart);
+            if (valEnd == -1) {
+                break;
+            }
+            cursor = valEnd + 1;
+            if (valEnd - valStart < 20 || !html.substring(valStart, valStart + 11).equalsIgnoreCase('data:image/')) {
+                continue;
+            }
+            Integer b64Marker = html.indexOf(';base64,', valStart);
+            if (b64Marker == -1 || b64Marker > valEnd) {
+                continue;
+            }
+            valStarts.add(valStart);
+            valEnds.add(valEnd);
+            subtypes.add(html.substring(valStart + 11, b64Marker).toLowerCase());
+            payloads.add(html.substring(b64Marker + 8, valEnd));
+        }
+        if (valStarts.isEmpty()) {
+            return html;
+        }
+
+        // Pass 2 — decode (heap-budgeted), hash, and resolve one CV per distinct
+        // image: transaction cache → an existing CV for this template → insert.
+        List<String> titlePerOcc = new List<String>(); // parallel to valStarts; null = leave as-is
+        List<ContentVersion> toInsert = new List<ContentVersion>();
+        Set<String> pendingTitles = new Set<String>();
+        for (Integer i = 0; i < payloads.size(); i++) {
+            Blob bytes;
+            try {
+                bytes = EncodingUtil.base64Decode(payloads[i].deleteWhitespace());
+            } catch (Exception decodeErr) {
+                titlePerOcc.add(null); // malformed — leave the data: URI in place
+                continue;
+            }
+            String title =
+                'docgen_html_img_' +
+                ctx.templateId +
+                '_' +
+                EncodingUtil.convertToHex(Crypto.generateDigest('SHA-256', bytes));
+            titlePerOcc.add(title);
+
+            if (ctx.cvIdByTitle.containsKey(title) || pendingTitles.contains(title)) {
+                continue;
+            }
+            if (!ctx.existingLoaded) {
+                for (
+                    ContentVersion cv : loadInternalContentVersionMetaForEntityByTitlePrefix(
+                        ctx.templateId,
+                        'docgen_html_img_'
+                    )
+                ) {
+                    ctx.cvIdByTitle.put(cv.Title, cv.Id);
+                }
+                ctx.existingLoaded = true;
+                if (ctx.cvIdByTitle.containsKey(title)) {
+                    continue;
+                }
+            }
+            if (ctx.decodedBytesUsed + bytes.size() > MAX_INLINE_IMAGE_DECODED_BYTES) {
+                System.debug(
+                    LoggingLevel.WARN,
+                    '#377 inline-image budget exhausted on template ' +
+                        ctx.templateId +
+                        ' — remaining data: URIs left in place (will render blank).'
+                );
+                titlePerOcc[i] = null; // over budget — leave the data: URI
+                continue;
+            }
+            ctx.decodedBytesUsed += bytes.size();
+            String ext = subtypes[i] == 'jpeg' ? 'jpg' : (subtypes[i] == 'svg+xml' ? 'svg' : subtypes[i].left(8));
+            toInsert.add(
+                new ContentVersion(
+                    Title = title,
+                    PathOnClient = 'inline.' + ext,
+                    VersionData = bytes,
+                    FirstPublishLocationId = ctx.templateId
+                )
+            );
+            pendingTitles.add(title);
+        }
+
+        if (!toInsert.isEmpty()) {
+            try {
+                // SYSTEM_MODE: package-managed image assets, and the render-path
+                // fallback can run as a guest user (public signing / guest-runner)
+                // where ContentVersion create FLS would otherwise block it.
+                /* code-analyzer-suppress ApexFlsViolation */
+                Database.insert(toInsert, AccessLevel.SYSTEM_MODE); // NOPMD ApexCRUDViolation — package-internal template image assets
+                for (ContentVersion cv : toInsert) {
+                    ctx.cvIdByTitle.put(cv.Title, cv.Id);
+                }
+            } catch (Exception insertErr) {
+                // e.g. DML-after-callout, or a storage limit. Degrade: images not
+                // inserted keep their data: URI; anything already committed still
+                // gets rewritten below.
+                System.debug(
+                    LoggingLevel.WARN,
+                    '#377 inline-image ContentVersion insert failed on template ' +
+                        ctx.templateId +
+                        ': ' +
+                        insertErr.getMessage()
+                );
+            }
+        }
+
+        // Pass 3 — splice each resolved data: URI to its /sfc/ URL; leave the rest.
+        String out = '';
+        Integer prev = 0;
+        for (Integer i = 0; i < valStarts.size(); i++) {
+            Id cvId = titlePerOcc[i] == null ? null : ctx.cvIdByTitle.get(titlePerOcc[i]);
+            if (cvId == null) {
+                continue;
+            }
+            out += html.substring(prev, valStarts[i]) + '/sfc/servlet.shepherd/version/download/' + cvId;
+            prev = valEnds[i];
+        }
+        out += html.substring(prev);
+        return out;
     }
 
     /**

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -10038,8 +10038,15 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
     // Total decoded bytes one call is allowed to pull out of `data:` URIs. Heap
     // guard: the caller already holds the full HTML string. Images over the cap
     // keep their `data:` URI (and render blank) rather than risking a mid-run
-    // heap crash.
-    private static final Integer MAX_INLINE_IMAGE_DECODED_BYTES = 5 * 1024 * 1024;
+    // heap crash. Scaled to the transaction's heap ceiling — the save path is
+    // synchronous (6 MB), so it gets a much smaller budget than an async render.
+    private static Integer maxInlineImageDecodedBytes() {
+        return Limits.getLimitHeapSize() > 6000000 ? 5 * 1024 * 1024 : 1536 * 1024;
+    }
+
+    // Largest single base64 payload to even hold as a substring — a bigger one is
+    // left as a `data:` URI. Bounds the peak of Pass 2's per-image slice.
+    private static final Integer MAX_INLINE_IMAGE_B64_CHARS = 2 * 1024 * 1024;
 
     /**
      * Rewrites every `<img src="data:image/...;base64,...">` in `html` to a
@@ -10091,6 +10098,12 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             if (b64Marker == -1 || b64Marker > valEnd) {
                 continue;
             }
+            // Leave an oversized single image as a `data:` URI (renders blank)
+            // rather than holding a multi-MB substring — and its decoded blob —
+            // in the synchronous heap.
+            if (valEnd - (b64Marker + 8) > MAX_INLINE_IMAGE_B64_CHARS) {
+                continue;
+            }
             valStarts.add(valStart);
             valEnds.add(valEnd);
             subtypes.add(html.substring(valStart + 11, b64Marker).toLowerCase());
@@ -10137,7 +10150,7 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                     continue;
                 }
             }
-            if (ctx.decodedBytesUsed + bytes.size() > MAX_INLINE_IMAGE_DECODED_BYTES) {
+            if (ctx.decodedBytesUsed + bytes.size() > maxInlineImageDecodedBytes()) {
                 System.debug(
                     LoggingLevel.WARN,
                     '#377 inline-image budget exhausted on template ' +
@@ -10165,10 +10178,22 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                 // SYSTEM_MODE: package-managed image assets, and the render-path
                 // fallback can run as a guest user (public signing / guest-runner)
                 // where ContentVersion create FLS would otherwise block it.
+                // allOrNone=false: one bad image (storage limit, oversized blob)
+                // must not roll back the CVs for every other image on the page.
                 /* code-analyzer-suppress ApexFlsViolation */
-                Database.insert(toInsert, AccessLevel.SYSTEM_MODE); // NOPMD ApexCRUDViolation — package-internal template image assets
-                for (ContentVersion cv : toInsert) {
-                    ctx.cvIdByTitle.put(cv.Title, cv.Id);
+                List<Database.SaveResult> results = Database.insert(toInsert, false, AccessLevel.SYSTEM_MODE); // NOPMD ApexCRUDViolation — package-internal template image assets
+                for (Integer k = 0; k < results.size(); k++) {
+                    if (results[k].isSuccess()) {
+                        ctx.cvIdByTitle.put(toInsert[k].Title, results[k].getId());
+                    } else {
+                        System.debug(
+                            LoggingLevel.WARN,
+                            '#377 inline-image CV insert skipped for ' +
+                                toInsert[k].Title +
+                                ': ' +
+                                results[k].getErrors()[0].getMessage()
+                        );
+                    }
                 }
             } catch (Exception insertErr) {
                 // e.g. DML-after-callout, or a storage limit. Degrade: images not


### PR DESCRIPTION
## Summary

`Blob.toPdf` (Flying Saucer) silently drops `<img src="data:image/...;base64,...">` — the page renders with a blank gap where the image should be. A large inline blob also trips a `System.LimitException: Regex too complicated` in the HTML pipeline's whole-body regex passes. This extracts each inline image to a `ContentVersion` at save time and rewrites the `<img>` to the relative `/sfc/` URL the renderer can fetch.

## Changes

- **New `DocGenService.materialiseInlineHtmlImages(templateId, html)`** — `indexOf`-based scan for `data:` URI `<img>` sources (never a `Matcher` over the string; a single embedded image can be hundreds of KB and that throws `Regex too complicated`). Decodes → SHA-256 → `docgen_html_img_<templateId>_<hash>` CV (the title prefix `listHtmlTemplateImages`, the clone re-key, and the signature-image allowlist already match on). Deduped by content hash, so the same logo is one file across every template and render; re-running is a no-op. `SYSTEM_MODE` insert (package-managed assets; the render-path fallback can run in a guest context). Never throws — malformed base64 and a DML failure both leave the affected `data:` URI in place; a ~5 MB total-decoded cap stops a pathological body from a mid-run heap crash.
- **Wired at save time**, because `Blob.toPdf`'s server-side image fetch **cannot see a `ContentVersion` inserted in the same transaction as the `toPdf` call** (isolated and confirmed on a scratch org — a committed image embeds at full size, a same-transaction one renders blank):
  - `DocGenController.saveHtmlTemplateBody` — before the body is stored (and before the `hasSubstantiveHtml` regex a big blob would trip)
  - `DocGenController.saveTemplate` — on `Header_Html__c` / `Footer_Html__c`, written back into the `fields` map so the version snapshot stores the materialised markup too
  - `DocGenController.importTemplateBundle` — on the body bytes and both header/footer bands, alongside the existing shepherd-URL re-key (not gated on `isHtmlBacked`: Word templates carry HTML header/footer bands that also need re-keying)
- **`DocGenService.mergeHtmlTemplate`** calls it as a **self-healing render fallback** for bodies that never passed a write path — the first render still shows blank images (CVs uncommitted), but they're on disk now, so every later render resolves them.
- `CHANGELOG.md` entry under Unreleased → Fixed.

## Testing

- [x] Ran Apex unit tests (`RunLocalTests`) — **2020 methods, 0 failures**. Impacted suites (`DocGenControllerTests`, `DocGenHtmlTemplateTest`, `DocGenHtmlRendererTest`, `DocGenMiscTests`, `DocGenGiantQueryTest`) all green.
- [x] Tested manually in a scratch org — **save and generate in separate transactions**:
  - HTML template with `data:` URIs in body ×2 + header + footer (all the same 84 KB PNG) → **85,682-byte PDF**, one deduped image XObject (`/Width 200 /Height 140`, 84,177-byte stream), image renders in all four positions. Rendered HTML: 0 `data:image`, 4 resolved `/sfc/` URLs.
  - Word template with a 112 KB `data:` URI in its HTML header band → materialised on save, **no `Regex too complicated`**, Word→PDF still renders.
- [x] Added `DocGenInlineImageTest` (13 methods): rewrite + CV creation, hash dedupe, single-quote `src`, `jpeg`→`.jpg`, malformed base64 left in place, no-op on a clean body, null template, `saveHtmlTemplateBody` strips `data:`, large inline image doesn't throw, render-path fallback commits the CVs, `saveTemplate` header/footer bands, bundle-import body+header+footer.
- `sf code-analyzer` (Security + AppExchange, scoped to changed files) — 0 code findings.

## Related Issues

Closes #377

## Checklist

- [x] No hardcoded IDs, URLs, or credentials
- [x] No `VersionData` in PDF image queries (see CLAUDE.md)
- [x] SOQL/DML — the new asset inserts use `SYSTEM_MODE` deliberately (package-managed image assets; the render-path fallback can run as a guest user), matching the existing `saveHtmlTemplateImage` pattern
- [x] No new external dependencies introduced

## Notes for reviewers

- Not retroactive on its own: an org on an older package version still needs affected templates re-saved (or the render-path self-heal after two generations). An optional backfill action is noted in #377.
- The `stripStyleAndScriptBlocks` "Regex too complicated" ceiling (its own `replaceAll`) is **not** touched here — same class as #325/#362, tracked separately. This PR incidentally removes the crash for the `data:`-URI case because the blob is gone before that regex runs.

