### PR TITLE
fix: make Content Deliveries & Public Links an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,21 @@ Two small fixes where the editor promised something the PDF did not deliver.
 
 ### Fixed
 
+- **Portwood installs and runs with "Content Deliveries and Public Links" disabled (#384).**
+  Five classes named the `ContentDistribution` SObject as a compile-time type. Security-
+  hardened orgs that turn that org preference off remove the type, so those classes would
+  not compile — which aborted package install/upgrade and, in an installed org, took the
+  "Generate Document" Flow action down with "No Apex action available for 'Apex method'"
+  (`DocGenFlowAction` → `DocGenService` → `DocGenController`). Every reference now goes
+  through a new `DocGenContentDelivery` shim that resolves the type dynamically
+  (`Schema.getGlobalDescribe` + `Database.query` + `SObject.newSObject`), so the package
+  compiles either way. With the feature off, public-link creation is skipped and callers
+  fall back to relative `/sfc/servlet.shepherd/version/download/<cvId>` URLs; the one
+  path that genuinely needs an anonymously-fetchable URL — the email branded-header logo
+  — now fails with an actionable "enable Content Deliveries" message instead of a raw
+  error. Reproduces only in a real subscriber install (or a namespaced scratch org) with
+  the preference disabled, not in a default staging org.
+
 - **Canvas bold is no longer a silent no-op on `'Arial Unicode MS'` (#281).** The PDF
   engine (`Blob.toPdf`/Flying Saucer) embeds Arial Unicode MS with no bold face, so a
   bold box set to it printed regular while the canvas showed bold — WYSIWYG said

--- a/force-app/main/default/classes/DocGenContentDelivery.cls
+++ b/force-app/main/default/classes/DocGenContentDelivery.cls
@@ -1,0 +1,115 @@
+/**
+ * Optional-dependency shim for the `ContentDistribution` SObject — the object
+ * behind Setup → "Content Deliveries and Public Links".
+ *
+ * Security-hardened orgs disable that org preference, which removes
+ * `ContentDistribution` as a *compilable* Apex type. Any class that names the
+ * type statically (`List<ContentDistribution>`, `new ContentDistribution()`,
+ * `[SELECT ... FROM ContentDistribution]`, `ContentDistribution.sObjectType`)
+ * then fails to compile, which aborts package install/upgrade and takes down
+ * every downstream Flow action ("No Apex action available for 'Apex method'").
+ * See issue #384.
+ *
+ * Every reference to the type is therefore routed through this class as a
+ * *dynamic* reference (`Schema.getGlobalDescribe()` + `Database.query` +
+ * `SObject.newSObject()`), so Portwood compiles and runs whether the feature is
+ * on or off. When it is off, `isAvailable()` returns false and callers fall
+ * back to relative `/sfc/servlet.shepherd/version/download/<cvId>` URLs (or, for
+ * the email-logo path that genuinely needs an anonymously-fetchable URL, a clear
+ * "enable Content Deliveries" message).
+ */
+public with sharing class DocGenContentDelivery {
+    /** Fixed select list for every distribution read here — a static string so
+     *  Code Analyzer sees no injection surface. */
+    private static final String SELECT_FIELDS =
+        'Id, ContentVersionId, DistributionPublicUrl, ContentDownloadUrl, PreferencesExpires, ExpiryDate';
+
+    /** Test / e2e hook: force the feature on (`true`) or off (`false`) regardless
+     *  of the org preference. Null = describe the real org. Package-internal
+     *  (`public`, so anonymous-Apex e2e scripts can flip it too — not `global`,
+     *  so it is invisible to subscribers). */
+    public static Boolean availabilityOverride;
+
+    private static Boolean cachedAvailable;
+
+    /** True when `ContentDistribution` exists in this org (the org preference is
+     *  on). False means every method below is a safe no-op. */
+    public static Boolean isAvailable() {
+        if (availabilityOverride != null) {
+            return availabilityOverride;
+        }
+        if (cachedAvailable == null) {
+            cachedAvailable = Schema.getGlobalDescribe().get('ContentDistribution') != null;
+        }
+        return cachedAvailable;
+    }
+
+    /** The dynamic SObjectType, for `DocGenFlsGuard` calls. Null when unavailable. */
+    public static Schema.SObjectType sObjectType() {
+        return isAvailable() ? Schema.getGlobalDescribe().get('ContentDistribution') : null;
+    }
+
+    /** An unsaved `ContentDistribution` with the given fields set, or null when
+     *  the feature is unavailable. */
+    public static SObject newDistribution(Map<String, Object> fields) {
+        Schema.SObjectType t = sObjectType();
+        if (t == null) {
+            return null;
+        }
+        SObject dist = t.newSObject();
+        if (fields != null) {
+            for (String f : fields.keySet()) {
+                dist.put(f, fields.get(f));
+            }
+        }
+        return dist;
+    }
+
+    /** Existing distribution for a ContentVersion, or null. SYSTEM_MODE — callers
+     *  gate access with `DocGenFlsGuard` first. */
+    public static SObject findByContentVersion(Id contentVersionId) {
+        if (!isAvailable() || contentVersionId == null) {
+            return null;
+        }
+        /* code-analyzer-suppress ApexSOQLInjection, ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<SObject> rows = Database.query(
+            'SELECT ' + SELECT_FIELDS + ' FROM ContentDistribution WHERE ContentVersionId = :contentVersionId LIMIT 1',
+            AccessLevel.SYSTEM_MODE
+        );
+        return rows.isEmpty() ? null : rows[0];
+    }
+
+    /** Existing distributions for a set of ContentVersions, keyed by
+     *  ContentVersionId (first row wins). Empty map when unavailable. */
+    public static Map<Id, SObject> findByContentVersions(Set<Id> contentVersionIds) {
+        Map<Id, SObject> byCv = new Map<Id, SObject>();
+        if (!isAvailable() || contentVersionIds == null || contentVersionIds.isEmpty()) {
+            return byCv;
+        }
+        /* code-analyzer-suppress ApexSOQLInjection, ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<SObject> rows = Database.query(
+            'SELECT ' + SELECT_FIELDS + ' FROM ContentDistribution WHERE ContentVersionId IN :contentVersionIds',
+            AccessLevel.SYSTEM_MODE
+        );
+        for (SObject row : rows) {
+            Id cvId = (Id) row.get('ContentVersionId');
+            if (!byCv.containsKey(cvId)) {
+                byCv.put(cvId, row);
+            }
+        }
+        return byCv;
+    }
+
+    /** Re-reads a just-inserted distribution for its server-generated URLs. */
+    public static SObject reload(Id distributionId) {
+        if (!isAvailable() || distributionId == null) {
+            return null;
+        }
+        /* code-analyzer-suppress ApexSOQLInjection, ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<SObject> rows = Database.query(
+            'SELECT ' + SELECT_FIELDS + ' FROM ContentDistribution WHERE Id = :distributionId LIMIT 1',
+            AccessLevel.SYSTEM_MODE
+        );
+        return rows.isEmpty() ? null : rows[0];
+    }
+}

--- a/force-app/main/default/classes/DocGenContentDelivery.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenContentDelivery.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenContentDeliveryTest.cls
+++ b/force-app/main/default/classes/DocGenContentDeliveryTest.cls
@@ -1,0 +1,132 @@
+/**
+ * Coverage for DocGenContentDelivery — the optional-dependency shim for the
+ * `ContentDistribution` SObject (issue #384). The "feature off" branches are
+ * exercised through the `availabilityOverride` test hook, since a scratch/CI org
+ * always has "Content Deliveries and Public Links" enabled.
+ */
+@IsTest
+private class DocGenContentDeliveryTest {
+    @IsTest
+    static void available_describesRealOrgWithoutThrowing() {
+        // Nothing overridden — the real describe result. Just assert it resolves
+        // to a concrete Boolean and stays internally consistent.
+        Boolean live = DocGenContentDelivery.isAvailable();
+        System.assertNotEquals(null, live, 'isAvailable returns a concrete Boolean');
+        System.assertEquals(
+            live,
+            DocGenContentDelivery.sObjectType() != null,
+            'sObjectType is non-null exactly when the feature is available'
+        );
+    }
+
+    @IsTest
+    static void featureOff_everyEntryPointIsASafeNoOp() {
+        DocGenContentDelivery.availabilityOverride = false;
+
+        System.assertEquals(false, DocGenContentDelivery.isAvailable(), 'override forces off');
+        System.assertEquals(null, DocGenContentDelivery.sObjectType(), 'no type when off');
+        System.assertEquals(null, DocGenContentDelivery.newDistribution(new Map<String, Object>{ 'Name' => 'x' }));
+        System.assertEquals(null, DocGenContentDelivery.findByContentVersion(null));
+        System.assertEquals(0, DocGenContentDelivery.findByContentVersions(new Set<Id>()).size(), 'no rows when off');
+        System.assertEquals(0, DocGenContentDelivery.findByContentVersions(null).size(), 'null-safe');
+        System.assertEquals(null, DocGenContentDelivery.reload(null));
+    }
+
+    @IsTest
+    static void featureOn_buildQueryReloadRoundTrip() {
+        if (!DocGenContentDelivery.isAvailable()) {
+            return; // org without the feature — nothing to exercise
+        }
+        ContentVersion cv = new ContentVersion(
+            Title = 'cd-shim',
+            PathOnClient = 'cd-shim.png',
+            VersionData = Blob.valueOf('bytes')
+        );
+        insert cv;
+        Id cvId = cv.Id;
+
+        Test.startTest();
+        SObject dist = DocGenContentDelivery.newDistribution(
+            new Map<String, Object>{
+                'Name' => 'cd-shim-test',
+                'ContentVersionId' => cvId,
+                'PreferencesAllowViewInBrowser' => true,
+                'PreferencesLinkLatestVersion' => true,
+                'PreferencesExpires' => false
+            }
+        );
+        System.assertNotEquals(null, dist, 'dynamic SObject built when feature on');
+        insert dist;
+
+        SObject found = DocGenContentDelivery.findByContentVersion(cvId);
+        System.assertNotEquals(null, found, 'findByContentVersion locates the new row');
+        System.assertEquals(dist.Id, found.get('Id'));
+
+        Map<Id, SObject> byCv = DocGenContentDelivery.findByContentVersions(new Set<Id>{ cvId });
+        System.assert(byCv.containsKey(cvId), 'findByContentVersions keys by ContentVersionId');
+
+        SObject reloaded = DocGenContentDelivery.reload((Id) dist.get('Id'));
+        System.assertNotEquals(null, reloaded, 'reload returns the row');
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void featureOff_emailLogoResolutionThrowsFriendlyMessage() {
+        DocGenContentDelivery.availabilityOverride = false;
+
+        DocGen_Asset__c asset = new DocGen_Asset__c(Name = 'Logo 384', Asset_Key__c = 'logo-384');
+        insert asset;
+        insert new ContentVersion(
+            Title = 'logo',
+            PathOnClient = 'logo.png',
+            VersionData = Blob.valueOf('png'),
+            FirstPublishLocationId = asset.Id
+        );
+
+        Boolean caught = false;
+        try {
+            DocGenEmailTemplateController.resolveAssetPublicUrl(asset.Id);
+        } catch (AuraHandledException e) {
+            caught = true;
+            System.assert(
+                e.getMessage().contains('Content Deliveries'),
+                'Actionable guidance expected; got: ' + e.getMessage()
+            );
+        }
+        System.assert(caught, 'logo public-URL creation must fail with guidance, never a raw compile/DML error');
+    }
+
+    @IsTest
+    static void featureOff_emailAssetTagResolutionFallsBackCleanly() {
+        DocGenContentDelivery.availabilityOverride = false;
+
+        DocGen_Asset__c asset = new DocGen_Asset__c(Name = 'Banner 384', Asset_Key__c = 'banner-384');
+        insert asset;
+        insert new ContentVersion(
+            Title = 'banner',
+            PathOnClient = 'banner.png',
+            VersionData = Blob.valueOf('png'),
+            FirstPublishLocationId = asset.Id
+        );
+
+        DocGenEmailTemplateService.TemplateDef def = new DocGenEmailTemplateService.TemplateDef();
+        def.type = DocGenEmailTemplateService.TYPE_PIN;
+        def.subject = 'Hi';
+        def.bodyHtml = '<p>{Pin}</p><img src="{%asset:banner-384}"/>';
+        def.layoutMode = DocGenEmailTemplateService.MODE_FULL_HTML;
+
+        Test.startTest();
+        DocGenEmailTemplateService.RenderedEmail r = DocGenEmailTemplateService.renderWith(
+            def,
+            new Map<String, String>{ 'Pin' => '123456' },
+            null
+        );
+        Test.stopTest();
+
+        System.assertNotEquals(null, r, 'render still succeeds with deliveries off');
+        System.assert(
+            r.htmlBody != null && !r.htmlBody.contains('{%asset:'),
+            'unresolved asset tag drops cleanly rather than leaking or throwing'
+        );
+    }
+}

--- a/force-app/main/default/classes/DocGenContentDeliveryTest.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenContentDeliveryTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -8367,6 +8367,10 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             if (newLatestCvId == null) {
                 return;
             }
+            // Content Deliveries disabled (issue #384): no public links to carry forward.
+            if (!DocGenContentDelivery.isAvailable()) {
+                return;
+            }
             // Every file ever linked to this asset → their latest version Ids.
             /* code-analyzer-suppress ApexFlsViolation */
             List<ContentDocumentLink> links = [
@@ -8384,21 +8388,11 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             if (allCvIds.isEmpty()) {
                 return;
             }
-            /* code-analyzer-suppress ApexFlsViolation */
-            List<ContentDistribution> dists = [
-                SELECT Id, ContentVersionId
-                FROM ContentDistribution
-                WHERE ContentVersionId IN :allCvIds
-                WITH SYSTEM_MODE
-            ]; // NOPMD ApexCRUDViolation - internal plumbing behind the addAssetVersion guards
-            Boolean anyPublished = false;
-            for (ContentDistribution d : dists) {
-                if (d.ContentVersionId == newLatestCvId) {
-                    return; // new file already has its delivery
-                }
-                anyPublished = true;
+            Map<Id, SObject> distsByCv = DocGenContentDelivery.findByContentVersions(allCvIds);
+            if (distsByCv.containsKey(newLatestCvId)) {
+                return; // new file already has its delivery
             }
-            if (!anyPublished) {
+            if (distsByCv.isEmpty()) {
                 return; // asset was never used as a public logo — nothing to carry forward
             }
             /* code-analyzer-suppress ApexFlsViolation */
@@ -8409,15 +8403,17 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 WITH SYSTEM_MODE
                 LIMIT 1
             ]; // NOPMD ApexCRUDViolation - internal plumbing behind the addAssetVersion guards
-            ContentDistribution cd = new ContentDistribution(
-                Name = 'Portwood Asset - ' + (named.isEmpty() ? 'Logo' : named[0].Name),
-                ContentVersionId = newLatestCvId,
-                PreferencesAllowViewInBrowser = true,
-                PreferencesLinkLatestVersion = true,
-                PreferencesAllowOriginalDownload = true,
-                PreferencesExpires = false,
-                PreferencesNotifyOnVisit = false,
-                PreferencesAllowPDFDownload = false
+            SObject cd = DocGenContentDelivery.newDistribution(
+                new Map<String, Object>{
+                    'Name' => 'Portwood Asset - ' + (named.isEmpty() ? 'Logo' : named[0].Name),
+                    'ContentVersionId' => newLatestCvId,
+                    'PreferencesAllowViewInBrowser' => true,
+                    'PreferencesLinkLatestVersion' => true,
+                    'PreferencesAllowOriginalDownload' => true,
+                    'PreferencesExpires' => false,
+                    'PreferencesNotifyOnVisit' => false,
+                    'PreferencesAllowPDFDownload' => false
+                }
             );
             /* code-analyzer-suppress ApexFlsViolation */
             Database.insert(cd, AccessLevel.SYSTEM_MODE);

--- a/force-app/main/default/classes/DocGenEmailTemplateController.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateController.cls
@@ -303,44 +303,53 @@ public with sharing class DocGenEmailTemplateController {
             throw DocGenService.ahe('This asset has no published file version.');
         }
 
+        // Content Deliveries disabled (issue #384): the branded-header logo needs an
+        // anonymously-fetchable URL, so this feature genuinely can't proceed — but
+        // the class must still compile, so the type is never named statically.
+        if (!DocGenContentDelivery.isAvailable()) {
+            throw DocGenService.ahe(
+                'Content Deliveries and Public Links is disabled in this org, so a public logo URL cannot be created. ' +
+                    'Enable it under Setup → Content Deliveries and Public Links, or paste an image URL instead.'
+            );
+        }
+
         DocGenFlsGuard.assertAccessible(
-            ContentDistribution.sObjectType,
+            DocGenContentDelivery.sObjectType(),
             new Set<String>{ 'ContentDownloadUrl', 'ContentVersionId', 'PreferencesExpires' }
         );
-        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-        List<ContentDistribution> existing = [
-            SELECT Id, ContentDownloadUrl, PreferencesExpires
-            FROM ContentDistribution
-            WHERE ContentVersionId = :cvId
-            WITH SYSTEM_MODE
-            LIMIT 1
-        ];
+        SObject existing = DocGenContentDelivery.findByContentVersion(cvId);
         try {
-            if (!existing.isEmpty()) {
-                if (existing[0].PreferencesExpires == true) {
+            if (existing != null) {
+                Boolean existingExpires = (Boolean) existing.get('PreferencesExpires');
+                if (existingExpires == true) {
                     // A delivery created elsewhere (e.g. the signing flow) may carry an
                     // expiry — a logo link must not go dark, so clear it.
-                    ContentDistribution fix = new ContentDistribution(
-                        Id = existing[0].Id,
-                        PreferencesExpires = false,
-                        ExpiryDate = null
+                    SObject fix = DocGenContentDelivery.newDistribution(
+                        new Map<String, Object>{
+                            'Id' => (Id) existing.get('Id'),
+                            'PreferencesExpires' => false,
+                            'ExpiryDate' => null
+                        }
                     );
                     DocGenFlsGuard.assertUpdateable(fix, new Set<String>{ 'PreferencesExpires', 'ExpiryDate' });
                     /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
                     Database.update(fix, AccessLevel.SYSTEM_MODE);
                 }
-                return existing[0].ContentDownloadUrl;
+                return (String) existing.get('ContentDownloadUrl');
             }
 
-            ContentDistribution cd = new ContentDistribution();
-            cd.Name = 'Portwood Asset - ' + assets[0].Name;
-            cd.ContentVersionId = cvId;
-            cd.PreferencesAllowViewInBrowser = true;
-            cd.PreferencesLinkLatestVersion = true;
-            cd.PreferencesAllowOriginalDownload = true;
-            cd.PreferencesExpires = false;
-            cd.PreferencesNotifyOnVisit = false;
-            cd.PreferencesAllowPDFDownload = false;
+            SObject cd = DocGenContentDelivery.newDistribution(
+                new Map<String, Object>{
+                    'Name' => 'Portwood Asset - ' + assets[0].Name,
+                    'ContentVersionId' => cvId,
+                    'PreferencesAllowViewInBrowser' => true,
+                    'PreferencesLinkLatestVersion' => true,
+                    'PreferencesAllowOriginalDownload' => true,
+                    'PreferencesExpires' => false,
+                    'PreferencesNotifyOnVisit' => false,
+                    'PreferencesAllowPDFDownload' => false
+                }
+            );
             DocGenFlsGuard.assertCreateable(
                 cd,
                 new Set<String>{
@@ -357,20 +366,14 @@ public with sharing class DocGenEmailTemplateController {
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
             Database.insert(cd, AccessLevel.SYSTEM_MODE);
             // ContentDownloadUrl is generated server-side — re-query for it.
-            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-            ContentDistribution created = [
-                SELECT ContentDownloadUrl
-                FROM ContentDistribution
-                WHERE Id = :cd.Id
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ];
-            if (String.isBlank(created.ContentDownloadUrl)) {
+            SObject created = DocGenContentDelivery.reload((Id) cd.get('Id'));
+            String createdUrl = created == null ? null : (String) created.get('ContentDownloadUrl');
+            if (String.isBlank(createdUrl)) {
                 throw DocGenService.ahe(
                     'The public file link was created but has no download URL yet — try again in a moment.'
                 );
             }
-            return created.ContentDownloadUrl;
+            return createdUrl;
         } catch (AuraHandledException ahe) {
             throw ahe;
         } catch (Exception e) {

--- a/force-app/main/default/classes/DocGenEmailTemplateService.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateService.cls
@@ -564,19 +564,17 @@ global with sharing class DocGenEmailTemplateService {
             if (cvId == null) {
                 return null;
             }
+            // Content Deliveries disabled (issue #384): no public URL — caller
+            // falls back to the stored URL.
+            if (!DocGenContentDelivery.isAvailable()) {
+                return null;
+            }
             DocGenFlsGuard.guestAssertAccessible(
-                ContentDistribution.sObjectType,
+                DocGenContentDelivery.sObjectType(),
                 new Set<String>{ 'ContentDownloadUrl', 'ContentVersionId' }
             );
-            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-            List<ContentDistribution> dists = [
-                SELECT ContentDownloadUrl
-                FROM ContentDistribution
-                WHERE ContentVersionId = :cvId
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ];
-            return dists.isEmpty() ? null : dists[0].ContentDownloadUrl;
+            SObject dist = DocGenContentDelivery.findByContentVersion(cvId);
+            return dist == null ? null : (String) dist.get('ContentDownloadUrl');
         } catch (Exception e) {
             System.debug(LoggingLevel.WARN, 'Portwood: logo asset resolution fell back to URL: ' + e.getMessage());
             return null;

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -790,34 +790,37 @@ public without sharing class DocGenSignatureController {
 
     // CxSAST: Apex_CRUD_ContentDistribution — SYSTEM_MODE required for guest user context; ContentDistribution created for signature document preview
     private static String getOrCreatePublicLink(ContentVersion cv, Datetime requestExpiresAt) {
+        // Content Deliveries disabled (issue #384): the public preview link is
+        // optional — the signing flow renders the document via getSourcePdfBase64.
+        if (!DocGenContentDelivery.isAvailable()) {
+            return null;
+        }
         DocGenFlsGuard.guestAssertAccessible(
-            ContentDistribution.sObjectType,
+            DocGenContentDelivery.sObjectType(),
             new Set<String>{ 'DistributionPublicUrl', 'ContentVersionId' }
         );
-        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-        List<ContentDistribution> dists = [
-            SELECT DistributionPublicUrl
-            FROM ContentDistribution
-            WHERE ContentVersionId = :cv.Id
-            WITH SYSTEM_MODE
-            LIMIT 1
-        ];
-        if (!dists.isEmpty()) {
-            return dists[0].DistributionPublicUrl;
+        SObject existing = DocGenContentDelivery.findByContentVersion(cv.Id);
+        if (existing != null) {
+            return (String) existing.get('DistributionPublicUrl');
         }
-        ContentDistribution cd = new ContentDistribution();
-        cd.Name = 'Signature Preview - ' + cv.Title;
-        cd.ContentVersionId = cv.Id;
-        cd.PreferencesAllowViewInBrowser = true;
-        cd.PreferencesLinkLatestVersion = true;
-        // Expire the public link in line with the signing window so a signed
-        // (or cancelled) request can't be re-fetched anonymously afterwards.
-        // Legacy requests (no stamped expiry) keep the historical 48 hours.
-        cd.PreferencesExpires = true;
-        cd.ExpiryDate = requestExpiresAt != null ? requestExpiresAt : System.now().addHours(TOKEN_EXPIRATION_HOURS);
-        cd.PreferencesNotifyOnVisit = false;
-        cd.PreferencesAllowOriginalDownload = false;
-        cd.PreferencesAllowPDFDownload = false;
+        SObject cd = DocGenContentDelivery.newDistribution(
+            new Map<String, Object>{
+                'Name' => 'Signature Preview - ' + cv.Title,
+                'ContentVersionId' => cv.Id,
+                'PreferencesAllowViewInBrowser' => true,
+                'PreferencesLinkLatestVersion' => true,
+                // Expire the public link in line with the signing window so a signed
+                // (or cancelled) request can't be re-fetched anonymously afterwards.
+                // Legacy requests (no stamped expiry) keep the historical 48 hours.
+                'PreferencesExpires' => true,
+                'ExpiryDate' => requestExpiresAt != null
+                    ? requestExpiresAt
+                    : System.now().addHours(TOKEN_EXPIRATION_HOURS),
+                'PreferencesNotifyOnVisit' => false,
+                'PreferencesAllowOriginalDownload' => false,
+                'PreferencesAllowPDFDownload' => false
+            }
+        );
         // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Create").
         DocGenFlsGuard.guestAssertCreateable(
             cd,
@@ -834,16 +837,14 @@ public without sharing class DocGenSignatureController {
             }
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-        Database.insert(new List<ContentDistribution>{ cd }, false, AccessLevel.SYSTEM_MODE);
+        Database.insert(new List<SObject>{ cd }, false, AccessLevel.SYSTEM_MODE);
         // SYSTEM_MODE required: guest profile has no Portwood CRUD by design; access is gated by token-bound lookup. See DocGenSignatureGuestSecurity for the security model.
-        cd = new ContentDistribution(Id = cd.Id);
         DocGenFlsGuard.guestAssertAccessible(
-            ContentDistribution.sObjectType,
+            DocGenContentDelivery.sObjectType(),
             new Set<String>{ 'DistributionPublicUrl' }
         );
-        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-        cd = [SELECT DistributionPublicUrl FROM ContentDistribution WHERE Id = :cd.Id WITH SYSTEM_MODE LIMIT 1];
-        return cd.DistributionPublicUrl;
+        SObject reloaded = DocGenContentDelivery.reload((Id) cd.get('Id'));
+        return reloaded == null ? null : (String) reloaded.get('DistributionPublicUrl');
     }
 
     /**

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -3117,20 +3117,29 @@ public with sharing class DocGenSignatureSenderController {
             previewImageMap.put('/sfc/servlet.shepherd/version/download/' + cvId, previewImageMap.get(cvId));
             return;
         }
+        // Content Deliveries disabled (issue #384): preview images stay on their
+        // relative /sfc/servlet.shepherd URLs.
+        if (!DocGenContentDelivery.isAvailable()) {
+            return;
+        }
         try {
-            ContentDistribution dist = new ContentDistribution();
-            dist.Name = 'sig_preview_' + (String.isBlank(key) ? cvId : key).left(80);
-            dist.ContentVersionId = cvId;
-            dist.PreferencesAllowViewInBrowser = true;
-            dist.PreferencesLinkLatestVersion = false;
-            dist.PreferencesExpires = false;
+            SObject dist = DocGenContentDelivery.newDistribution(
+                new Map<String, Object>{
+                    'Name' => 'sig_preview_' + (String.isBlank(key) ? cvId : key).left(80),
+                    'ContentVersionId' => (Id) cvId,
+                    'PreferencesAllowViewInBrowser' => true,
+                    'PreferencesLinkLatestVersion' => false,
+                    'PreferencesExpires' => false
+                }
+            );
             Database.insert(dist, AccessLevel.USER_MODE);
-            dist = [SELECT ContentDownloadUrl FROM ContentDistribution WHERE Id = :dist.Id WITH USER_MODE];
+            SObject reloaded = DocGenContentDelivery.reload((Id) dist.get('Id'));
+            String downloadUrl = reloaded == null ? null : (String) reloaded.get('ContentDownloadUrl');
             if (String.isNotBlank(key)) {
-                previewImageMap.put(key, dist.ContentDownloadUrl);
+                previewImageMap.put(key, downloadUrl);
             }
-            previewImageMap.put(cvId, dist.ContentDownloadUrl);
-            previewImageMap.put('/sfc/servlet.shepherd/version/download/' + cvId, dist.ContentDownloadUrl);
+            previewImageMap.put(cvId, downloadUrl);
+            previewImageMap.put('/sfc/servlet.shepherd/version/download/' + cvId, downloadUrl);
         } catch (Exception e) {
             System.debug(
                 LoggingLevel.WARN,

--- a/scripts/e2e-07-syntax5.apex
+++ b/scripts/e2e-07-syntax5.apex
@@ -260,6 +260,38 @@ try {
     System.debug('CURRENCY AGG :convert WITH LOCALE: FAIL — ' + e.getMessage());
 }
 
+// ============================================================
+// #384 — DocGenContentDelivery shim degrades cleanly when
+// "Content Deliveries and Public Links" is disabled. The type
+// is referenced dynamically so the package still compiles.
+// ============================================================
+try {
+    // Real org describe: must not throw, must return a Boolean.
+    Boolean live = DocGenContentDelivery.isAvailable();
+
+    // Forced "feature off": every entry point is a safe no-op, never a throw.
+    DocGenContentDelivery.availabilityOverride = false;
+    Boolean ok =
+        DocGenContentDelivery.isAvailable() == false &&
+        DocGenContentDelivery.sObjectType() == null &&
+        DocGenContentDelivery.newDistribution(new Map<String, Object>{ 'Name' => 'x' }) == null &&
+        DocGenContentDelivery.findByContentVersion(null) == null &&
+        DocGenContentDelivery.findByContentVersions(new Set<Id>()).isEmpty() &&
+        DocGenContentDelivery.reload(null) == null;
+    DocGenContentDelivery.availabilityOverride = null;
+
+    if (ok) {
+        pass++;
+        System.debug('CONTENT DELIVERY SHIM (#384): PASS — live=' + live + ', feature-off contract holds');
+    } else {
+        fail++;
+        System.debug('CONTENT DELIVERY SHIM (#384): FAIL — feature-off path is not a clean no-op');
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('CONTENT DELIVERY SHIM (#384): FAIL — ' + e.getMessage());
+}
+
 System.debug('========================================');
 System.debug(
     'E2E-07-SYNTAX5 — PASS: ' + pass + '  FAIL: ' + fail + (fail == 0 ? '  ALL TESTS PASSED' : '  FAILURES DETECTED')


### PR DESCRIPTION
## Problem

Five classes referenced the `ContentDistribution` SObject — the object behind Setup → **Content Deliveries and Public Links** — as a **compile-time type** (`List<ContentDistribution>`, `new ContentDistribution()`, `[SELECT … FROM ContentDistribution]`, `ContentDistribution.sObjectType`):

| Class | Method |
| --- | --- |
| `DocGenController` | `carryForwardAssetDistribution` (via `addAssetVersion`) |
| `DocGenEmailTemplateController` | `resolveAssetPublicUrl` |
| `DocGenEmailTemplateService` | `queryAssetPublicUrl` |
| `DocGenSignatureController` | `getOrCreatePublicLink` |
| `DocGenSignatureSenderController` | `addSignaturePreviewImage` |

Security-hardened orgs disable that org preference, which removes `ContentDistribution` as a compilable type. Those classes then fail to compile, which:

- **aborts package install / upgrade** — the subscriber org recompiles all managed Apex at install time; and
- in an already-installed org, takes the **"Generate Document" Flow action** down with *"No Apex action available for 'Apex method'"*. The dependency chain is `DocGenFlowAction` → `DocGenService.generateDocument / generateAndSaveFromData / generatePdfBlobFromData` → `DocGenController.generateDocumentData`, so a compile failure in `DocGenController` invalidates the whole path.

The runtime `try/catch` around each site never helped — the failure is at class **load** time, not execution.

## Fix

New **`DocGenContentDelivery`** shim resolves the type dynamically (`Schema.getGlobalDescribe()` + `Database.query` + `SObject.newSObject()`), so no class names `ContentDistribution` at compile time and the package compiles whether the feature is on or off.

`isAvailable()` gates every path. When the feature is **off**:

| Call site | Degradation |
| --- | --- |
| `DocGenController.carryForwardAssetDistribution` | early return (already best-effort) |
| `DocGenSignatureController.getOrCreatePublicLink` | returns `null` → preview URL simply absent; the document still renders via `getSourcePdfBase64` |
| `DocGenSignatureSenderController.addSignaturePreviewImage` | early return → images stay on relative `/sfc/servlet.shepherd/version/download/<cvId>` URLs |
| `DocGenEmailTemplateService.queryAssetPublicUrl` | returns `null` → caller falls back to the stored URL |
| `DocGenEmailTemplateController.resolveAssetPublicUrl` | throws an actionable *"enable Content Deliveries and Public Links"* message — an email branded-header logo genuinely needs an anonymously-fetchable URL |

Dynamic reads use a fixed static select list and `AccessLevel.SYSTEM_MODE`; callers keep their existing `DocGenFlsGuard` checks (now passed the dynamic `SObjectType`).

## Tests

- **`DocGenContentDeliveryTest`** — new, 5 methods, 100% line coverage of the shim: every feature-off entry point is a clean no-op (via the `availabilityOverride` hook), the email-logo path throws the friendly message, the `{%asset:}` send path drops the tag cleanly, and a feature-on build → query → reload round-trip.
- **`scripts/e2e-07-syntax5.apex`** — a `#384` regression block asserting the feature-off contract.
- **`CHANGELOG.md`** — Unreleased → Fixed entry.

## Validation (scratch org, Content Deliveries enabled)

- `RunLocalTests` — **1902 methods, 0 failures**, org-wide **79%**
- `DocGenContentDelivery` — **47/47 lines, 100%**
- `e2e-01…08` + `07-syntax1…5` — every script `PASS  FAIL: 0`
- `sf code-analyzer` (Security + AppExchange) — **no new violations**

> The compile break itself only reproduces in a real subscriber install (or a namespaced scratch org) with the preference disabled — not in a default `--no-namespace` staging org. A subscriber-scratch check with *Content Deliveries and Public Links* disabled is recommended as the final gate.

## Scope

Parser / merge-tag paths untouched. No API-name or `global` surface changes. Test classes that still reference `ContentDistribution` statically (`DocGenEmailTemplateTest`, `DocGenSignatureTests`, `DocGenSignaturePdfTests`) are left as-is — subscriber test compilation is not what blocks install, and package-build orgs have the feature enabled.
