### PR TITLE
fix(flow-action): route Auto Giant Query on estimated heap, not row c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,25 @@ Two small fixes where the editor promised something the PDF did not deliver.
   resolve to the base-14 bold faces (verified selecting Helvetica-Bold / Times-Bold /
   Courier-Bold in a real org).
 
+- **The Auto Giant Query Flow action no longer crashes on a heavy dataset that stays
+  under the row-count threshold (#374).** It chose between synchronous and background
+  generation on a child **row count over 2,000** alone, so a record with a few hundred
+  rows carrying large rich-text fields — tens of MB of data — ran synchronously and hit
+  the **uncatchable** `System.LimitException: Apex heap size too large`. It now routes on
+  estimated peak heap, sampling one real child row so rows that each carry a 30 KB field
+  are costed accordingly. A new `DocGenGiantQueryRouter` is the single decision point,
+  shared with the on-screen Runner's pre-flight so the two can't drift apart again. An
+  over-budget job that can't be auto-routed now fails with a clear message instead of the
+  heap crash: a V1 or V2 query config is told to re-save as V3 (auto-routing needs V3 —
+  the background path skips `processXml`, which would drop parent-level `{#IF}` and
+  secondary loops), and non-Word templates or already-async contexts are pointed to the
+  Runner.
+
+    **Existing Flows:** more documents now route to the background, returning
+    `Is Giant Query = true` and a **Job ID** with no **Content Document ID** yet. A Flow
+    that uses the generated file immediately after this action should branch on
+    `Is Giant Query` and poll the job.
+
 ## v3.55.0 — Element linking, named blocks, client-side charts
 
 Released 2026-08-08 · `04tVx0000010fXFIAY` · ancestor 3.54.0 · 1,957 tests, 78% coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,19 +71,21 @@ Two small fixes where the editor promised something the PDF did not deliver.
   generation on a child **row count over 2,000** alone, so a record with a few hundred
   rows carrying large rich-text fields — tens of MB of data — ran synchronously and hit
   the **uncatchable** `System.LimitException: Apex heap size too large`. It now routes on
-  estimated peak heap, sampling one real child row so rows that each carry a 30 KB field
-  are costed accordingly. A new `DocGenGiantQueryRouter` is the single decision point,
-  shared with the on-screen Runner's pre-flight so the two can't drift apart again. An
-  over-budget job that can't be auto-routed now fails with a clear message instead of the
-  heap crash: a V1 or V2 query config is told to re-save as V3 (auto-routing needs V3 —
-  the background path skips `processXml`, which would drop parent-level `{#IF}` and
-  secondary loops), and non-Word templates or already-async contexts are pointed to the
-  Runner.
+  estimated peak heap: when a dataset is borderline on row count it measures one real
+  child row, so a few hundred rows that each carry a 30 KB field are costed accordingly
+  and route to the background. A new `DocGenGiantQueryRouter` is the single decision
+  point; the on-screen Runner's pre-flight shares its estimator and constants (the
+  Runner's inline warning stays row-count-based — it doesn't sample). An over-budget job
+  that can't be auto-routed now fails with a clear message instead of the heap crash: a
+  V1 or V2 query config is told to re-save as V3 (auto-routing needs V3 — the background
+  path skips `processXml`, which would drop parent-level `{#IF}` and secondary loops),
+  and non-Word templates or already-async contexts are pointed to the Runner.
 
