### PR TITLE
fix(designer): don't warn of unsaved changes when closing after a save…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ Two small fixes where the editor promised something the PDF did not deliver.
   resolve to the base-14 bold faces (verified selecting Helvetica-Bold / Times-Bold /
   Courier-Bold in a real org).
 
+- **The template editor no longer warns about unsaved changes right after a save
+  (#370).** "Save Template Details" and "Save as New Version" both deliberately leave the
+  edit modal open, but neither re-baselined the modal's change-detection snapshot — so
+  the next **Close** always prompted to discard edits that were already persisted on the
+  record. Both save paths now re-snapshot after a successful save; a genuine edit made
+  _after_ the save still moves the snapshot and still warns.
+
 ## v3.55.0 — Element linking, named blocks, client-side charts
 
 Released 2026-08-08 · `04tVx0000010fXFIAY` · ancestor 3.54.0 · 1,957 tests, 78% coverage

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -5695,6 +5695,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
             await saveTemplate({ fields: fields, createVersion: false, contentVersionId: null });
             this.showToast('Success', 'Template Details saved.', 'success');
+            // The modal stays open after a details save; re-baseline the
+            // unsaved-changes snapshot so a following Close doesn't warn about
+            // edits that are now persisted on the record (#370).
+            this._editSnapshot = this._editFieldSignature();
             return refreshApex(this.wiredTemplatesResult);
         } catch (error) {
             this.showToast('Error saving template', error.body ? error.body.message : error.message, 'error');
@@ -5850,6 +5854,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 this.loadVersions(this.editTemplateId);
             }
             this.activeEditTab = this.editTemplateType === 'PDF' ? 'pdfFields' : 'document';
+            // "Save as New Version" deliberately leaves the modal open (authors
+            // want to preview/test the new version straight away). Re-baseline the
+            // unsaved-changes snapshot against the just-saved values so clicking
+            // Close afterwards doesn't falsely prompt to discard changes (#370).
+            this._editSnapshot = this._editFieldSignature();
             return refreshApex(this.wiredTemplatesResult);
         } catch (error) {
             this.showToast('Error saving template', error.body ? error.body.message : error.message, 'error');

--- a/scripts/qa/suites/ui-admin.mjs
+++ b/scripts/qa/suites/ui-admin.mjs
@@ -1776,6 +1776,38 @@ export async function run({ org, headed }) {
                 )
             );
 
+            // 5d-bis. #370 — the modal deliberately stays open after "Save as New
+            // Version". Closing it now must NOT prompt to discard: the edits were
+            // just persisted. The bug: the save handlers never re-baselined
+            // _editSnapshot, so it kept its pre-edit value and Close always warned.
+            await drainToasts(page);
+            nativeDialogs.length = 0;
+            await clickByText(page, 'lightning-button', 'Close', { exact: true });
+            await wait(2500);
+            const falseDiscardPrompt = await ev(
+                page,
+                `return ((__dgFind('[role="alertdialog"], .slds-modal', true) || [])
+           .map((d) => __deep(d))
+           .filter((t) => /unsaved changes|discard them|discard changes/i.test(t)))[0] || null;`,
+                null
+            );
+            const closedAfterSave = (await ev(page, `return !__dgFind('.slds-modal');`, false)) === true;
+            add(
+                check(
+                    'closing the modal right after a save does not prompt to discard (#370)',
+                    !falseDiscardPrompt && closedAfterSave,
+                    falseDiscardPrompt
+                        ? `Close warned "${String(falseDiscardPrompt).slice(0, 90)}" although Save as New Version had just succeeded — the save handlers in docGenAdmin.js must re-baseline _editSnapshot`
+                        : closedAfterSave
+                          ? ''
+                          : 'no false discard prompt, but the modal did not close on Close either',
+                    SEVERITY.MAJOR
+                )
+            );
+            // Clear a stray confirm (if any) so the next block starts clean.
+            await clickByText(page, 'button', 'Cancel', { exact: true });
+            await wait(600);
+
             // 5e. CLOSING WITHOUT SAVING must not silently bin the work.
             try {
                 await clickByText(page, '[role="tab"]', 'Your Templates');


### PR DESCRIPTION
Closes #370

## Summary

The template edit modal's "you have unsaved changes" prompt fired on **every** close after a save. "Save as New Version" and "Save Details" deliberately leave the modal open, but neither re-baselined the dirty-check snapshot — so clicking Close afterwards always warned about edits that were already persisted.

## Changes

- **`docGenAdmin.js`** — re-baseline `_editSnapshot` to the just-saved field signature at the end of both successful save paths (`handleSaveOnly`, `handleSaveAndClose`). After a save, "no unsaved changes" is now a true statement, so Close proceeds silently. A genuine *post-save* edit still moves the signature and still warns — that path is untouched.
- **`scripts/qa/suites/ui-admin.mjs`** — new regression check (`5d-bis`): after "Save as New Version", clicking Close must not raise a discard prompt and must actually close the modal. The suite previously only tested the opposite direction (a real unsaved edit *should* warn).

## Testing

- [x] Tested manually against a scratch org (Playwright): edit a field → Save as New Version → Close → modal closes silently (before: false "Discard changes?" prompt + modal stuck open). Control case (open, no edits, Close) unaffected.
- [x] Added a `ui-admin` suite assertion for the new behaviour
- [x] `prettier --check` clean
- [ ] Full `npm run qa` / `RunLocalTests` / `code-analyzer` — deferred to CI (LWC-only change; no Apex touched, so Apex tests and coverage are unaffected)

## Related Issues

Closes #370

## Screenshots

_Behaviour change only — no visual change. The "Discard changes?" `LightningConfirm` simply no longer appears when there is nothing unsaved._

## Checklist

- [x] No hardcoded IDs, URLs, or credentials
- [x] No `VersionData` in PDF image queries (N/A — no SOQL changed)
- [x] SOQL uses `WITH USER_MODE` / `Security.stripInaccessible()` where appropriate (N/A — no SOQL changed)
- [x] No new external dependencies introduced
