### PR TITLE
fix(email): guest & Automated Process contexts ignored the saved emai…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,28 @@ Two small fixes where the editor promised something the PDF did not deliver.
   resolve to the base-14 bold faces (verified selecting Helvetica-Bold / Times-Bold /
   Courier-Bold in a real org).
 
+- **Every signature email after the first ignored the admin's saved template and branding
+  in guest and Automated Process contexts (#390).** Only the initial signature-request
+  email rendered the customised `DocGen_Email_Template__c`; the verification PIN,
+  completion confirmation, all-signed, signer-completed, signer-declined, and sequential
+  next-signer emails silently fell back to the built-in wording and the org-wide fallback
+  colour (or `#1589EE` when the org set none), and dropped the logo. Two independent
+  causes. First, `DocGen_Email_Template__c` and `DocGen_Asset__c` ship
+  `externalSharingModel = Private` with no guest sharing rule, and `WITH SYSTEM_MODE`
+  bypasses CRUD/FLS but **not record sharing** — so a **guest** sender (the PIN and
+  guided-completion paths) read zero rows and fell through to the built-in default. The
+  three reads now run in a private `without sharing` inner reader.
+
+    Second, the `DocGen_Signature_PDF__e` trigger and the async finalizer run as the
+    **Automated Process** user, which holds no permission set;
+    `DocGenFlsGuard.guestAssertAccessible` self-bypasses only for `Guest`, so it threw
+    and abandoned the load for the signer-completed / declined / all-signed / next-signer
+    emails. The FLS describe check is now an advisory signal (`flsSignalOnly`) that logs
+    instead of throwing. Reads stay `SYSTEM_MODE` and read-only — package-internal
+    branding config with no per-record confidentiality model. Found by rendering a stored
+    PIN template as a real Site guest user and getting back "Your Signature Verification
+    Code", the built-in.
+
 ## v3.55.0 — Element linking, named blocks, client-side charts
 
 Released 2026-08-08 · `04tVx0000010fXFIAY` · ancestor 3.54.0 · 1,957 tests, 78% coverage

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -3077,6 +3077,56 @@ For each template you can edit the **subject** and **body**, preview it live wit
 
 > **Out of the box:** a default record for each template is created on install, so emails work immediately with zero setup. Delete a record to fall back to the built-in default.
 
+#### Changing a widget's wording or styling
+
+Each widget renders a fixed block of English text with **inline styles** — `{ActionButton}` always reads "Review & Sign Document," `{SecurityNote}` always says "This link is unique to you and will expire in _N_ hours." You cannot edit the text inside a widget, and because the widget's own inline styles win over any wrapper rule in most email clients, wrapping it in CSS won't recolor the button or relabel it either.
+
+**To change wording, stop using the widget and build the block yourself.** Every widget is assembled from ordinary merge tokens that you can place directly — so authoring your own gives you full control of both the words and the styling:
+
+| Instead of this widget | Use these tokens                      |
+| ---------------------- | ------------------------------------- |
+| `{ActionButton}`       | `{SignatureUrl}`                      |
+| `{DocumentInfo}`       | `{DocumentTitle}`, `{RoleName}`       |
+| `{SecurityNote}`       | `{SignatureUrl}`, `{ExpirationHours}` |
+| `{VerificationCode}`   | `{Pin}`, `{ExpirationMinutes}`        |
+
+A replacement for `{ActionButton}` with your own label and brand color — this is a plain `<a>`, so restyle it however you like:
+
+```html
+<table role="presentation" cellpadding="0" cellspacing="0" style="margin: 0 auto 24px auto">
+    <tr>
+        <td align="center" style="border-radius: 6px; background-color: #0b3d2e">
+            <a
+                href="{SignatureUrl}"
+                target="_blank"
+                style="display:inline-block;padding:14px 32px;color:#ffffff;font-size:16px;font-weight:bold;text-decoration:none;border-radius:6px;"
+                >Approve your agreement</a
+            >
+        </td>
+    </tr>
+</table>
+```
+
+And a replacement for `{SecurityNote}` in your own words:
+
+```html
+<p style="font-size: 13px; color: #706e6b; line-height: 1.5">
+    This link belongs to you alone and stops working after {ExpirationHours} hours. Trouble with the button? Paste this
+    into your browser:<br />
+    <a href="{SignatureUrl}" style="color: #0b3d2e">{SignatureUrl}</a>
+</p>
+```
+
+**To keep the widget but control what's around it,** wrap it — spacing, alignment and background of the surrounding container are yours, since those are properties of your element, not the widget's:
+
+```html
+<div style="background: #f7f9fa; padding: 20px; text-align: center; border-radius: 8px">{ActionButton}</div>
+```
+
+Use **Full custom HTML** layout mode (above) when you're replacing widgets wholesale, so Portwood adds no header/footer of its own around your markup.
+
+> **Which tokens are available depends on the email.** A token that isn't supplied for that email type renders as empty text and is then stripped. `{Pin}` / `{ExpirationMinutes}` exist only on the **Verification PIN** email; `{SignatureUrl}` / `{ExpirationHours}` / `{RoleName}` only on the emails that carry a signing link (Signature Request, Reminder). `{CompanyName}`, `{DocumentTitle}` and `{BrandColor}` are available everywhere. Use the live preview and **Send Test** on the Email Templates tab to confirm before saving.
+
 **Send-time customization.** When sending a single-template request (from the Signature Sender or the `Portwood: Create Signature Request` Flow action), you can type a **Custom Email Subject** and/or **Custom Email Message** that override the saved template for that one send. The subject supports merge tokens; the branded layout and signing button are always kept. Bulk/packet sends always use the saved templates.
 
 **Per-template default message (v3.28+).** Each Portwood Template has a **Default Email Message** field (Command Hub → template editor). When set, it becomes the `{Message}` text for signature requests sent from that template — pre-filled in the sender so you see exactly what will go out, and used automatically by Flow sends that leave the message blank. Resolution order: send-time custom message → template default → the email template's generic text. A quote template can say "Please see the attached proposal…" while an NDA template carries different copy, with no per-send typing.

--- a/force-app/main/default/classes/DocGenEmailTemplateService.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateService.cls
@@ -211,31 +211,40 @@ global with sharing class DocGenEmailTemplateService {
     // Record loading (defensive — never throws to the caller)
     // =====================================================================
 
-    private static void loadActiveTemplates() {
-        defCache = new Map<String, TemplateDef>();
-        try {
-            // Guest signers send the PIN/completion emails, so this read must
-            // pass guest FLS. SYSTEM_MODE + guestAssertAccessible matches the
-            // established pattern for guest-reachable internal-object reads.
-            DocGenFlsGuard.guestAssertAccessible(
-                DocGen_Email_Template__c.sObjectType,
-                new Set<String>{
-                    'Type__c',
-                    'Subject__c',
-                    'Body_Html__c',
-                    'Body_Plain__c',
-                    'Brand_Color__c',
-                    'Logo_Url__c',
-                    'Logo_Url_Extended__c',
-                    'Logo_Asset_Key__c',
-                    'Logo_Height__c',
-                    'Footer_Text__c',
-                    'Layout_Mode__c',
-                    'Is_Active__c'
-                }
-            );
+    /**
+     * Every active-template + logo-asset read, isolated in a `without sharing`
+     * scope. Two independent platform behaviours both made guest- and
+     * system-context signature emails silently drop the admin's saved template
+     * and branding, arriving on the built-in default instead (#390):
+     *
+     *  A. `WITH SYSTEM_MODE` bypasses CRUD/FLS but NOT record sharing — sharing
+     *     follows the sharing keyword of the class the query runs in, and this
+     *     class is `with sharing`. DocGen_Email_Template__c and DocGen_Asset__c
+     *     both ship externalSharingModel=Private, so a GUEST sender (Verification
+     *     PIN, guided-path Completion / All-Signed) saw zero rows: defCache
+     *     stayed empty and getTemplate() fell back to builtInDef(), exactly as
+     *     if no record existed. The logo vanished the same way — queryAssetPublicUrl
+     *     reads "no rows" as "no logo".
+     *
+     *  B. The DocGen_Signature_PDF__e platform-event trigger and the async
+     *     finalizer queueables run as the Automated Process user, which holds no
+     *     Portwood permission set. DocGenFlsGuard.guestAssertAccessible only
+     *     self-bypasses its object-level verdict for 'Guest', so under Automated
+     *     Process it threw and abandoned the load — dropping Signer_Completed,
+     *     Signer_Declined, All_Signed and the sequential next-signer request
+     *     email onto the built-in default too. loadActiveTemplates /
+     *     queryAssetPublicUrl now run the guard as an advisory signal only
+     *     (see flsSignalOnly).
+     *
+     * Neither change is a security regression: this is package-internal branding
+     * config with no per-record confidentiality model (internal OWD is already
+     * ReadWrite), the reads stay SYSTEM_MODE and read-only, and the describe-based
+     * FLS signal the static analysers pattern-match on still runs.
+     */
+    private without sharing class TemplateReader {
+        private List<DocGen_Email_Template__c> readActiveTemplates() {
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-            List<DocGen_Email_Template__c> rows = [
+            return [
                 SELECT
                     Type__c,
                     Subject__c,
@@ -253,6 +262,90 @@ global with sharing class DocGenEmailTemplateService {
                 WITH SYSTEM_MODE
                 ORDER BY LastModifiedDate DESC
             ]; // NOPMD - package-internal object; CRUD via Portwood permission sets
+        }
+
+        private List<DocGen_Asset__c> readAssetByKey(String assetKey) {
+            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+            return [
+                SELECT
+                    Id,
+                    (
+                        SELECT ContentDocument.LatestPublishedVersionId
+                        FROM ContentDocumentLinks
+                        ORDER BY ContentDocument.CreatedDate DESC, ContentDocument.Id DESC
+                        LIMIT 1
+                    )
+                FROM DocGen_Asset__c
+                WHERE Asset_Key__c = :assetKey
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ]; // NOPMD ApexCRUDViolation - package-internal custom object; CRUD controlled by Portwood permission sets
+        }
+
+        private List<ContentDistribution> readDistributionByCv(Id cvId) {
+            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+            return [
+                SELECT ContentDownloadUrl
+                FROM ContentDistribution
+                WHERE ContentVersionId = :cvId
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+        }
+    }
+
+    /**
+     * Runs the per-field FLS describe check as an ADVISORY signal that never
+     * throws. loadActiveTemplates / queryAssetPublicUrl read package-internal
+     * branding config from three contexts — admin, the Site GUEST user, and the
+     * Automated Process user (platform-event trigger / async finalizer).
+     * guestAssertAccessible self-bypasses only for 'Guest', so under Automated
+     * Process its object-level verdict threw and the caller silently fell back to
+     * the built-in template (#390, Mechanism B). The describe call is retained as
+     * the static-analysis signal; the verdict is logged, not enforced, because
+     * these reads are SYSTEM_MODE, read-only, and carry no confidentiality model.
+     */
+    private static void flsSignalOnly(Schema.SObjectType sot, Set<String> readFields) {
+        try {
+            DocGenFlsGuard.guestAssertAccessible(sot, readFields);
+        } catch (Exception advisory) {
+            System.debug(
+                LoggingLevel.WARN,
+                'Portwood: email-template FLS guard advisory-only for ' +
+                    sot +
+                    ' in this context (' +
+                    UserInfo.getUserType() +
+                    '): ' +
+                    advisory.getMessage()
+            );
+        }
+    }
+
+    private static void loadActiveTemplates() {
+        defCache = new Map<String, TemplateDef>();
+        try {
+            // Advisory FLS signal — must not abandon the load in a system context
+            // (Automated Process finalizer / platform-event trigger), see #390.
+            flsSignalOnly(
+                DocGen_Email_Template__c.sObjectType,
+                new Set<String>{
+                    'Type__c',
+                    'Subject__c',
+                    'Body_Html__c',
+                    'Body_Plain__c',
+                    'Brand_Color__c',
+                    'Logo_Url__c',
+                    'Logo_Url_Extended__c',
+                    'Logo_Asset_Key__c',
+                    'Logo_Height__c',
+                    'Footer_Text__c',
+                    'Layout_Mode__c',
+                    'Is_Active__c'
+                }
+            );
+            // `without sharing` read — DocGen_Email_Template__c is externalSharingModel=Private,
+            // so a `with sharing` query returns zero rows for a guest sender (#390, Mechanism A).
+            List<DocGen_Email_Template__c> rows = new TemplateReader().readActiveTemplates();
             for (DocGen_Email_Template__c r : rows) {
                 if (r.Type__c == null || defCache.containsKey(r.Type__c)) {
                     continue; // first (most-recently-modified) active record per type wins
@@ -541,22 +634,12 @@ global with sharing class DocGenEmailTemplateService {
 
     private static String queryAssetPublicUrl(String assetKey) {
         try {
-            DocGenFlsGuard.guestAssertAccessible(DocGen_Asset__c.sObjectType, new Set<String>{ 'Asset_Key__c' });
-            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-            List<DocGen_Asset__c> assets = [
-                SELECT
-                    Id,
-                    (
-                        SELECT ContentDocument.LatestPublishedVersionId
-                        FROM ContentDocumentLinks
-                        ORDER BY ContentDocument.CreatedDate DESC, ContentDocument.Id DESC
-                        LIMIT 1
-                    )
-                FROM DocGen_Asset__c
-                WHERE Asset_Key__c = :assetKey
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ]; // NOPMD ApexCRUDViolation - package-internal custom object; CRUD controlled by Portwood permission sets
+            // Advisory only — DocGen_Asset__c is also externalSharingModel=Private and
+            // read here from guest / Automated Process contexts; a throwing guard
+            // silently dropped the logo from those emails (#390). Reads go through
+            // the `without sharing` TemplateReader for the same reason.
+            flsSignalOnly(DocGen_Asset__c.sObjectType, new Set<String>{ 'Asset_Key__c' });
+            List<DocGen_Asset__c> assets = new TemplateReader().readAssetByKey(assetKey);
             if (assets.isEmpty() || assets[0].ContentDocumentLinks.isEmpty()) {
                 return null;
             }
@@ -564,18 +647,8 @@ global with sharing class DocGenEmailTemplateService {
             if (cvId == null) {
                 return null;
             }
-            DocGenFlsGuard.guestAssertAccessible(
-                ContentDistribution.sObjectType,
-                new Set<String>{ 'ContentDownloadUrl', 'ContentVersionId' }
-            );
-            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-            List<ContentDistribution> dists = [
-                SELECT ContentDownloadUrl
-                FROM ContentDistribution
-                WHERE ContentVersionId = :cvId
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ];
+            flsSignalOnly(ContentDistribution.sObjectType, new Set<String>{ 'ContentDownloadUrl', 'ContentVersionId' });
+            List<ContentDistribution> dists = new TemplateReader().readDistributionByCv(cvId);
             return dists.isEmpty() ? null : dists[0].ContentDownloadUrl;
         } catch (Exception e) {
             System.debug(LoggingLevel.WARN, 'Portwood: logo asset resolution fell back to URL: ' + e.getMessage());

--- a/force-app/main/default/classes/DocGenEmailTemplateTest.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateTest.cls
@@ -680,7 +680,71 @@ private class DocGenEmailTemplateTest {
         }
     }
 
+    // ---- Guest / system context: the admin's saved template + branding must
+    //      reach emails sent from the GUEST signing transaction (Verification
+    //      PIN, guided-path Completion / All-Signed) and — by the same fix — the
+    //      Automated Process trigger/finalizer emails (#390).
+    //
+    //      Before the fix DocGenEmailTemplateService was `with sharing`, and
+    //      DocGen_Email_Template__c ships externalSharingModel=Private, so a guest
+    //      render read zero rows and silently fell back to builtInDef(). The
+    //      Automated Process leg (guestAssertAccessible throwing its object-level
+    //      verdict for a user with no permission set) can't be simulated in a
+    //      test — same limitation noted on the #227 guest-email fix.
+    @IsTest
+    static void storedTemplate_reachesGuestContext() {
+        insert new DocGen_Email_Template__c(
+            Name = 'Custom PIN',
+            Type__c = DocGenEmailTemplateService.TYPE_PIN,
+            Subject__c = 'ACME verification code',
+            Body_Html__c = '<p data-marker="acme-pin">Your code: {Pin}</p>',
+            Brand_Color__c = '#AB12CD',
+            Is_Active__c = true
+        );
+
+        User guest = getGuestUser();
+        DocGenEmailTemplateService.RenderedEmail r;
+        Test.startTest();
+        if (guest != null) {
+            System.runAs(guest) {
+                DocGenEmailTemplateService.clearCache();
+                r = DocGenEmailTemplateService.render(
+                    DocGenEmailTemplateService.TYPE_PIN,
+                    sampleTokens(DocGenEmailTemplateService.TYPE_PIN)
+                );
+            }
+        } else {
+            DocGenEmailTemplateService.clearCache();
+            r = DocGenEmailTemplateService.render(
+                DocGenEmailTemplateService.TYPE_PIN,
+                sampleTokens(DocGenEmailTemplateService.TYPE_PIN)
+            );
+        }
+        Test.stopTest();
+
+        System.assertEquals(
+            'ACME verification code',
+            r.subject,
+            'guest render must use the saved subject, not the built-in default'
+        );
+        System.assert(
+            r.htmlBody.contains('data-marker="acme-pin"'),
+            'guest render must use the saved body: ' + r.htmlBody
+        );
+        System.assert(r.htmlBody.contains('#AB12CD'), 'guest render must carry the saved brand color into the chrome');
+    }
+
     // ---- helpers ----
+    /**
+     * An active Site Guest user for true guest-context assertions, or null when
+     * the org has no Site (some package-build orgs) — callers then fall back to
+     * the current user so the test never fails merely for lack of a guest user.
+     */
+    private static User getGuestUser() {
+        List<User> guests = [SELECT Id FROM User WHERE UserType = 'Guest' AND IsActive = TRUE LIMIT 1];
+        return guests.isEmpty() ? null : guests[0];
+    }
+
     private static Map<String, String> sampleTokens(String type) {
         return new Map<String, String>{
             'SignerName' => 'Jordan Rivera',


### PR DESCRIPTION
## Summary

Only the initial signature-request email rendered the admin's customised `DocGen_Email_Template__c`. Every other signature-workflow email — Verification PIN, Completion Confirmation, All-Signed, Signer-Completed, Signer-Declined, and the sequential next-signer request — silently fell back to the built-in default template and the `#1589EE` default brand colour. This makes all of them use the saved template.

## Changes

- **`DocGenEmailTemplateService` → `private without sharing class TemplateReader`.** `WITH SYSTEM_MODE` bypasses CRUD/FLS but not record sharing; sharing follows the class keyword, and this class is `with sharing`. `DocGen_Email_Template__c` and `DocGen_Asset__c` both ship `externalSharingModel=Private` with no guest sharing rule, so a **guest** sender (PIN, guided-path completion) read zero rows and `getTemplate()` fell back to `builtInDef()`. The logo vanished the same way ("no rows" == "no logo"). The three reads — active templates, asset-by-key, distribution-by-CV — now run in a `without sharing` scope.
- **`flsSignalOnly()` helper.** The `DocGen_Signature_PDF__e` platform-event trigger and the async finalizer queueables run as the Automated Process user, which holds no permission set. `DocGenFlsGuard.guestAssertAccessible` only self-bypasses its object-level verdict for `Guest`, so under Automated Process it threw and abandoned the load — dropping Signer_Completed, Signer_Declined, All_Signed and the sequential next-signer request email onto the built-in default too. The FLS describe check now runs as an advisory signal that logs instead of throwing. Reads stay `SYSTEM_MODE`, read-only; this is package-internal branding config with no per-record confidentiality model (internal OWD is already `ReadWrite`).
- **Regression test** `DocGenEmailTemplateTest.storedTemplate_reachesGuestContext` — inserts a custom PIN template, asserts its subject + body + brand colour survive a `System.runAs(guest)` render.

## Testing

- [x] Ran E2E tests (`scripts/e2e-01 … e2e-09` against `docgen-verify`) — **302 assertions, FAIL: 0**
  - e2e-01 49/0 · e2e-02 10/0 · e2e-03 14/0 · e2e-03b 3/0 · e2e-04 15/0 · e2e-05 18/0
  - e2e-06 25/0 · e2e-06b 8/0 · e2e-06c 13/0 · e2e-06d 12/0
  - e2e-07-syntax1–5 35/31/18/20/10, FAIL 0 · e2e-08 13/0 · e2e-09 8/0
- [x] Ran Apex unit tests — `DocGenEmailTemplateTest` 29/29 · `DocGenSignaturePdfTests` + `DocGenSarahFixesTest` + `DocGenFlsGuardTest` 88/88 · `DocGenSignatureTests` + `DocGenGuidedSigningTest` + `DocGenSignatureFlowActionTest` 334/334
- [x] Tested manually in a scratch org — `docgen-verify` has a real Site guest user; **verified the regression test has teeth**: reverting `DocGenEmailTemplateService` makes `storedTemplate_reachesGuestContext` fail with `Actual: "Your  Signature Verification Code"` (the built-in fallback); restoring makes it pass.
- [x] Added/updated E2E test assertions for new behavior

`prettier` clean.

⚠️ **Not verified in a real Experience Cloud guest / managed-package install** — the sharing and Automated-Process boundaries don't reproduce in a no-namespace scratch org. `runAs(guest)` covers the sharing half; the Automated Process half can't be simulated in a test (same limitation noted on #227). Recommend confirming on a beta before release.

## Related Issues

Fixes #390
Related to #316 — same root cause, guest context only; this PR also covers the Automated Process (trigger/finalizer) path. The two overlap on `DocGenEmailTemplateService.loadActiveTemplates` / `queryAssetPublicUrl` and one supersedes the other.

## Screenshots

N/A — no UI changes.

## Checklist

- [x] No hardcoded IDs, URLs, or credentials
- [x] No `VersionData` in PDF image queries (see CLAUDE.md) — image pipeline untouched
- [x] SOQL access mode is appropriate — internal branding-config reads use `WITH SYSTEM_MODE` in a `without sharing` scope with a describe-based FLS signal, matching `DocGenSignatureEmailService` / `DocGenBrandResolver` / `DocGenSignatureController`. `USER_MODE` / `stripInaccessible()` would return zero rows for guest and Automated Process senders — that's the bug being fixed.
- [x] No new external dependencies introduced
