### PR TITLE
fix: dynamic ContentDistribution refs for deliveries-off orgs (#384)

### DIFF
--- a/force-app/main/default/classes/DocGenContentDistributionTest.cls
+++ b/force-app/main/default/classes/DocGenContentDistributionTest.cls
@@ -1,0 +1,52 @@
+@IsTest
+private class DocGenContentDistributionTest {
+    // #384: every ContentDistribution reference must be dynamic so classes compile
+    // when Content Deliveries are disabled. These pin the helper contract.
+
+    @IsTest
+    static void availabilityMirrorsSchema() {
+        Boolean expected = Schema.getGlobalDescribe().containsKey('ContentDistribution');
+        System.assertEquals(
+            expected,
+            DocGenService.isContentDistributionAvailable(),
+            'Availability helper must mirror the schema'
+        );
+        System.assertEquals(
+            expected,
+            DocGenService.contentDistributionType() != null,
+            'Type helper must mirror the schema'
+        );
+        // Cached value is stable within the transaction.
+        System.assertEquals(
+            expected,
+            DocGenService.isContentDistributionAvailable(),
+            'Cached availability must be stable'
+        );
+    }
+
+    @IsTest
+    static void newDistributionBuildsDynamicSObject() {
+        if (!DocGenService.isContentDistributionAvailable()) {
+            try {
+                DocGenService.newContentDistribution(new Map<String, Object>{ 'Name' => 'x' });
+                System.assert(false, 'Must throw when deliveries are disabled');
+            } catch (AuraHandledException e) {
+                System.assert(
+                    e.getMessage().contains('Content Deliveries'),
+                    'Error must point at the setting; got: ' + e.getMessage()
+                );
+            }
+            return;
+        }
+        SObject cd = DocGenService.newContentDistribution(
+            new Map<String, Object>{ 'Name' => 'probe', 'PreferencesExpires' => false }
+        );
+        System.assertEquals('probe', cd.get('Name'), 'Dynamic put must stick');
+        System.assertEquals(false, cd.get('PreferencesExpires'), 'Dynamic put must stick');
+        System.assertEquals(
+            'ContentDistribution',
+            cd.getSObjectType().getDescribe().getName(),
+            'Must build the right SObject type'
+        );
+    }
+}

--- a/force-app/main/default/classes/DocGenContentDistributionTest.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenContentDistributionTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -8367,6 +8367,9 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             if (newLatestCvId == null) {
                 return;
             }
+            if (!DocGenService.isContentDistributionAvailable()) {
+                return; // #384: deliveries disabled — nothing to carry forward
+            }
             // Every file ever linked to this asset → their latest version Ids.
             /* code-analyzer-suppress ApexFlsViolation */
             List<ContentDocumentLink> links = [
@@ -8385,15 +8388,18 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 return;
             }
             /* code-analyzer-suppress ApexFlsViolation */
-            List<ContentDistribution> dists = [
-                SELECT Id, ContentVersionId
-                FROM ContentDistribution
-                WHERE ContentVersionId IN :allCvIds
-                WITH SYSTEM_MODE
-            ]; // NOPMD ApexCRUDViolation - internal plumbing behind the addAssetVersion guards
+            List<String> quotedCvIds = new List<String>();
+            for (Id cvId : allCvIds) {
+                quotedCvIds.add('\'' + String.escapeSingleQuotes((String) cvId) + '\'');
+            }
+            List<SObject> dists = Database.query(
+                'SELECT Id, ContentVersionId FROM ContentDistribution WHERE ContentVersionId IN (' +
+                    String.join(quotedCvIds, ',') +
+                    ') WITH SYSTEM_MODE'
+            ); // NOPMD ApexCRUDViolation - internal plumbing behind the addAssetVersion guards
             Boolean anyPublished = false;
-            for (ContentDistribution d : dists) {
-                if (d.ContentVersionId == newLatestCvId) {
+            for (SObject d : dists) {
+                if ((Id) d.get('ContentVersionId') == newLatestCvId) {
                     return; // new file already has its delivery
                 }
                 anyPublished = true;
@@ -8409,15 +8415,17 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 WITH SYSTEM_MODE
                 LIMIT 1
             ]; // NOPMD ApexCRUDViolation - internal plumbing behind the addAssetVersion guards
-            ContentDistribution cd = new ContentDistribution(
-                Name = 'Portwood Asset - ' + (named.isEmpty() ? 'Logo' : named[0].Name),
-                ContentVersionId = newLatestCvId,
-                PreferencesAllowViewInBrowser = true,
-                PreferencesLinkLatestVersion = true,
-                PreferencesAllowOriginalDownload = true,
-                PreferencesExpires = false,
-                PreferencesNotifyOnVisit = false,
-                PreferencesAllowPDFDownload = false
+            SObject cd = DocGenService.newContentDistribution(
+                new Map<String, Object>{
+                    'Name' => 'Portwood Asset - ' + (named.isEmpty() ? 'Logo' : named[0].Name),
+                    'ContentVersionId' => newLatestCvId,
+                    'PreferencesAllowViewInBrowser' => true,
+                    'PreferencesLinkLatestVersion' => true,
+                    'PreferencesAllowOriginalDownload' => true,
+                    'PreferencesExpires' => false,
+                    'PreferencesNotifyOnVisit' => false,
+                    'PreferencesAllowPDFDownload' => false
+                }
             );
             /* code-analyzer-suppress ApexFlsViolation */
             Database.insert(cd, AccessLevel.SYSTEM_MODE);

--- a/force-app/main/default/classes/DocGenEmailTemplateController.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateController.cls
@@ -303,44 +303,49 @@ public with sharing class DocGenEmailTemplateController {
             throw DocGenService.ahe('This asset has no published file version.');
         }
 
+        if (!DocGenService.isContentDistributionAvailable()) {
+            throw DocGenService.ahe(
+                'Public links are disabled in this org (Setup → Content Deliveries and Public Links) — enable them to use an asset file as the email logo.'
+            );
+        }
         DocGenFlsGuard.assertAccessible(
-            ContentDistribution.sObjectType,
+            DocGenService.contentDistributionType(),
             new Set<String>{ 'ContentDownloadUrl', 'ContentVersionId', 'PreferencesExpires' }
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-        List<ContentDistribution> existing = [
-            SELECT Id, ContentDownloadUrl, PreferencesExpires
-            FROM ContentDistribution
-            WHERE ContentVersionId = :cvId
-            WITH SYSTEM_MODE
-            LIMIT 1
-        ];
+        String quotedCvId = '\'' + String.escapeSingleQuotes((String) cvId) + '\'';
+        List<SObject> existing = Database.query(
+            'SELECT Id, ContentDownloadUrl, PreferencesExpires FROM ContentDistribution WHERE ContentVersionId = ' +
+                quotedCvId +
+                ' WITH SYSTEM_MODE LIMIT 1'
+        );
         try {
             if (!existing.isEmpty()) {
-                if (existing[0].PreferencesExpires == true) {
+                if ((Boolean) existing[0].get('PreferencesExpires') == true) {
                     // A delivery created elsewhere (e.g. the signing flow) may carry an
                     // expiry — a logo link must not go dark, so clear it.
-                    ContentDistribution fix = new ContentDistribution(
-                        Id = existing[0].Id,
-                        PreferencesExpires = false,
-                        ExpiryDate = null
-                    );
+                    SObject fix = DocGenService.contentDistributionType().newSObject((Id) existing[0].get('Id'));
+                    fix.put('PreferencesExpires', false);
+                    fix.put('ExpiryDate', null);
                     DocGenFlsGuard.assertUpdateable(fix, new Set<String>{ 'PreferencesExpires', 'ExpiryDate' });
                     /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
                     Database.update(fix, AccessLevel.SYSTEM_MODE);
                 }
-                return existing[0].ContentDownloadUrl;
+                return (String) existing[0].get('ContentDownloadUrl');
             }
 
-            ContentDistribution cd = new ContentDistribution();
-            cd.Name = 'Portwood Asset - ' + assets[0].Name;
-            cd.ContentVersionId = cvId;
-            cd.PreferencesAllowViewInBrowser = true;
-            cd.PreferencesLinkLatestVersion = true;
-            cd.PreferencesAllowOriginalDownload = true;
-            cd.PreferencesExpires = false;
-            cd.PreferencesNotifyOnVisit = false;
-            cd.PreferencesAllowPDFDownload = false;
+            SObject cd = DocGenService.newContentDistribution(
+                new Map<String, Object>{
+                    'Name' => 'Portwood Asset - ' + assets[0].Name,
+                    'ContentVersionId' => cvId,
+                    'PreferencesAllowViewInBrowser' => true,
+                    'PreferencesLinkLatestVersion' => true,
+                    'PreferencesAllowOriginalDownload' => true,
+                    'PreferencesExpires' => false,
+                    'PreferencesNotifyOnVisit' => false,
+                    'PreferencesAllowPDFDownload' => false
+                }
+            );
             DocGenFlsGuard.assertCreateable(
                 cd,
                 new Set<String>{
@@ -358,19 +363,17 @@ public with sharing class DocGenEmailTemplateController {
             Database.insert(cd, AccessLevel.SYSTEM_MODE);
             // ContentDownloadUrl is generated server-side — re-query for it.
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-            ContentDistribution created = [
-                SELECT ContentDownloadUrl
-                FROM ContentDistribution
-                WHERE Id = :cd.Id
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ];
-            if (String.isBlank(created.ContentDownloadUrl)) {
+            List<SObject> created = Database.query(
+                'SELECT ContentDownloadUrl FROM ContentDistribution WHERE Id = \'' +
+                    String.escapeSingleQuotes((String) cd.get('Id')) +
+                    '\' WITH SYSTEM_MODE LIMIT 1'
+            );
+            if (created.isEmpty() || String.isBlank((String) created[0].get('ContentDownloadUrl'))) {
                 throw DocGenService.ahe(
                     'The public file link was created but has no download URL yet — try again in a moment.'
                 );
             }
-            return created.ContentDownloadUrl;
+            return (String) created[0].get('ContentDownloadUrl');
         } catch (AuraHandledException ahe) {
             throw ahe;
         } catch (Exception e) {

--- a/force-app/main/default/classes/DocGenEmailTemplateService.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateService.cls
@@ -564,19 +564,20 @@ global with sharing class DocGenEmailTemplateService {
             if (cvId == null) {
                 return null;
             }
+            if (!DocGenService.isContentDistributionAvailable()) {
+                return null; // #384: deliveries disabled — caller falls back to the stored URL
+            }
             DocGenFlsGuard.guestAssertAccessible(
-                ContentDistribution.sObjectType,
+                DocGenService.contentDistributionType(),
                 new Set<String>{ 'ContentDownloadUrl', 'ContentVersionId' }
             );
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-            List<ContentDistribution> dists = [
-                SELECT ContentDownloadUrl
-                FROM ContentDistribution
-                WHERE ContentVersionId = :cvId
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ];
-            return dists.isEmpty() ? null : dists[0].ContentDownloadUrl;
+            List<SObject> dists = Database.query(
+                'SELECT ContentDownloadUrl FROM ContentDistribution WHERE ContentVersionId = \'' +
+                    String.escapeSingleQuotes((String) cvId) +
+                    '\' WITH SYSTEM_MODE LIMIT 1'
+            );
+            return dists.isEmpty() ? null : (String) dists[0].get('ContentDownloadUrl');
         } catch (Exception e) {
             System.debug(LoggingLevel.WARN, 'Portwood: logo asset resolution fell back to URL: ' + e.getMessage());
             return null;

--- a/force-app/main/default/classes/DocGenEmailTemplateTest.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateTest.cls
@@ -178,7 +178,11 @@ private class DocGenEmailTemplateTest {
             System.assert(url.startsWith('http'), 'Public download URL returned: ' + url);
             System.assertEquals(
                 1,
-                [SELECT COUNT() FROM ContentDistribution WHERE ContentVersionId = :cv.Id],
+                Database.countQuery(
+                    'SELECT COUNT() FROM ContentDistribution WHERE ContentVersionId = \'' +
+                        String.escapeSingleQuotes((String) cv.Id) +
+                        '\''
+                ),
                 'Exactly one distribution per asset version'
             );
         } else {
@@ -315,12 +319,21 @@ private class DocGenEmailTemplateTest {
         Id newLatestCvId = DocGenController.addAssetVersion(asset.Id, v2.Id);
         Test.stopTest();
 
-        System.assertEquals(
-            1,
-            [SELECT COUNT() FROM ContentDistribution WHERE ContentVersionId = :newLatestCvId],
-            'Replacing a published asset image must publish the NEW file too, so ' +
-            'send-time logo resolution keeps working (guest senders cannot create deliveries)'
+        Integer carryCount = Database.countQuery(
+            'SELECT COUNT() FROM ContentDistribution WHERE ContentVersionId = \'' +
+                String.escapeSingleQuotes((String) newLatestCvId) +
+                '\''
         );
+        if (DocGenService.isContentDistributionAvailable()) {
+            System.assertEquals(
+                1,
+                carryCount,
+                'Replacing a published asset image must publish the NEW file too, so ' +
+                'send-time logo resolution keeps working (guest senders cannot create deliveries)'
+            );
+        } else {
+            System.assertEquals(0, carryCount, 'No deliveries when the feature is disabled');
+        }
     }
 
     // ---- {%asset:key} tags in email bodies resolve to public delivery URLs ----
@@ -351,11 +364,12 @@ private class DocGenEmailTemplateTest {
         DocGenEmailTemplateController.saveTemplate(data);
         Test.stopTest();
 
-        List<ContentDistribution> dists = [
-            SELECT ContentDownloadUrl
-            FROM ContentDistribution
-            WHERE Name LIKE 'Portwood Asset - Footer Banner%'
-        ];
+        List<SObject> dists = new List<SObject>();
+        if (DocGenService.isContentDistributionAvailable()) {
+            dists = Database.query(
+                'SELECT ContentDownloadUrl FROM ContentDistribution WHERE Name LIKE \'Portwood Asset - Footer Banner%\''
+            );
+        }
         if (dists.isEmpty()) {
             return; // org without Content Deliveries — publish path covered elsewhere
         }
@@ -369,9 +383,10 @@ private class DocGenEmailTemplateTest {
             !r.htmlBody.contains('{%asset:'),
             'Every asset tag must resolve or blank — none may leak: ' + r.htmlBody
         );
-        String expected = dists[0].ContentDownloadUrl.escapeHtml4();
+        String expectedUrl = (String) dists[0].get('ContentDownloadUrl');
+        String expected = expectedUrl.escapeHtml4();
         System.assert(
-            r.htmlBody.contains(expected) || r.htmlBody.contains(dists[0].ContentDownloadUrl),
+            r.htmlBody.contains(expected) || r.htmlBody.contains(expectedUrl),
             'Known asset tag resolves to its public delivery URL: ' + r.htmlBody
         );
         System.assert(r.htmlBody.contains('src=""'), 'Unknown asset key blanks cleanly');

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -5887,6 +5887,46 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         return templateType == 'HTML' || templateType == 'Canvas';
     }
 
+    /**
+     * Whether the org supports ContentDistribution (Setup → Content Deliveries and
+     * Public Links, #384). When disabled the SObject is not a compilable type, so
+     * every reference must stay dynamic (Schema describe + Database.query +
+     * SObject.put) and callers must degrade: preview/logo URLs fall back to the
+     * relative /sfc/ form or raise an actionable error. Cached per transaction.
+     */
+    @TestVisible
+    static Boolean contentDistributionAvailableCache;
+    public static Boolean isContentDistributionAvailable() {
+        if (contentDistributionAvailableCache == null) {
+            contentDistributionAvailableCache = Schema.getGlobalDescribe().containsKey('ContentDistribution');
+        }
+        return contentDistributionAvailableCache;
+    }
+
+    /**
+     * Dynamic SObjectType for ContentDistribution, or null when deliveries are
+     * disabled. Use for FLS guards instead of a static type token.
+     */
+    public static Schema.SObjectType contentDistributionType() {
+        return Schema.getGlobalDescribe().get('ContentDistribution');
+    }
+
+    /**
+     * Builds a ContentDistribution SObject without a static type reference.
+     * Throws an actionable error when deliveries are disabled.
+     */
+    public static SObject newContentDistribution(Map<String, Object> fieldValues) {
+        Schema.SObjectType t = contentDistributionType();
+        if (t == null) {
+            throw ahe('Public links are disabled in this org (Setup → Content Deliveries and Public Links).');
+        }
+        SObject cd = t.newSObject();
+        for (String f : fieldValues.keySet()) {
+            cd.put(f, fieldValues.get(f));
+        }
+        return cd;
+    }
+
     private static Boolean isNumericFormat(String fmt) {
         if (fmt == null) {
             return false;

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -806,6 +806,7 @@ public without sharing class DocGenSignatureController {
         if (!dists.isEmpty()) {
             return (String) dists[0].get('DistributionPublicUrl');
         }
+        Datetime linkExpiry = requestExpiresAt != null ? requestExpiresAt : System.now().addHours(TOKEN_EXPIRATION_HOURS);
         SObject cd = DocGenService.newContentDistribution(
             new Map<String, Object>{
                 'Name' => 'Signature Preview - ' + cv.Title,
@@ -813,7 +814,7 @@ public without sharing class DocGenSignatureController {
                 'PreferencesAllowViewInBrowser' => true,
                 'PreferencesLinkLatestVersion' => true,
                 'PreferencesExpires' => true,
-                'ExpiryDate' => requestExpiresAt != null ? requestExpiresAt : System.now().addHours(TOKEN_EXPIRATION_HOURS),
+                'ExpiryDate' => linkExpiry,
                 'PreferencesNotifyOnVisit' => false,
                 'PreferencesAllowOriginalDownload' => false,
                 'PreferencesAllowPDFDownload' => false

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -790,34 +790,35 @@ public without sharing class DocGenSignatureController {
 
     // CxSAST: Apex_CRUD_ContentDistribution — SYSTEM_MODE required for guest user context; ContentDistribution created for signature document preview
     private static String getOrCreatePublicLink(ContentVersion cv, Datetime requestExpiresAt) {
+        if (!DocGenService.isContentDistributionAvailable()) {
+            return null; // #384: deliveries disabled — preview link is optional (caller try/catch)
+        }
         DocGenFlsGuard.guestAssertAccessible(
-            ContentDistribution.sObjectType,
+            DocGenService.contentDistributionType(),
             new Set<String>{ 'DistributionPublicUrl', 'ContentVersionId' }
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-        List<ContentDistribution> dists = [
-            SELECT DistributionPublicUrl
-            FROM ContentDistribution
-            WHERE ContentVersionId = :cv.Id
-            WITH SYSTEM_MODE
-            LIMIT 1
-        ];
+        List<SObject> dists = Database.query(
+            'SELECT DistributionPublicUrl FROM ContentDistribution WHERE ContentVersionId = \'' +
+                String.escapeSingleQuotes((String) cv.Id) +
+                '\' WITH SYSTEM_MODE LIMIT 1'
+        );
         if (!dists.isEmpty()) {
-            return dists[0].DistributionPublicUrl;
+            return (String) dists[0].get('DistributionPublicUrl');
         }
-        ContentDistribution cd = new ContentDistribution();
-        cd.Name = 'Signature Preview - ' + cv.Title;
-        cd.ContentVersionId = cv.Id;
-        cd.PreferencesAllowViewInBrowser = true;
-        cd.PreferencesLinkLatestVersion = true;
-        // Expire the public link in line with the signing window so a signed
-        // (or cancelled) request can't be re-fetched anonymously afterwards.
-        // Legacy requests (no stamped expiry) keep the historical 48 hours.
-        cd.PreferencesExpires = true;
-        cd.ExpiryDate = requestExpiresAt != null ? requestExpiresAt : System.now().addHours(TOKEN_EXPIRATION_HOURS);
-        cd.PreferencesNotifyOnVisit = false;
-        cd.PreferencesAllowOriginalDownload = false;
-        cd.PreferencesAllowPDFDownload = false;
+        SObject cd = DocGenService.newContentDistribution(
+            new Map<String, Object>{
+                'Name' => 'Signature Preview - ' + cv.Title,
+                'ContentVersionId' => cv.Id,
+                'PreferencesAllowViewInBrowser' => true,
+                'PreferencesLinkLatestVersion' => true,
+                'PreferencesExpires' => true,
+                'ExpiryDate' => requestExpiresAt != null ? requestExpiresAt : System.now().addHours(TOKEN_EXPIRATION_HOURS),
+                'PreferencesNotifyOnVisit' => false,
+                'PreferencesAllowOriginalDownload' => false,
+                'PreferencesAllowPDFDownload' => false
+            }
+        );
         // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Create").
         DocGenFlsGuard.guestAssertCreateable(
             cd,
@@ -834,16 +835,19 @@ public without sharing class DocGenSignatureController {
             }
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-        Database.insert(new List<ContentDistribution>{ cd }, false, AccessLevel.SYSTEM_MODE);
+        Database.insert(new List<SObject>{ cd }, false, AccessLevel.SYSTEM_MODE);
         // SYSTEM_MODE required: guest profile has no Portwood CRUD by design; access is gated by token-bound lookup. See DocGenSignatureGuestSecurity for the security model.
-        cd = new ContentDistribution(Id = cd.Id);
         DocGenFlsGuard.guestAssertAccessible(
-            ContentDistribution.sObjectType,
+            DocGenService.contentDistributionType(),
             new Set<String>{ 'DistributionPublicUrl' }
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-        cd = [SELECT DistributionPublicUrl FROM ContentDistribution WHERE Id = :cd.Id WITH SYSTEM_MODE LIMIT 1];
-        return cd.DistributionPublicUrl;
+        List<SObject> created = Database.query(
+            'SELECT DistributionPublicUrl FROM ContentDistribution WHERE Id = \'' +
+                String.escapeSingleQuotes((String) cd.get('Id')) +
+                '\' WITH SYSTEM_MODE LIMIT 1'
+        );
+        return created.isEmpty() ? null : (String) created[0].get('DistributionPublicUrl');
     }
 
     /**

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -806,7 +806,9 @@ public without sharing class DocGenSignatureController {
         if (!dists.isEmpty()) {
             return (String) dists[0].get('DistributionPublicUrl');
         }
-        Datetime linkExpiry = requestExpiresAt != null ? requestExpiresAt : System.now().addHours(TOKEN_EXPIRATION_HOURS);
+        Datetime linkExpiry = requestExpiresAt != null
+            ? requestExpiresAt
+            : System.now().addHours(TOKEN_EXPIRATION_HOURS);
         SObject cd = DocGenService.newContentDistribution(
             new Map<String, Object>{
                 'Name' => 'Signature Preview - ' + cv.Title,

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -3117,20 +3117,34 @@ public with sharing class DocGenSignatureSenderController {
             previewImageMap.put('/sfc/servlet.shepherd/version/download/' + cvId, previewImageMap.get(cvId));
             return;
         }
+        if (!DocGenService.isContentDistributionAvailable()) {
+            return; // #384: deliveries disabled — preview keeps relative /sfc/ URLs
+        }
         try {
-            ContentDistribution dist = new ContentDistribution();
-            dist.Name = 'sig_preview_' + (String.isBlank(key) ? cvId : key).left(80);
-            dist.ContentVersionId = cvId;
-            dist.PreferencesAllowViewInBrowser = true;
-            dist.PreferencesLinkLatestVersion = false;
-            dist.PreferencesExpires = false;
+            SObject dist = DocGenService.newContentDistribution(
+                new Map<String, Object>{
+                    'Name' => 'sig_preview_' + (String.isBlank(key) ? cvId : key).left(80),
+                    'ContentVersionId' => cvId,
+                    'PreferencesAllowViewInBrowser' => true,
+                    'PreferencesLinkLatestVersion' => false,
+                    'PreferencesExpires' => false
+                }
+            );
             Database.insert(dist, AccessLevel.USER_MODE);
-            dist = [SELECT ContentDownloadUrl FROM ContentDistribution WHERE Id = :dist.Id WITH USER_MODE];
-            if (String.isNotBlank(key)) {
-                previewImageMap.put(key, dist.ContentDownloadUrl);
+            List<SObject> created = Database.query(
+                'SELECT ContentDownloadUrl FROM ContentDistribution WHERE Id = \'' +
+                    String.escapeSingleQuotes((String) dist.get('Id')) +
+                    '\' WITH USER_MODE'
+            );
+            if (created.isEmpty()) {
+                return;
             }
-            previewImageMap.put(cvId, dist.ContentDownloadUrl);
-            previewImageMap.put('/sfc/servlet.shepherd/version/download/' + cvId, dist.ContentDownloadUrl);
+            String downloadUrl = (String) created[0].get('ContentDownloadUrl');
+            if (String.isNotBlank(key)) {
+                previewImageMap.put(key, downloadUrl);
+            }
+            previewImageMap.put(cvId, downloadUrl);
+            previewImageMap.put('/sfc/servlet.shepherd/version/download/' + cvId, downloadUrl);
         } catch (Exception e) {
             System.debug(
                 LoggingLevel.WARN,

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -5509,6 +5509,9 @@ private class DocGenSignatureTests {
             '<html><body><img src="' + sourceUrl + '"/>{@Signature_Customer}</body></html>'
         );
         Test.stopTest();
+        if (!DocGenService.isContentDistributionAvailable()) {
+            return; // org without Content Deliveries — creation path covered elsewhere
+        }
 
         System.assert(previewMap.containsKey(sourceUrl), 'HTML image source should be mapped for signer preview');
         System.assert(
@@ -5517,7 +5520,11 @@ private class DocGenSignatureTests {
         );
         System.assertEquals(
             1,
-            [SELECT COUNT() FROM ContentDistribution WHERE ContentVersionId = :imgCv.Id],
+            Database.countQuery(
+                'SELECT COUNT() FROM ContentDistribution WHERE ContentVersionId = \'' +
+                    String.escapeSingleQuotes((String) imgCv.Id) +
+                    '\''
+            ),
             'A public distribution should be created for the HTML template image'
         );
     }
@@ -6034,18 +6041,21 @@ private class DocGenSignatureTests {
         Test.startTest();
         DocGenSignatureController.fetchDocumentData(signer.Secure_Token__c);
         Test.stopTest();
+        if (!DocGenService.isContentDistributionAvailable()) {
+            return; // org without Content Deliveries — preview link skipped by design
+        }
 
-        List<ContentDistribution> dists = [
-            SELECT PreferencesExpires, ExpiryDate, PreferencesAllowOriginalDownload
-            FROM ContentDistribution
-            WHERE ContentVersionId = :srcId
-        ];
+        List<SObject> dists = Database.query(
+            'SELECT PreferencesExpires, ExpiryDate, PreferencesAllowOriginalDownload FROM ContentDistribution WHERE ContentVersionId = \'' +
+                String.escapeSingleQuotes((String) srcId) +
+                '\''
+        );
         System.assertEquals(1, dists.size(), 'Should create exactly one public link for source doc');
-        System.assertEquals(true, dists[0].PreferencesExpires, 'Public link must expire');
-        System.assertNotEquals(null, dists[0].ExpiryDate, 'ExpiryDate must be set');
+        System.assertEquals(true, dists[0].get('PreferencesExpires'), 'Public link must expire');
+        System.assertNotEquals(null, dists[0].get('ExpiryDate'), 'ExpiryDate must be set');
         System.assertEquals(
             false,
-            dists[0].PreferencesAllowOriginalDownload,
+            dists[0].get('PreferencesAllowOriginalDownload'),
             'Original download must be disabled for the preview link'
         );
     }


### PR DESCRIPTION
## Summary

Fixes #384. When "Content Deliveries and Public Links" is disabled, `ContentDistribution` leaves the schema, so every class with a static reference fails to compile — breaking generation (Flow "No Apex action available") and install/upgrade. This removes all static references: availability probe + dynamic `Database.query`/`newSObject` in `DocGenService`, with graceful fallbacks at each of the 5 production sites (early return / actionable error / relative `/sfc/` URLs).

## Verification (real deliveries-OFF scratch org, `portwood-verify`)

- Toggled Content Deliveries + Public Links OFF via Setup; `Schema.getGlobalDescribe().containsKey('ContentDistribution')` → **false**.
- Pre-fix code deployed to the OFF org → `Invalid type: ContentDistribution` + package-wide dependent-class cascade (the reported failure class, reproduced).
- This branch deployed to the same OFF org → **Succeeded, 0 errors**.
- OFF org: 60/60 unit tests (`DocGenContentDistributionTest` new, `DocGenEmailTemplateTest`, `DocGenSignaturePdfTests`); e2e-02/03/06/06b/08 all FAIL 0.
- ON org (same scratch before the toggle): full 14-script e2e green, 58/58 unit — enabled-path behavior identical.

One residual the OFF run caught and fixed here: an unguarded `Database.query` in a test throws `QueryException` where `countQuery` returns 0 — test-only guard, prod untouched.

Note: the repo pre-commit prettier hook cannot run on ARM Macs (prettier-plugin-apex binary needs x86 CPU features); CI format check will be the arbiter — the diff follows surrounding style.