-    **Existing Flows:** more documents now route to the background, returning
-    `Is Giant Query = true` and a **Job ID** with no **Content Document ID** yet. A Flow
-    that uses the generated file immediately after this action should branch on
-    `Is Giant Query` and poll the job.
+    **Existing Flows:** a dataset that is heavy per-row but under 2,000 rows now routes
+    to the background where it used to run inline — returning `Is Giant Query = true` and
+    a **Job ID** with no **Content Document ID** yet. A Flow that uses the generated file
+    immediately after this action should branch on `Is Giant Query` and poll the job.
+    Datasets with ordinary-sized rows are unaffected.
 
 ## v3.55.0 — Element linking, named blocks, client-side charts
 

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -3150,7 +3150,7 @@ For a truly storage-less path, drop into Apex: `DocGenService.generatePdfBlob(te
 
 ### 11.5 Recipe — Generate when dataset size is unpredictable
 
-**Use case:** a customer-portal screen Flow generates an invoice. Most invoices have 5–20 line items, but a few customers have 5,000+. You can't know at design time which path is right.
+**Use case:** a customer-portal screen Flow generates an invoice. Most invoices have 5–20 line items, but a few customers have 5,000+ — or a normal count with very large line-item descriptions. You can't know at design time which path is right.
 
 **Step:** **Portwood — Generate Document (Auto Giant Query)**.
 
@@ -3167,6 +3167,8 @@ For a truly storage-less path, drop into Apex: `DocGenService.generatePdfBlob(te
 - `isGiantQuery` — boolean so your Flow can branch
 
 **Pattern:** add a Decision element after the action. If `isGiantQuery = true`, send the user to a "your invoice is being prepared" screen with a polling component that watches the job. If `false`, present the file immediately.
+
+**How it routes (v3.57+).** The action estimates peak memory and samples one real child row, so a record with only a few hundred line items still routes async when each row carries a large rich-text description — not just when the row count is high. Auto-routing to the background needs a **V3 query config**: a V1 or V2 query config that's over budget returns an error asking you to re-save it as V3 or use the Runner, and a non-Word template is pointed to the Runner (the background path is Word-only).
 
 ### 11.6 Recipe — Send a contract for signature on Opportunity approval
 

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -3168,7 +3168,7 @@ For a truly storage-less path, drop into Apex: `DocGenService.generatePdfBlob(te
 
 **Pattern:** add a Decision element after the action. If `isGiantQuery = true`, send the user to a "your invoice is being prepared" screen with a polling component that watches the job. If `false`, present the file immediately.
 
-**How it routes (v3.57+).** The action estimates peak memory and samples one real child row, so a record with only a few hundred line items still routes async when each row carries a large rich-text description — not just when the row count is high. Auto-routing to the background needs a **V3 query config**: a V1 or V2 query config that's over budget returns an error asking you to re-save it as V3 or use the Runner, and a non-Word template is pointed to the Runner (the background path is Word-only).
+**How it routes (v3.57+).** The action estimates peak memory rather than counting rows alone — and when a dataset is borderline it measures one real child row, so a record with only a few hundred line items still routes async when each row carries a large rich-text description. Auto-routing to the background needs a **V3 query config**: a V1 or V2 query config that's over budget returns an error asking you to re-save it as V3 or use the Runner, and a non-Word template is pointed to the Runner (the background path is Word-only). The Runner's own on-screen size warning is based on row count and is advisory — it doesn't block generation.
 
 ### 11.6 Recipe — Send a contract for signature on Opportunity approval
 

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -1491,20 +1491,8 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
      * @param templateId The DocGen_Template__c record ID
      * @return Map of relationship name to child record count
      */
-    // Heap-pressure router constants — tuned from real-world breakage.
-    // Output format matters enormously: PDF rendering via Blob.toPdf() parses the
-    // entire HTML into an in-memory DOM, so peak heap is ~5-10× the raw expanded
-    // XML size. DOCX/Excel paths just write XML and ship base64 to the client.
-    private static final Integer SYNC_HEAP_LIMIT = 6000000; // Apex sync heap governor (6MB)
-    private static final Decimal SAFE_HEAP_RATIO = 0.6; // leave 40% headroom
-
-    // PDF: Blob.toPdf() holds full DOM + parse tree in heap
-    private static final Integer PDF_BASE_BYTES = 1000000; // template HTML + styles + parent data
-    private static final Integer PDF_BYTES_PER_ROW = 10000; // ~10KB per row after DOM/CSS parsing
-
-    // DOCX/Excel/PowerPoint: server merges XML, returns base64 to client
-    private static final Integer DOCX_BASE_BYTES = 200000;
-    private static final Integer DOCX_BYTES_PER_ROW = 2000;
+    // Heap-pressure routing is owned by DocGenGiantQueryRouter so this pre-flight
+    // and the "Auto Giant Query" Flow action share one estimator (#374).
 
     @AuraEnabled
     public static Map<String, Object> scoutChildCounts(Id recordId, Id templateId) {
@@ -1513,7 +1501,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         result.put('childNodes', new Map<String, Map<String, Object>>());
         result.put('heapEstimates', new Map<String, Integer>());
         result.put('useGiantPath', new Map<String, Boolean>());
-        result.put('heapLimitBytes', SYNC_HEAP_LIMIT);
+        result.put('heapLimitBytes', DocGenGiantQueryRouter.SYNC_HEAP_LIMIT);
 
         if (recordId == null || templateId == null) {
             return result;
@@ -1640,20 +1628,16 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
 
         result.put('childNodes', childNodes);
 
-        // Heap-pressure pre-flight: for each relationship with a known count, estimate
-        // peak sync-path heap. Constants differ by output format because PDF's
-        // Blob.toPdf() holds the whole HTML DOM in heap while rendering.
+        // Heap-pressure pre-flight: for each relationship with a known count,
+        // estimate peak sync-path heap via the shared router (#374). Row-count
+        // only here (no per-row sampling) — the client just needs the flag.
         String outputFormat = templates[0].Output_Format__c;
-        Boolean isPdf = 'PDF'.equalsIgnoreCase(outputFormat);
-        Integer baseBytes = isPdf ? PDF_BASE_BYTES : DOCX_BASE_BYTES;
-        Integer bytesPerRow = isPdf ? PDF_BYTES_PER_ROW : DOCX_BYTES_PER_ROW;
-        Integer safeHeapBytes = (Integer) (SYNC_HEAP_LIMIT * SAFE_HEAP_RATIO);
+        Integer safeHeapBytes = DocGenGiantQueryRouter.safeHeapBytes();
 
         Map<String, Integer> heapEstimates = new Map<String, Integer>();
         Map<String, Boolean> useGiantPath = new Map<String, Boolean>();
         for (String relName : counts.keySet()) {
-            Integer rowCount = counts.get(relName);
-            Integer estimatedPeak = baseBytes + (rowCount * bytesPerRow);
+            Integer estimatedPeak = DocGenGiantQueryRouter.estimatePeakHeapBytes(counts.get(relName), 0, outputFormat);
             heapEstimates.put(relName, estimatedPeak);
             useGiantPath.put(relName, estimatedPeak > safeHeapBytes);
         }
@@ -5167,8 +5151,11 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
      * Builds a Giant Query child node config from a V1 flat query string.
      * Parses the subquery for the given relationship name and resolves
      * the child object + lookup field from the parent record's schema.
+     *
+     * Public so DocGenGiantQueryRouter can reuse it — the router is the single
+     * sync-vs-giant decision point shared with DocGenGiantQueryFlowAction (#374).
      */
-    private static Map<String, Object> buildNodeConfigFromFlat(
+    public static Map<String, Object> buildNodeConfigFromFlat(
         Id recordId,
         String queryConfig,
         String relationshipName

--- a/force-app/main/default/classes/DocGenGiantQueryFlowAction.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryFlowAction.cls
@@ -1,17 +1,22 @@
 /**
  * Invocable action for generating documents that may have large child datasets.
- * Auto-detects whether Giant Query is needed by scouting child record counts.
+ * Auto-detects whether Giant Query (async batch) is needed.
  *
- * Under 2,000 child records: generates synchronously (same as DocGenFlowAction).
- * Over 2,000 child records: launches async batch. PDF is saved to the record
- * when complete. Returns the Job ID for status tracking.
+ * The decision is a HEAP estimate, not a raw row count (#374): a Quote with a
+ * few hundred line items carrying large descriptions is well under any row
+ * threshold but tens of MB of data, and running it synchronously blew the 6 MB
+ * Apex heap governor with an uncatchable System.LimitException. Routing is
+ * delegated to DocGenGiantQueryRouter, shared with the on-screen Runner so the
+ * two cannot diverge again.
+ *
+ *   Fits the synchronous heap budget -> generate now (same as DocGenFlowAction).
+ *   Over the budget (or > 2,000 rows) -> launch async batch, PDF saved to the
+ *   record when complete, Job ID returned for status tracking.
  *
  * Ideal for customer portals, Screen Flows, and automated processes where
  * the dataset size isn't known in advance.
  */
 global with sharing class DocGenGiantQueryFlowAction { // NOPMD AvoidGlobalModifier — global required for @InvocableMethod visibility in subscriber orgs
-    private static final Integer GIANT_THRESHOLD = 2000;
-
     global class Request {
         @InvocableVariable(label='Template ID' required=true description='The Portwood Template record ID')
         global Id templateId;
@@ -44,7 +49,7 @@ global with sharing class DocGenGiantQueryFlowAction { // NOPMD AvoidGlobalModif
 
         @InvocableVariable(
             label='Is Giant Query'
-            description='True if the dataset exceeded 2,000 rows and generation is async'
+            description='True if the dataset was too large for synchronous generation and is being processed by the async batch (poll Job ID)'
         )
         global Boolean isGiantQuery;
 
@@ -57,7 +62,7 @@ global with sharing class DocGenGiantQueryFlowAction { // NOPMD AvoidGlobalModif
 
     @InvocableMethod(
         label='Generate Document (Auto Giant Query)'
-        description='Generates a document, automatically using async Giant Query for datasets over 2,000 child records. PDF is saved to the record when complete.'
+        description='Generates a document, automatically switching to async Giant Query when the dataset is too large for synchronous generation. PDF is saved to the record when complete.'
     )
     global static List<Response> generateDocument(List<Request> requests) {
         List<Response> responses = new List<Response>();
@@ -92,37 +97,67 @@ global with sharing class DocGenGiantQueryFlowAction { // NOPMD AvoidGlobalModif
                 DocGen_Template__c template = templates[0];
                 String queryConfig = template.Query_Config__c;
 
-                // Scout child counts to decide sync vs async
-                String giantRelationship = null;
-                Map<String, Object> giantNodeConfig = null;
+                // Sync vs async is a HEAP decision, not a row-count one. The
+                // shared router estimates peak synchronous heap (sampling one
+                // real child row so heavy rich-text rows are not under-counted).
+                // It scouts every config format for the estimate; only V3 is
+                // auto-routed to the batch (see the guard below) (#374).
+                DocGenGiantQueryRouter.Decision route = DocGenGiantQueryRouter.decide(
+                    req.recordId,
+                    queryConfig,
+                    template.Output_Format__c
+                );
 
-                Integer configVersion = DocGenDataRetriever.getConfigVersion(queryConfig);
-                if (configVersion >= 3) {
-                    Map<String, Integer> counts = DocGenDataRetriever.scoutChildCounts(req.recordId, queryConfig);
-                    Map<String, Object> config = (Map<String, Object>) JSON.deserializeUntyped(queryConfig.trim());
-                    List<Object> nodesJson = (List<Object>) config.get('nodes');
-
-                    for (String relName : counts.keySet()) {
-                        if (counts.get(relName) > GIANT_THRESHOLD) {
-                            giantRelationship = relName;
-                            if (nodesJson != null) {
-                                for (Object nodeObj : nodesJson) {
-                                    Map<String, Object> n = (Map<String, Object>) nodeObj;
-                                    if (relName.equals((String) n.get('relationshipName'))) {
-                                        giantNodeConfig = n;
-                                        break;
-                                    }
-                                }
-                            }
-                            break;
-                        }
+                if (route.useGiantPath) {
+                    // Predicted to exceed the synchronous heap governor. The heap
+                    // LimitException is uncatchable, so this MUST be a decision
+                    // made before generation, not a try/catch after it.
+                    if (template.Type__c != 'Word') {
+                        throw new DocGenException(
+                            'This ' +
+                                template.Type__c +
+                                ' template produces a document too large for synchronous generation (' +
+                                route.reason +
+                                '). The Auto Giant Query Flow action can only background-process Word templates — ' +
+                                'generate it from the Portwood Runner instead.'
+                        );
                     }
-                }
-
-                if (giantRelationship != null && giantNodeConfig != null) {
-                    // Async Giant Query path
+                    // Only V3 (tree) query configs are auto-routed to the batch.
+                    // The batch path skips processXml, so parent-level {#IF} /
+                    // inverse tags / secondary child loops would leak as raw text
+                    // — routing a large V1/V2 template there could silently
+                    // corrupt the output. Fail loud with a route instead (#374).
+                    if (DocGenDataRetriever.getConfigVersion(queryConfig) < 3) {
+                        throw new DocGenException(
+                            'This template is too large for synchronous generation (' +
+                                route.reason +
+                                '). Background generation from this Flow action needs a tree-style (V3) query ' +
+                                'configuration — re-save the template in the Query Builder, or generate it from the Portwood Runner.'
+                        );
+                    }
+                    if (route.giantNodeConfig == null) {
+                        throw new DocGenException(
+                            'This document is too large to generate inside the Flow (' +
+                                route.reason +
+                                ') and Portwood could not prepare it for background generation. Reduce the fields ' +
+                                'queried for the large related list, or generate it from the Portwood Runner.'
+                        );
+                    }
+                    if (System.isBatch() || System.isFuture() || System.isQueueable() || System.isScheduled()) {
+                        throw new DocGenException(
+                            'This document needs background generation (' +
+                                route.reason +
+                                ') but the Flow is already running asynchronously, which cannot start a batch job. ' +
+                                'Run this Generate Document step from a screen or record-triggered (synchronous) Flow.'
+                        );
+                    }
                     res.isGiantQuery = true;
-                    res.jobId = launchGiantBatch(req.templateId, req.recordId, giantRelationship, giantNodeConfig);
+                    res.jobId = launchGiantBatch(
+                        req.templateId,
+                        req.recordId,
+                        route.giantRelationship,
+                        route.giantNodeConfig
+                    );
                     res.success = true;
                 } else {
                     // Sync path — same as DocGenFlowAction. attachmentRecordId is null when
@@ -167,7 +202,7 @@ global with sharing class DocGenGiantQueryFlowAction { // NOPMD AvoidGlobalModif
     private static Id launchGiantBatch(
         Id templateId,
         Id recordId,
-        String giantRelationship,
+        String giantRelationshipKey,
         Map<String, Object> childNodeConfig
     ) {
         // Get document XML from pre-decomposed parts
@@ -208,10 +243,12 @@ global with sharing class DocGenGiantQueryFlowAction { // NOPMD AvoidGlobalModif
             throw new DocGenException('Pre-decomposed template parts not found. Please re-save the template.');
         }
 
-        Map<String, String> loopParts = DocGenService.extractLoopBody(documentXml, giantRelationship);
+        // The loop tag in the template body is keyed by the alias when the node
+        // has one (e.g. {#SubscriptionItems}), which is the effective key.
+        Map<String, String> loopParts = DocGenService.extractLoopBody(documentXml, giantRelationshipKey);
         documentXml = null;
         if (loopParts == null) {
-            throw new DocGenException('Could not find loop for relationship: ' + giantRelationship);
+            throw new DocGenException('Could not find loop for relationship: ' + giantRelationshipKey);
         }
 
         // Create Job record
@@ -225,7 +262,13 @@ global with sharing class DocGenGiantQueryFlowAction { // NOPMD AvoidGlobalModif
         );
         insert job; // NOPMD ApexCRUDViolation — package-internal; CRUD controlled by permission sets
 
-        childNodeConfig.put('relationshipName', giantRelationship);
+        // The router's node config already carries the real relationshipName
+        // (and alias, if any) for DocGenGiantQueryBatch — only fill it in if a
+        // V1-parsed config somehow left it blank. Never overwrite: the effective
+        // key can be an alias, which would break the batch's SOQL FROM.
+        if (String.isBlank((String) childNodeConfig.get('relationshipName'))) {
+            childNodeConfig.put('relationshipName', giantRelationshipKey);
+        }
 
         DocGenGiantQueryBatch batch = new DocGenGiantQueryBatch(
             job.Id,

--- a/force-app/main/default/classes/DocGenGiantQueryFlowActionTest.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryFlowActionTest.cls
@@ -142,4 +142,216 @@ private class DocGenGiantQueryFlowActionTest {
         System.assertEquals(false, responses[0].success, 'Bad template id should fail gracefully');
         System.assertNotEquals(null, responses[0].errorMessage, 'errorMessage populated');
     }
+
+    // ---------------------------------------------------------------------
+    // #374 — heap-aware routing
+    // ---------------------------------------------------------------------
+
+    private static final String V3_CONTACTS =
+        '{"v":3,"root":"Account","nodes":[' +
+        '{"id":"n0","object":"Account","fields":["Name"],"parentFields":[],"parentNode":null,"lookupField":null,"relationshipName":null},' +
+        '{"id":"n1","object":"Contact","fields":["LastName","Description"],"parentFields":[],"parentNode":"n0","lookupField":"AccountId","relationshipName":"Contacts"}' +
+        ']}';
+
+    // Few rows, each heavy: the router routes async on the SAMPLED payload, and
+    // the row count stays under DocGenGiantQueryBatch's 50-row page size so the
+    // batch runs in exactly one execute() (the test-context executeBatch limit).
+    private static void seedContacts(Id acctId, Integer howMany, Integer descLen) {
+        String descText = null;
+        if (descLen != null && descLen > 0) {
+            descText = 'x'.rightPad(descLen, 'x');
+        }
+        List<Contact> cs = new List<Contact>();
+        for (Integer i = 0; i < howMany; i++) {
+            cs.add(new Contact(LastName = 'G' + i, AccountId = acctId, Description = descText));
+        }
+        insert cs;
+    }
+
+    /** Word template with a pre-decomposed word/document.xml carrying a {#Contacts} loop. */
+    private static Id createGiantWordTemplate(String queryConfig) {
+        DocGen_Template__c tmpl = new DocGen_Template__c(
+            Name = 'GQFA Word ' + Datetime.now().getTime(),
+            Type__c = 'Word',
+            Output_Format__c = 'PDF',
+            Base_Object_API__c = 'Account',
+            Query_Config__c = queryConfig
+        );
+        insert tmpl;
+
+        DocGen_Template_Version__c ver = new DocGen_Template_Version__c(Template__c = tmpl.Id, Is_Active__c = true);
+        insert ver;
+
+        String documentXml =
+            '<w:document><w:body><w:tbl><w:tr><w:tc><w:p>' +
+            '{#Contacts}<w:r><w:t>{LastName}</w:t></w:r>{/Contacts}' +
+            '</w:p></w:tc></w:tr></w:tbl></w:body></w:document>';
+        ContentVersion cv = new ContentVersion(
+            Title = 'docgen_tmpl_xml_' + ver.Id + '_word__document.xml',
+            PathOnClient = 'document.xml',
+            VersionData = Blob.valueOf(documentXml),
+            FirstPublishLocationId = ver.Id
+        );
+        insert cv;
+        return tmpl.Id;
+    }
+
+    @IsTest
+    static void heavyDatasetRoutesToTheGiantBatch() {
+        Account acct = [SELECT Id FROM Account LIMIT 1];
+        seedContacts(acct.Id, 40, 20000); // 40 rows, ~20KB each -> over the sampled heap estimate
+        Id tmplId = createGiantWordTemplate(V3_CONTACTS);
+
+        DocGenGiantQueryFlowAction.Request req = new DocGenGiantQueryFlowAction.Request();
+        req.templateId = tmplId;
+        req.recordId = acct.Id;
+        req.saveToRecord = true;
+
+        Test.startTest();
+        List<DocGenGiantQueryFlowAction.Response> responses = DocGenGiantQueryFlowAction.generateDocument(
+            new List<DocGenGiantQueryFlowAction.Request>{ req }
+        );
+        DocGenGiantQueryFlowAction.Response r = responses[0];
+        System.assertEquals(true, r.success, 'Routing must succeed: ' + r.errorMessage);
+        System.assertEquals(true, r.isGiantQuery, '300 heavy rows route async, not sync');
+        System.assertNotEquals(null, r.jobId, 'a Job Id is returned for polling');
+        System.assertEquals(null, r.contentDocumentId, 'async path returns no sync document id');
+        Test.stopTest();
+
+        System.assertEquals(
+            1,
+            [SELECT COUNT() FROM DocGen_Job__c WHERE Id = :r.jobId],
+            'the Giant Query job was created'
+        );
+    }
+
+    @IsTest
+    static void v1FlatConfigOverBudgetIsRefusedNotCrashedNorCorrupted() {
+        // Pre-#374 a large V1 template crashed (uncatchable heap LimitException).
+        // It is NOT auto-routed to the batch — that path skips processXml and
+        // could silently drop parent-level tags. It fails loud with guidance.
+        Account acct = [SELECT Id FROM Account LIMIT 1];
+        seedContacts(acct.Id, 40, 20000);
+        Id tmplId = createGiantWordTemplate('Name, (SELECT LastName, Description FROM Contacts)');
+
+        DocGenGiantQueryFlowAction.Request req = new DocGenGiantQueryFlowAction.Request();
+        req.templateId = tmplId;
+        req.recordId = acct.Id;
+
+        Test.startTest();
+        List<DocGenGiantQueryFlowAction.Response> responses = DocGenGiantQueryFlowAction.generateDocument(
+            new List<DocGenGiantQueryFlowAction.Request>{ req }
+        );
+        DocGenGiantQueryFlowAction.Response r = responses[0];
+        Test.stopTest();
+
+        System.assertEquals(false, r.success, 'V1 over budget is refused, not run');
+        System.assertEquals(false, r.isGiantQuery, 'and not sent to the batch');
+        System.assertEquals(null, r.jobId, 'no job created');
+        System.assert(
+            r.errorMessage.containsIgnoreCase('V3') || r.errorMessage.containsIgnoreCase('Runner'),
+            'error tells the admin how to proceed: ' + r.errorMessage
+        );
+    }
+
+    @IsTest
+    static void smallDatasetStillGeneratesSynchronously() {
+        Account acct = [SELECT Id FROM Account LIMIT 1];
+        seedContacts(acct.Id, 3, 0);
+        Id tmplId = createGiantWordTemplate(V3_CONTACTS);
+
+        DocGenGiantQueryFlowAction.Request req = new DocGenGiantQueryFlowAction.Request();
+        req.templateId = tmplId;
+        req.recordId = acct.Id;
+
+        Test.startTest();
+        List<DocGenGiantQueryFlowAction.Response> responses = DocGenGiantQueryFlowAction.generateDocument(
+            new List<DocGenGiantQueryFlowAction.Request>{ req }
+        );
+        Test.stopTest();
+
+        System.assertEquals(false, responses[0].isGiantQuery, '3 contacts stay on the synchronous path');
+    }
+
+    @IsTest
+    static void htmlTemplateOverBudgetPointsToTheRunner() {
+        // launchGiantBatch only handles Word (pre-decomposed document.xml). An
+        // over-budget HTML template used to fall through to the crash-prone sync
+        // path; now it fails fast with actionable guidance.
+        Account acct = [SELECT Id FROM Account LIMIT 1];
+        seedContacts(acct.Id, 40, 20000);
+        DocGen_Template__c tmpl = new DocGen_Template__c(
+            Name = 'GQFA HTML big ' + Datetime.now().getTime(),
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF',
+            Base_Object_API__c = 'Account',
+            Query_Config__c = V3_CONTACTS
+        );
+        insert tmpl;
+        ContentVersion cv = new ContentVersion(
+            Title = tmpl.Name + ' Body',
+            PathOnClient = 'b.html',
+            VersionData = Blob.valueOf('<html><body>{#Contacts}<p>{Description}</p>{/Contacts}</body></html>'),
+            FirstPublishLocationId = tmpl.Id
+        );
+        insert cv;
+        insert new DocGen_Template_Version__c(
+            Template__c = tmpl.Id,
+            Content_Version_Id__c = cv.Id,
+            Is_Active__c = true
+        );
+
+        DocGenGiantQueryFlowAction.Request req = new DocGenGiantQueryFlowAction.Request();
+        req.templateId = tmpl.Id;
+        req.recordId = acct.Id;
+
+        Test.startTest();
+        List<DocGenGiantQueryFlowAction.Response> responses = DocGenGiantQueryFlowAction.generateDocument(
+            new List<DocGenGiantQueryFlowAction.Request>{ req }
+        );
+        Test.stopTest();
+
+        System.assertEquals(false, responses[0].success, 'HTML over budget is refused, not crashed');
+        System.assert(
+            responses[0].errorMessage.containsIgnoreCase('Runner'),
+            'error points to the Runner: ' + responses[0].errorMessage
+        );
+    }
+
+    @IsTest
+    static void giantRouteFromAnAsyncContextReturnsAClearError() {
+        Account acct = [SELECT Id FROM Account LIMIT 1];
+        seedContacts(acct.Id, 40, 20000);
+        Id tmplId = createGiantWordTemplate(V3_CONTACTS);
+
+        Test.startTest();
+        System.enqueueJob(new AsyncActionCaller(tmplId, acct.Id));
+        Test.stopTest();
+
+        System.assertNotEquals(null, asyncResponses, 'the queueable ran the action');
+        System.assertEquals(false, asyncResponses[0].success, 'cannot start a batch from a queueable');
+        System.assert(
+            asyncResponses[0].errorMessage.containsIgnoreCase('asynchronously'),
+            'error explains the async-context limitation: ' + asyncResponses[0].errorMessage
+        );
+    }
+
+    private static List<DocGenGiantQueryFlowAction.Response> asyncResponses;
+
+    private class AsyncActionCaller implements Queueable {
+        private Id templateId;
+        private Id recordId;
+        AsyncActionCaller(Id templateId, Id recordId) {
+            this.templateId = templateId;
+            this.recordId = recordId;
+        }
+        public void execute(QueueableContext qc) {
+            DocGenGiantQueryFlowAction.Request req = new DocGenGiantQueryFlowAction.Request();
+            req.templateId = templateId;
+            req.recordId = recordId;
+            asyncResponses = DocGenGiantQueryFlowAction.generateDocument(
+                new List<DocGenGiantQueryFlowAction.Request>{ req }
+            );
+        }
+    }
 }

--- a/force-app/main/default/classes/DocGenGiantQueryRouter.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryRouter.cls
@@ -1,0 +1,234 @@
+/**
+ * Single source of truth for "generate this document now, or hand it to the
+ * async Giant Query batch?".
+ *
+ * Both entry points that make this call — the on-screen Runner
+ * (DocGenController.scoutChildCounts) and the "Generate Document (Auto Giant
+ * Query)" Flow action (DocGenGiantQueryFlowAction) — route through here so the
+ * two can never drift apart again. They did drift: the Runner estimated peak
+ * heap and routed on that, while the Flow action only looked at a raw child
+ * row count > 2,000. A Quote with a few hundred line items carrying large
+ * rich-text descriptions is well under 2,000 rows but tens of MB of data, so
+ * the Flow action ran it synchronously and blew the 6 MB Apex heap governor
+ * with an uncatchable System.LimitException (issue #374).
+ *
+ * The estimate is heap-aware AND payload-aware: it samples one real child row
+ * so a relationship whose rows carry a 30 KB text field is not costed as if
+ * every row were 2 KB.
+ */
+public with sharing class DocGenGiantQueryRouter {
+    // Apex synchronous heap governor, and the fraction of it we are willing to
+    // spend before routing to the background batch (40 % headroom).
+    public static final Integer SYNC_HEAP_LIMIT = 6000000;
+    public static final Decimal SAFE_HEAP_RATIO = 0.6;
+
+    // Peak-heap model, per output format. PDF renders through Blob.toPdf() which
+    // holds the entire HTML DOM + parse tree in heap while rendering, so its
+    // per-row cost is several times the raw expanded row; DOCX/Excel/PowerPoint
+    // just write XML and ship base64 to the client.
+    public static final Integer PDF_BASE_BYTES = 1000000; // template HTML + styles + parent data
+    public static final Integer PDF_BYTES_PER_ROW = 10000; // ~10 KB per row after DOM/CSS parsing
+    public static final Integer DOCX_BASE_BYTES = 200000;
+    public static final Integer DOCX_BYTES_PER_ROW = 2000;
+
+    // Multiplier applied to a *sampled* raw row size to approximate its peak
+    // heap contribution during rendering.
+    private static final Integer PDF_ROW_BLOWUP = 5;
+    private static final Integer DOCX_ROW_BLOWUP = 2;
+
+    // A hard backstop on top of the heap estimate: this many child rows always
+    // routes async regardless of how skinny the rows look. Matches the
+    // historical threshold so V3 templates behave exactly as before at scale.
+    public static final Integer GIANT_ROW_CEILING = 2000;
+
+    // Below this row count even fat rows cannot realistically blow the sync
+    // heap, so skip the sampling SOQL.
+    private static final Integer SAMPLE_MIN_ROWS = 25;
+
+    /** The routing verdict for one parent record + template. */
+    public class Decision {
+        public Boolean useGiantPath = false;
+        /** Effective relationship key (alias when the node has one, else relationshipName). */
+        public String giantRelationship;
+        /** Child node config for DocGenGiantQueryBatch — null if it could not be resolved. */
+        public Map<String, Object> giantNodeConfig;
+        /** Every scouted relationship → child row count. */
+        public Map<String, Integer> counts = new Map<String, Integer>();
+        /** Estimated peak sync heap for the chosen relationship (bytes). */
+        public Integer estimatedPeakHeapBytes = 0;
+        /** Human-readable explanation, surfaced in the Flow error / debug log. */
+        public String reason = '';
+    }
+
+    /** 60 % of the sync heap governor — the ceiling for a synchronous generation. */
+    public static Integer safeHeapBytes() {
+        return (Integer) (SYNC_HEAP_LIMIT * SAFE_HEAP_RATIO);
+    }
+
+    /**
+     * Estimated peak synchronous heap (bytes) for expanding `rowCount` rows of a
+     * child relationship into the merged document.
+     *
+     * @param sampleRowBytes measured size of one real child row (0 / null = not
+     *        sampled → the per-format default per-row cost is used, which keeps
+     *        this identical to the pre-#374 estimate).
+     */
+    public static Integer estimatePeakHeapBytes(Integer rowCount, Integer sampleRowBytes, String outputFormat) {
+        Boolean isPdf = String.isBlank(outputFormat) || 'PDF'.equalsIgnoreCase(outputFormat);
+        Long baseBytes = isPdf ? PDF_BASE_BYTES : DOCX_BASE_BYTES;
+        Long perRow = isPdf ? PDF_BYTES_PER_ROW : DOCX_BYTES_PER_ROW;
+        if (sampleRowBytes != null && sampleRowBytes > 0) {
+            Long sampled = (Long) sampleRowBytes * (isPdf ? PDF_ROW_BLOWUP : DOCX_ROW_BLOWUP);
+            if (sampled > perRow) {
+                perRow = sampled;
+            }
+        }
+        Long rows = rowCount == null ? 0 : rowCount;
+        // Long math + clamp: rows * a sampled fat per-row cost overflows a
+        // 32-bit Integer well before it stops being "definitely too big".
+        Long total = baseBytes + (rows * perRow);
+        return total > 2000000000L ? 2000000000 : (Integer) total;
+    }
+
+    /**
+     * Decide sync vs Giant Query for a parent record + template query config.
+     * Works for every config format (V1 flat string, V2/V3 JSON).
+     */
+    public static Decision decide(Id parentRecordId, String queryConfig, String outputFormat) {
+        Decision d = new Decision();
+        if (parentRecordId == null || String.isBlank(queryConfig)) {
+            d.reason = 'No record or query config to scout.';
+            return d;
+        }
+
+        d.counts = DocGenDataRetriever.scoutChildCounts(parentRecordId, queryConfig);
+        if (d.counts.isEmpty()) {
+            d.reason = 'Template has no child relationships to scout.';
+            return d;
+        }
+
+        Integer safe = safeHeapBytes();
+        for (String relKey : d.counts.keySet()) {
+            Integer rows = d.counts.get(relKey);
+            if (rows == null || rows == 0) {
+                continue;
+            }
+
+            Map<String, Object> nodeConfig = resolveNodeConfig(parentRecordId, queryConfig, relKey);
+            Integer sampleBytes = (rows >= SAMPLE_MIN_ROWS) ? sampleChildRowBytes(parentRecordId, nodeConfig) : 0;
+            Integer estPeak = estimatePeakHeapBytes(rows, sampleBytes, outputFormat);
+
+            Boolean overCeiling = rows > GIANT_ROW_CEILING;
+            Boolean overHeap = estPeak > safe;
+            if (overCeiling || overHeap) {
+                d.useGiantPath = true;
+                d.giantRelationship = relKey;
+                d.giantNodeConfig = nodeConfig;
+                d.estimatedPeakHeapBytes = estPeak;
+                Integer estMb = estPeak / 1048576;
+                Integer safeMb = safe / 1048576;
+                d.reason = overHeap
+                    ? 'Estimated peak heap ~' +
+                      estMb +
+                      ' MB for ' +
+                      rows +
+                      ' "' +
+                      relKey +
+                      '" rows exceeds the safe synchronous limit (~' +
+                      safeMb +
+                      ' MB).'
+                    : rows + ' "' + relKey + '" rows exceed the ' + GIANT_ROW_CEILING + '-row synchronous ceiling.';
+                return d;
+            }
+        }
+        d.reason = 'All child datasets fit the synchronous heap budget.';
+        return d;
+    }
+
+    /**
+     * Child node config for DocGenGiantQueryBatch. V3: the node whose
+     * alias||relationshipName matches the scout key. V1: parsed from the flat
+     * subquery. V2 (children array) is not supported for the batch → null.
+     */
+    @TestVisible
+    private static Map<String, Object> resolveNodeConfig(Id parentRecordId, String queryConfig, String relKey) {
+        String trimmed = queryConfig.trim();
+        if (trimmed.startsWith('{')) {
+            try {
+                Map<String, Object> config = (Map<String, Object>) JSON.deserializeUntyped(trimmed);
+                List<Object> nodes = (List<Object>) config.get('nodes');
+                if (nodes == null) {
+                    return null; // V2 children-array form — no giant batch support
+                }
+                for (Object nodeObj : nodes) {
+                    Map<String, Object> n = (Map<String, Object>) nodeObj;
+                    String alias = (String) n.get('alias');
+                    String rel = (String) n.get('relationshipName');
+                    String effectiveKey = String.isNotBlank(alias) ? alias : rel;
+                    if (relKey.equals(effectiveKey)) {
+                        return n;
+                    }
+                }
+                return null;
+            } catch (Exception e) {
+                return null;
+            }
+        }
+        // V1 flat string
+        return DocGenController.buildNodeConfigFromFlat(parentRecordId, queryConfig, relKey);
+    }
+
+    /**
+     * Serialized size (bytes) of one real child row with the configured fields —
+     * the payload signal the row-count-only router was missing. Best-effort: any
+     * failure returns 0 and the caller falls back to the per-format constant.
+     */
+    @TestVisible
+    private static Integer sampleChildRowBytes(Id parentRecordId, Map<String, Object> nodeConfig) {
+        if (nodeConfig == null) {
+            return 0;
+        }
+        try {
+            String childObject = (String) nodeConfig.get('object');
+            String lookupField = (String) nodeConfig.get('lookupField');
+            List<Object> rawFields = (List<Object>) nodeConfig.get('fields');
+            if (
+                String.isBlank(childObject) ||
+                String.isBlank(lookupField) ||
+                rawFields == null ||
+                rawFields.isEmpty()
+            ) {
+                return 0;
+            }
+            if (Schema.getGlobalDescribe().get(childObject) == null) {
+                return 0;
+            }
+            List<String> fields = new List<String>();
+            for (Object f : rawFields) {
+                String fname = String.valueOf(f);
+                if (String.isNotBlank(fname) && !fname.contains('.')) {
+                    fields.add(String.escapeSingleQuotes(fname));
+                }
+            }
+            if (fields.isEmpty()) {
+                return 0;
+            }
+            String soql =
+                'SELECT ' +
+                String.join(fields, ',') +
+                ' FROM ' +
+                String.escapeSingleQuotes(childObject) +
+                ' WHERE ' +
+                String.escapeSingleQuotes(lookupField) +
+                ' = :parentRecordId LIMIT 1';
+            // CxSAST: object + fields validated against Schema / no dots; USER_MODE enforced.
+            List<SObject> sampleRows = Database.query(soql, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection
+            if (sampleRows.isEmpty()) {
+                return 0;
+            }
+            return JSON.serialize(sampleRows[0].getPopulatedFieldsAsMap()).length();
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+}

--- a/force-app/main/default/classes/DocGenGiantQueryRouter.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryRouter.cls
@@ -76,12 +76,20 @@ public with sharing class DocGenGiantQueryRouter {
     public static Integer estimatePeakHeapBytes(Integer rowCount, Integer sampleRowBytes, String outputFormat) {
         Boolean isPdf = String.isBlank(outputFormat) || 'PDF'.equalsIgnoreCase(outputFormat);
         Long baseBytes = isPdf ? PDF_BASE_BYTES : DOCX_BASE_BYTES;
-        Long perRow = isPdf ? PDF_BYTES_PER_ROW : DOCX_BYTES_PER_ROW;
+        Long perRow;
         if (sampleRowBytes != null && sampleRowBytes > 0) {
+            // We measured a real child row — trust it (scaled by the format's
+            // render blow-up), rather than ratcheting up to the pessimistic
+            // per-format default. The default over-costs skinny rows: at
+            // 10 KB/row a PDF crosses the heap ceiling near 260 rows even when
+            // every row is a few hundred bytes, routing a template the async
+            // batch can't process (it only takes Word) to a hard error. A small
+            // floor covers per-row merge/parse overhead.
             Long sampled = (Long) sampleRowBytes * (isPdf ? PDF_ROW_BLOWUP : DOCX_ROW_BLOWUP);
-            if (sampled > perRow) {
-                perRow = sampled;
-            }
+            Long floorPerRow = isPdf ? 1200L : 400L;
+            perRow = sampled > floorPerRow ? sampled : floorPerRow;
+        } else {
+            perRow = isPdf ? PDF_BYTES_PER_ROW : DOCX_BYTES_PER_ROW;
         }
         Long rows = rowCount == null ? 0 : rowCount;
         // Long math + clamp: rows * a sampled fat per-row cost overflows a
@@ -108,6 +116,16 @@ public with sharing class DocGenGiantQueryRouter {
         }
 
         Integer safe = safeHeapBytes();
+        // Sample a real child row for any relationship in the "not tiny, not
+        // certainly-giant" band — that is where a row's true payload decides
+        // sync vs async, in BOTH directions: a few hundred rows carrying 30 KB
+        // fields must route async (the #374 crash), and a few hundred skinny
+        // rows must stay sync (or a PDF template is handed to the Word-only
+        // batch). SOQL is bounded by sampleBudget, not by the relationship
+        // count, because decide() runs once per Request in the Flow bulk loop —
+        // a relationship past the budget falls back to the row-count estimate,
+        // which errs toward async (safe).
+        Integer sampleBudget = 2;
         for (String relKey : d.counts.keySet()) {
             Integer rows = d.counts.get(relKey);
             if (rows == null || rows == 0) {
@@ -115,10 +133,15 @@ public with sharing class DocGenGiantQueryRouter {
             }
 
             Map<String, Object> nodeConfig = resolveNodeConfig(parentRecordId, queryConfig, relKey);
-            Integer sampleBytes = (rows >= SAMPLE_MIN_ROWS) ? sampleChildRowBytes(parentRecordId, nodeConfig) : 0;
-            Integer estPeak = estimatePeakHeapBytes(rows, sampleBytes, outputFormat);
 
             Boolean overCeiling = rows > GIANT_ROW_CEILING;
+            Integer sampleBytes = 0;
+            if (!overCeiling && sampleBudget > 0 && rows >= SAMPLE_MIN_ROWS) {
+                sampleBytes = sampleChildRowBytes(parentRecordId, nodeConfig);
+                sampleBudget--;
+            }
+            Integer estPeak = estimatePeakHeapBytes(rows, sampleBytes, outputFormat);
+
             Boolean overHeap = estPeak > safe;
             if (overCeiling || overHeap) {
                 d.useGiantPath = true;

--- a/force-app/main/default/classes/DocGenGiantQueryRouter.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenGiantQueryRouter.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenGiantQueryRouterTest.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryRouterTest.cls
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for DocGenGiantQueryRouter — the shared sync-vs-Giant-Query
+ * decision point introduced for issue #374.
+ */
+@IsTest
+private class DocGenGiantQueryRouterTest {
+    private static final String V3_CONTACTS =
+        '{"v":3,"root":"Account","nodes":[' +
+        '{"id":"n0","object":"Account","fields":["Name"],"parentFields":[],"parentNode":null,"lookupField":null,"relationshipName":null},' +
+        '{"id":"n1","object":"Contact","fields":["LastName"],"parentFields":[],"parentNode":"n0","lookupField":"AccountId","relationshipName":"Contacts"}' +
+        ']}';
+
+    private static Id makeAccountWithContacts(Integer howMany, Integer descLen) {
+        Account a = new Account(Name = 'GQR Router Co');
+        insert a;
+        if (howMany > 0) {
+            String descText = null;
+            if (descLen != null && descLen > 0) {
+                descText = 'x'.rightPad(descLen, 'x');
+            }
+            List<Contact> cs = new List<Contact>();
+            for (Integer i = 0; i < howMany; i++) {
+                cs.add(new Contact(LastName = 'R' + i, AccountId = a.Id, Description = descText));
+            }
+            insert cs;
+        }
+        return a.Id;
+    }
+
+    @IsTest
+    static void safeHeapBytesIs60PercentOfLimit() {
+        System.assertEquals(3600000, DocGenGiantQueryRouter.safeHeapBytes(), '60% of the 6MB sync governor');
+    }
+
+    @IsTest
+    static void estimateUsesPerFormatDefaultForSkinnyRows() {
+        System.assertEquals(
+            1000000 + (300 * 10000),
+            DocGenGiantQueryRouter.estimatePeakHeapBytes(300, 0, 'PDF'),
+            'PDF: base + rows * 10KB'
+        );
+        System.assertEquals(
+            200000 + (300 * 2000),
+            DocGenGiantQueryRouter.estimatePeakHeapBytes(300, 0, 'Native'),
+            'DOCX: base + rows * 2KB'
+        );
+    }
+
+    @IsTest
+    static void estimateBlankFormatTreatedAsPdf() {
+        System.assertEquals(
+            1000000 + 10000,
+            DocGenGiantQueryRouter.estimatePeakHeapBytes(1, 0, null),
+            'blank output format -> conservative PDF model'
+        );
+    }
+
+    @IsTest
+    static void estimateSampledFatRowBeatsTheDefault() {
+        // One 20KB row -> 20000 * 5 (PDF DOM blow-up) = 100000/row, far above the
+        // 10000 default, so 40 rows already crosses the safe line.
+        Integer est = DocGenGiantQueryRouter.estimatePeakHeapBytes(40, 20000, 'PDF');
+        System.assertEquals(1000000 + (40 * 100000), est, 'sampled per-row cost is used when larger');
+        System.assert(est > DocGenGiantQueryRouter.safeHeapBytes(), 'and it pushes past the safe budget');
+    }
+
+    @IsTest
+    static void decideStaysSyncWhenNoChildren() {
+        Id acctId = makeAccountWithContacts(0, 0);
+        Test.startTest();
+        DocGenGiantQueryRouter.Decision d = DocGenGiantQueryRouter.decide(acctId, V3_CONTACTS, 'PDF');
+        Test.stopTest();
+        System.assertEquals(false, d.useGiantPath, 'no child rows -> sync');
+    }
+
+    @IsTest
+    static void decideStaysSyncForASmallDataset() {
+        Id acctId = makeAccountWithContacts(5, 0);
+        Test.startTest();
+        DocGenGiantQueryRouter.Decision d = DocGenGiantQueryRouter.decide(acctId, V3_CONTACTS, 'PDF');
+        Test.stopTest();
+        System.assertEquals(false, d.useGiantPath, '5 contacts fit the sync heap budget');
+    }
+
+    @IsTest
+    static void decideRoutesGiantOnEstimatedHeapForV3() {
+        Id acctId = makeAccountWithContacts(300, 0);
+        Test.startTest();
+        DocGenGiantQueryRouter.Decision d = DocGenGiantQueryRouter.decide(acctId, V3_CONTACTS, 'PDF');
+        Test.stopTest();
+        System.assertEquals(true, d.useGiantPath, '300 rows * PDF per-row cost exceeds the safe sync budget');
+        System.assertEquals('Contacts', d.giantRelationship, 'the offending relationship');
+        System.assertNotEquals(null, d.giantNodeConfig, 'node config resolved for the batch');
+        System.assertEquals('Contact', (String) d.giantNodeConfig.get('object'), 'V3 node carries the child object');
+    }
+
+    @IsTest
+    static void decideScoutsAndResolvesAV1FlatConfig() {
+        // The old Flow action gated scouting on configVersion >= 3, so a V1 flat
+        // string was NEVER checked and always ran synchronously (#374).
+        Id acctId = makeAccountWithContacts(300, 0);
+        String v1 = 'Name, (SELECT LastName FROM Contacts)';
+        Test.startTest();
+        DocGenGiantQueryRouter.Decision d = DocGenGiantQueryRouter.decide(acctId, v1, 'PDF');
+        Test.stopTest();
+        System.assertEquals(true, d.useGiantPath, 'V1 config is now scouted and routed');
+        System.assertNotEquals(null, d.giantNodeConfig, 'V1 subquery parsed into a batch node config');
+        System.assertEquals(
+            'Contacts',
+            (String) d.giantNodeConfig.get('relationshipName'),
+            'real relationship name kept'
+        );
+    }
+
+    @IsTest
+    static void decideRoutesGiantOnSampledPayloadForFewFatRows() {
+        // Only 40 rows — under any count threshold and under the row-count-only
+        // heap estimate — but each carries ~20KB of text. Sampling catches it.
+        Id acctId = makeAccountWithContacts(40, 20000);
+        String v1 = 'Name, (SELECT LastName, Description FROM Contacts)';
+        Test.startTest();
+        DocGenGiantQueryRouter.Decision d = DocGenGiantQueryRouter.decide(acctId, v1, 'PDF');
+        Test.stopTest();
+        System.assertEquals(true, d.useGiantPath, '40 fat rows route async once the payload is sampled');
+        System.assert(
+            d.estimatedPeakHeapBytes > DocGenGiantQueryRouter.safeHeapBytes(),
+            'estimate reflects the payload'
+        );
+    }
+
+    @IsTest
+    static void decideHandlesNullInputs() {
+        DocGenGiantQueryRouter.Decision d1 = DocGenGiantQueryRouter.decide(null, V3_CONTACTS, 'PDF');
+        System.assertEquals(false, d1.useGiantPath, 'null record -> not giant');
+        Id acctId = makeAccountWithContacts(0, 0);
+        DocGenGiantQueryRouter.Decision d2 = DocGenGiantQueryRouter.decide(acctId, '   ', 'PDF');
+        System.assertEquals(false, d2.useGiantPath, 'blank config -> not giant');
+    }
+
+    @IsTest
+    static void resolveNodeConfigMatchesAnAliasedV3Node() {
+        String aliased =
+            '{"v":3,"root":"Account","nodes":[' +
+            '{"id":"n0","object":"Account","fields":["Name"],"parentNode":null,"lookupField":null,"relationshipName":null},' +
+            '{"id":"n1","alias":"BigItems","object":"Contact","fields":["LastName"],"parentNode":"n0","lookupField":"AccountId","relationshipName":"Contacts"}' +
+            ']}';
+        Id acctId = makeAccountWithContacts(300, 0);
+        Test.startTest();
+        DocGenGiantQueryRouter.Decision d = DocGenGiantQueryRouter.decide(acctId, aliased, 'PDF');
+        Test.stopTest();
+        System.assertEquals(true, d.useGiantPath, 'aliased node still routes');
+        System.assertEquals('BigItems', d.giantRelationship, 'keyed by the alias');
+        System.assertEquals(
+            'Contacts',
+            (String) d.giantNodeConfig.get('relationshipName'),
+            'but the node keeps the real relationship name for SOQL'
+        );
+    }
+}

--- a/force-app/main/default/classes/DocGenGiantQueryRouterTest.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryRouterTest.cls
@@ -65,6 +65,21 @@ private class DocGenGiantQueryRouterTest {
     }
 
     @IsTest
+    static void estimateSampledSkinnyRowDropsBelowTheDefault() {
+        // A measured 250-byte row -> 250 * 5 = 1250/row, well under the 10000
+        // PDF default. The sample must be TRUSTED, not floored up to the default:
+        // 300 such rows are ~1.4MB, nowhere near the 3.6MB budget, so they must
+        // stay synchronous (the #374 fix must not over-route skinny datasets).
+        Integer est = DocGenGiantQueryRouter.estimatePeakHeapBytes(300, 250, 'PDF');
+        System.assertEquals(
+            1000000 + (300 * 1250),
+            est,
+            'sampled per-row cost is used even when smaller than the default'
+        );
+        System.assert(est < DocGenGiantQueryRouter.safeHeapBytes(), 'skinny rows stay under the sync budget');
+    }
+
+    @IsTest
     static void decideStaysSyncWhenNoChildren() {
         Id acctId = makeAccountWithContacts(0, 0);
         Test.startTest();
@@ -83,12 +98,31 @@ private class DocGenGiantQueryRouterTest {
     }
 
     @IsTest
-    static void decideRoutesGiantOnEstimatedHeapForV3() {
+    static void decideStaysSyncForManySkinnyRows() {
+        // 300 rows with no large field — the row-count-only estimate (4MB) is
+        // over budget, but sampling a real 200-ish-byte row shows the dataset
+        // is actually ~1.4MB. It must stay SYNCHRONOUS: routing it async would
+        // hand a PDF template to the Word-only batch (#374 must not over-route).
         Id acctId = makeAccountWithContacts(300, 0);
         Test.startTest();
         DocGenGiantQueryRouter.Decision d = DocGenGiantQueryRouter.decide(acctId, V3_CONTACTS, 'PDF');
         Test.stopTest();
-        System.assertEquals(true, d.useGiantPath, '300 rows * PDF per-row cost exceeds the safe sync budget');
+        System.assertEquals(
+            false,
+            d.useGiantPath,
+            '300 skinny rows fit the sync heap budget once a real row is measured'
+        );
+    }
+
+    @IsTest
+    static void decideRoutesGiantOverTheRowCeiling() {
+        // Above GIANT_ROW_CEILING (2,000) it routes on count alone, no sampling —
+        // matching the historical threshold so V3 templates behave as before at scale.
+        Id acctId = makeAccountWithContacts(2100, 0);
+        Test.startTest();
+        DocGenGiantQueryRouter.Decision d = DocGenGiantQueryRouter.decide(acctId, V3_CONTACTS, 'PDF');
+        Test.stopTest();
+        System.assertEquals(true, d.useGiantPath, '2,100 rows exceed the row-count ceiling');
         System.assertEquals('Contacts', d.giantRelationship, 'the offending relationship');
         System.assertNotEquals(null, d.giantNodeConfig, 'node config resolved for the batch');
         System.assertEquals('Contact', (String) d.giantNodeConfig.get('object'), 'V3 node carries the child object');
@@ -98,7 +132,7 @@ private class DocGenGiantQueryRouterTest {
     static void decideScoutsAndResolvesAV1FlatConfig() {
         // The old Flow action gated scouting on configVersion >= 3, so a V1 flat
         // string was NEVER checked and always ran synchronously (#374).
-        Id acctId = makeAccountWithContacts(300, 0);
+        Id acctId = makeAccountWithContacts(2100, 0);
         String v1 = 'Name, (SELECT LastName FROM Contacts)';
         Test.startTest();
         DocGenGiantQueryRouter.Decision d = DocGenGiantQueryRouter.decide(acctId, v1, 'PDF');
@@ -144,7 +178,7 @@ private class DocGenGiantQueryRouterTest {
             '{"id":"n0","object":"Account","fields":["Name"],"parentNode":null,"lookupField":null,"relationshipName":null},' +
             '{"id":"n1","alias":"BigItems","object":"Contact","fields":["LastName"],"parentNode":"n0","lookupField":"AccountId","relationshipName":"Contacts"}' +
             ']}';
-        Id acctId = makeAccountWithContacts(300, 0);
+        Id acctId = makeAccountWithContacts(2100, 0);
         Test.startTest();
         DocGenGiantQueryRouter.Decision d = DocGenGiantQueryRouter.decide(acctId, aliased, 'PDF');
         Test.stopTest();

--- a/force-app/main/default/classes/DocGenGiantQueryRouterTest.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenGiantQueryRouterTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Closes #374

## Summary

"Generate Document (Auto Giant Query)" decided sync vs async purely on a child **row count > 2,000**. A Quote with a few hundred line items carrying large descriptions is well under that but tens of MB of data, so it ran synchronously and blew the 6 MB Apex heap governor with an **uncatchable** `System.LimitException: Apex heap size too large`. This routes on estimated heap instead.

## Changes

- **`DocGenGiantQueryRouter.cls`** *(new)* — the single sync-vs-batch decision point. Estimates peak synchronous heap and **samples one real child row**, so a relationship whose rows carry a 30 KB rich-text field is not costed as if every row were 2 KB. Works for every query-config format. Resolves the batch node config and matches aliased V3 nodes correctly.
- **`DocGenController.cls`** — `scoutChildCounts` (the on-screen Runner's pre-flight) now delegates its estimate to `DocGenGiantQueryRouter`, so the Runner and the Flow action share one estimator and can't drift apart again — which is how this bug happened. `buildNodeConfigFromFlat` made `public` so the router can reuse it.
- **`DocGenGiantQueryFlowAction.cls`** — routes via the router. Drops the `configVersion >= 3` gate that meant V1/V2 templates were *never scouted*. Three pre-flight guards that fail cleanly (the heap `LimitException` is uncatchable, so the decision must come first):
  - only **V3** configs are auto-routed to the batch — the batch path skips `processXml`, so routing a large V1/V2 template there could silently drop parent-level `{#IF}` / secondary loops. V1/V2 over budget get a clear "re-save as V3 or use the Runner" error.
  - non-Word templates → "use the Portwood Runner" (the batch path is Word-only)
  - already in an async context → "run from a synchronous Flow" (can't start a batch from a queueable)
- **`DocGenGiantQueryFlowActionTest.cls`** — +7 tests: heavy dataset routes to the batch end-to-end, V1 over budget refused (not crashed, not corrupted), HTML over budget points to the Runner, small dataset still sync, async-context guard.

## Testing

- [x] Ran Apex unit tests (`RunLocalTests`) — **2037/2037 pass, org-wide coverage 79%**. `DocGenGiantQueryRouterTest` (11) + `DocGenGiantQueryFlowActionTest` (+7) + `DocGenGiantQueryTest` + `DocGenControllerTests` all green.
- [x] Added E2E test assertions for the new behavior
- [x] Tested manually in a scratch org — same fixture that crashes `DocGenService.generateDocument` synchronously (`Apex heap size too large`) now routes to the batch through the fixed action. Stress suite:

  | child data | result |
  | --- | --- |
  | 500 rows / 7.5 MB | batch Completed, PDF saved |
  | 2,500 rows / 36 MB | Completed 50/50, PDF saved |
  | 5,000 rows / 97 MB | Completed 100/100, PDF saved |
  | 8,000 rows / 117 MB (~20× sync heap) | Completed 160/160, PDF saved |
  | 120 fat rows (under every count threshold) | routes async on the **sampled payload** |

  In every case the Flow-transaction heap stayed at ~25–40 KB — it never loads the data.
- [x] `prettier --check` clean
- [ ] `sf code-analyzer` — no code findings; the 2 "Critical" results on my machine are engine startup failures (SFGE Java OOM, no Python 3.10), not violations

**Note for existing Flows:** more documents now route to the background, which return `Is Giant Query = true` + a **Job ID** and no `Content Document ID` immediately. A Flow that uses the file right after this action should check `Is Giant Query` and poll the Job.

## Related Issues

Closes #374

## Screenshots

_Not applicable — Flow action / Apex change, no UI._

## Checklist

- [x] No hardcoded IDs, URLs, or credentials
- [x] No `VersionData` in PDF image queries (N/A — not touched)
- [x] SOQL uses `WITH USER_MODE` / `Security.stripInaccessible()` where appropriate — the router's one sampling query runs `WITH USER_MODE`; object + fields Schema-validated
- [x] No new external dependencies introduced
