### PR TITLE
feat(bulk): duplex-ready Combined PDF — blank filler after odd-length documents (#382)

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -2755,6 +2755,20 @@ Sorting applies to Individual Files too — it decides the order records are pro
 
 > **If your Flow passes a Record IDs collection:** SOQL does not preserve the order of that collection, so sorting the collection in the Flow has no effect on the document. Use **Sort Order**.
 
+### 9.1.2 Duplex Padding — every document starts on a fresh sheet
+
+When a **Combined PDF** is printed double-sided, a document with an **odd** page count leaves its last sheet half-used, and the next document starts on the back of it. **Duplex Padding** fixes that: before the merge, Portwood checks each document's page count and appends **one blank page** to any document that has an odd number of pages, so every document begins on the front of a sheet.
+
+- The toggle appears under the output mode once you pick **Combined PDF** or **Both** (it does nothing for Individual Files, so it is hidden there and forced off).
+- The filler page is **completely blank** — no header, no footer, no watermark, no page number.
+- **Page numbers count real pages only.** Because each record is rendered as its own document and then stitched, `{PageNumber}` / `{TotalPages}` (and the `Page X of Y` header/footer fields) read per-document — a 3-page statement numbers `1 of 3, 2 of 3, 3 of 3`, and the blank filler after it carries no number. This is different from a plain Combined PDF, which numbers continuously across the whole bundle.
+- Documents with an **even** page count are never touched.
+- **Leave it off and nothing changes** — the Combined PDF is built exactly as before, with continuous numbering across the bundle.
+
+**Scale.** A duplex packet is assembled in a single background job, which is more work than the normal merge — the pre-run analysis warns above ~250 documents and blocks above ~400. For a packet larger than that, run **Individual Files** (each already starts on its own sheet) or split the filter.
+
+**In Flows**, the `Portwood: Generate Bulk Documents` action exposes this as a **Duplex Padding** checkbox input; it is ignored unless the job is producing a Combined PDF.
+
 ### 9.2 Saved queries
 
 Save a filter as a reusable `DocGen_Saved_Query__c`. Gives non-technical users a drop-down of pre-built filters without writing SOQL. Created and managed in the Bulk Generation UI.

--- a/force-app/main/default/classes/DocGenBatch.cls
+++ b/force-app/main/default/classes/DocGenBatch.cls
@@ -38,8 +38,15 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
     public Id dataCacheCvId;
     public String cachedDataJson;
 
-    // Merge mode: sequence counter for HTML snippet ordering
+    // Merge mode: sequence counter for HTML snippet / PDF part ordering
     public Integer htmlSequence = 0;
+
+    // Duplex padding (#382). When true the batch renders each record as its own
+    // PDF part instead of an HTML snippet, and DocGenMergeJob stitches the parts
+    // with DocGenPdfMerger — appending one blank page to any odd-length document
+    // so it starts on a sheet front under duplex printing. False keeps the
+    // historical HTML-concatenation merge unchanged.
+    public Boolean duplexPadding = false;
 
     // Chart rasterization (Stateful — resolved once, reused across execute() chunks).
     //
@@ -94,7 +101,7 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
         // DocGenFlsGuard.cls.
         DocGenFlsGuard.assertAccessible(
             DocGen_Job__c.sObjectType,
-            new Set<String>{ 'Template__c', 'Query_Condition__c', 'Sort_Order__c' }
+            new Set<String>{ 'Template__c', 'Query_Condition__c', 'Sort_Order__c', 'Duplex_Padding__c' }
         );
         /* code-analyzer-suppress ApexFlsViolation */
         DocGen_Job__c job = [
@@ -103,7 +110,8 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
                 Template__r.Base_Object_API__c,
                 Template__r.Query_Config__c,
                 Query_Condition__c,
-                Sort_Order__c
+                Sort_Order__c,
+                Duplex_Padding__c
             FROM DocGen_Job__c
             WHERE Id = :jobId
             WITH SYSTEM_MODE
@@ -113,6 +121,7 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
         this.condition = job.Query_Condition__c;
         this.queryConfig = job.Template__r.Query_Config__c;
         this.sortOrder = job.Sort_Order__c;
+        this.duplexPadding = job.Duplex_Padding__c == true;
     }
 
     /**
@@ -352,8 +361,11 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
             DocGenService.generateDocument(templateId, recordId);
         }
 
-        // Merge mode (not merge-only): also capture HTML snippet for merged PDF
-        if (mergeMode && DocGenService.lastRenderedHtml != null) {
+        // Merge mode (not merge-only): also capture HTML snippet for merged PDF.
+        // Skipped under duplex padding — that path merges from per-record PDF
+        // parts saved in execute(), so an HTML snippet here would just be an
+        // orphaned ContentVersion the merge job never reads (#382).
+        if (mergeMode && !duplexPadding && DocGenService.lastRenderedHtml != null) {
             saveHtmlSnippet(DocGenService.lastRenderedHtml);
             DocGenService.lastRenderedHtml = null;
         }
@@ -369,6 +381,24 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
             Title = 'docgen_merge_' + jobId + '_' + seq,
             PathOnClient = 'docgen_merge_' + jobId + '_' + seq + '.html',
             VersionData = Blob.valueOf(html),
+            IsMajorVersion = false,
+            FirstPublishLocationId = jobId
+        );
+        SObjectAccessDecision cvDec = Security.stripInaccessible(AccessType.CREATABLE, new List<ContentVersion>{ cv });
+        insert cvDec.getRecords(); // NOPMD ApexCRUDViolation — FLS enforced by stripInaccessible
+    }
+
+    /**
+     * Writes one rendered PDF as a tiny ContentVersion linked to the Job, ordered
+     * by the same sequence counter as saveHtmlSnippet. DocGenMergeJob reads these
+     * by title prefix and hands them to DocGenPdfMerger. Duplex-padding path only.
+     */
+    private void savePdfPart(Blob pdf) {
+        String seq = String.valueOf(htmlSequence++).leftPad(5, '0');
+        ContentVersion cv = new ContentVersion(
+            Title = 'docgen_pdfpart_' + jobId + '_' + seq,
+            PathOnClient = 'docgen_pdfpart_' + jobId + '_' + seq + '.pdf',
+            VersionData = pdf,
             IsMajorVersion = false,
             FirstPublishLocationId = jobId
         );
@@ -442,7 +472,18 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
                     }
                 }
 
-                if (mergeOnly) {
+                if (duplexPadding) {
+                    // Duplex padding (#382): render this record as its own PDF part.
+                    // DocGenMergeJob stitches the parts and pads odd-length documents.
+                    // In "Combined + Individual" mode the per-record file is still saved.
+                    Map<String, Object> res = (recordData != null)
+                        ? DocGenService.generatePdfBlobFromData(templateId, rec.Id, recordData)
+                        : DocGenService.generatePdfBlob(templateId, rec.Id);
+                    savePdfPart((Blob) res.get('blob'));
+                    if (!mergeOnly) {
+                        generateIndividualDocument(rec.Id, recordData);
+                    }
+                } else if (mergeOnly) {
                     // Merge-only: generate HTML, save snippet — no Blob.toPdf(), no individual file
                     String html = DocGenService.generateHtmlForRecord(templateId, rec.Id, recordData);
                     saveHtmlSnippet(html);

--- a/force-app/main/default/classes/DocGenBulkController.cls
+++ b/force-app/main/default/classes/DocGenBulkController.cls
@@ -529,10 +529,19 @@ public with sharing class DocGenBulkController {
      * @param recordCount Total number of records to be processed
      * @param batchSize Records per batch execution
      * @param mergePdf Whether merge mode is enabled
+     * @param duplexPadding Whether Combined-PDF duplex padding is on (#382) — its
+     *        merge renders a PDF per record and stitches them, which has a much
+     *        lower record ceiling than the HTML-concatenation merge.
      * @return JobAnalysis with per-check results and overall verdict
      */
     @AuraEnabled
-    public static JobAnalysis analyzeJob(Id templateId, Integer recordCount, Integer batchSize, Boolean mergePdf) {
+    public static JobAnalysis analyzeJob(
+        Id templateId,
+        Integer recordCount,
+        Integer batchSize,
+        Boolean mergePdf,
+        Boolean duplexPadding
+    ) {
         // canProceed gates the Run button and is reserved for HARD blockers only —
         // conditions no batch size or record set can work around (unsupported
         // template/mode combination, or the platform's own QueryLocator ceiling).
@@ -695,7 +704,34 @@ public with sharing class DocGenBulkController {
                     // Merge Queueable only reads back saved HTML snippets, not full generation heap
                     Long snippetBytes = html.length() * 2; // UTF-16
 
-                    if (isMerge) {
+                    if (isMerge && duplexPadding == true) {
+                        // Duplex padding (#382): the merge renders a PDF per record
+                        // and stitches them in one Queueable. Measured ceiling is
+                        // ~350 records for a heavy template (CPU-bound on the byte
+                        // assembly, not heap after font dedup). Cap conservatively.
+                        AnalysisItem dItem = new AnalysisItem();
+                        dItem.label = 'Duplex Packet';
+                        dItem.estimated = recordCount;
+                        dItem.limitVal = 400;
+                        if (recordCount > 400) {
+                            dItem.status = 'error';
+                            dItem.message =
+                                recordCount +
+                                ' documents — a duplex packet is assembled in one job and cannot exceed ~400 documents. ' +
+                                'Turn off Duplex Padding, switch to Individual Files, or narrow the filter.';
+                            analysis.canProceed = false;
+                        } else if (recordCount > 250) {
+                            dItem.status = 'warning';
+                            dItem.message =
+                                recordCount +
+                                ' documents — large duplex packet. Assembly may fail near the ~400 ceiling; if it does, ' +
+                                'run Individual Files or split the filter.';
+                        } else {
+                            dItem.status = 'ok';
+                            dItem.message = recordCount + ' documents — within the duplex packet limit.';
+                        }
+                        analysis.items.add(dItem);
+                    } else if (isMerge) {
                         // Merge heap: Queueable reads all HTML snippets + concatenates + Blob.toPdf()
                         AnalysisItem heapItem = new AnalysisItem();
                         heapItem.label = 'Merge Heap';
@@ -867,7 +903,7 @@ public with sharing class DocGenBulkController {
     // Keep for backward compatibility — delegates to analyzeJob
     @AuraEnabled
     public static HeapEstimate estimateHeapUsage(Id templateId, Integer recordCount) {
-        JobAnalysis analysis = analyzeJob(templateId, recordCount, 1, true);
+        JobAnalysis analysis = analyzeJob(templateId, recordCount, 1, true, false);
         HeapEstimate estimate = new HeapEstimate();
         for (AnalysisItem item : analysis.items) {
             if (item.label == 'Merge Heap') {
@@ -899,6 +935,8 @@ public with sharing class DocGenBulkController {
      * @param batchSize Number of records per batch execution (1-200)
      * @param mergeOnly Whether to only generate merged PDF without individual files
      * @param sortOrder Optional SOQL ORDER BY clause controlling processing (and merged page) order
+     * @param duplexPadding Combined-PDF only (#382): when true, each odd-length document gets a
+     *        blank page before the merge so it starts on the front of a sheet. Null = off.
      * @return The DocGen_Job__c record ID
      */
     @AuraEnabled
@@ -909,11 +947,21 @@ public with sharing class DocGenBulkController {
         Boolean mergePdf,
         Integer batchSize,
         Boolean mergeOnly,
-        String sortOrder
+        String sortOrder,
+        Boolean duplexPadding
     ) {
         // The LWC boundary, and the ONLY place AuraHandledException may be raised.
         try {
-            return submitJobInternal(templateId, condition, jobLabel, mergePdf, batchSize, mergeOnly, sortOrder);
+            return submitJobInternal(
+                templateId,
+                condition,
+                jobLabel,
+                mergePdf,
+                batchSize,
+                mergeOnly,
+                sortOrder,
+                duplexPadding
+            );
         } catch (Exception e) {
             throw DocGenService.ahe(e, 'Error starting bulk generation job.');
         }
@@ -946,7 +994,7 @@ public with sharing class DocGenBulkController {
         Integer batchSize,
         Boolean mergeOnly
     ) {
-        return submitJobInternal(templateId, condition, jobLabel, mergePdf, batchSize, mergeOnly, null);
+        return submitJobInternal(templateId, condition, jobLabel, mergePdf, batchSize, mergeOnly, null, null);
     }
 
     /**
@@ -961,6 +1009,22 @@ public with sharing class DocGenBulkController {
         Integer batchSize,
         Boolean mergeOnly,
         String sortOrder
+    ) {
+        return submitJobInternal(templateId, condition, jobLabel, mergePdf, batchSize, mergeOnly, sortOrder, null);
+    }
+
+    /**
+     * As above, with Combined-PDF duplex padding (#382).
+     */
+    public static Id submitJobInternal(
+        Id templateId,
+        String condition,
+        String jobLabel,
+        Boolean mergePdf,
+        Integer batchSize,
+        Boolean mergeOnly,
+        String sortOrder,
+        Boolean duplexPadding
     ) {
         try {
             Boolean isMergeOnly = (mergeOnly == true);
@@ -991,13 +1055,19 @@ public with sharing class DocGenBulkController {
                 ? null
                 : normalizeSortOrder(templateBaseObject(templateId), sortOrder);
 
+            // Duplex padding (#382) only applies to a Combined PDF; it is
+            // meaningless on an Individual-Files job, so it's dropped there
+            // rather than errored.
+            Boolean safeDuplex = isMergeMode && duplexPadding == true;
+
             // 1. Create Job Record
             DocGen_Job__c job = new DocGen_Job__c(
                 Template__c = templateId,
                 Query_Condition__c = condition,
                 Status__c = 'Queued',
                 Merge_Only__c = isMergeOnly,
-                Sort_Order__c = safeSortOrder
+                Sort_Order__c = safeSortOrder,
+                Duplex_Padding__c = safeDuplex
             );
             if (String.isNotBlank(jobLabel)) {
                 job.Label__c = jobLabel;
@@ -1017,7 +1087,8 @@ public with sharing class DocGenBulkController {
                     'Status__c',
                     'Merge_Only__c',
                     'Label__c',
-                    'Sort_Order__c'
+                    'Sort_Order__c',
+                    'Duplex_Padding__c'
                 }
             );
             /* code-analyzer-suppress ApexFlsViolation */

--- a/force-app/main/default/classes/DocGenBulkControllerTest.cls
+++ b/force-app/main/default/classes/DocGenBulkControllerTest.cls
@@ -118,7 +118,7 @@ public with sharing class DocGenBulkControllerTest {
         DocGen_Template__c temp = [SELECT Id FROM DocGen_Template__c LIMIT 1];
 
         Test.startTest();
-        DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(temp.Id, 10, 1, false);
+        DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(temp.Id, 10, 1, false, false);
         Test.stopTest();
 
         System.assertNotEquals(null, analysis, 'Analysis should not be null');
@@ -140,7 +140,7 @@ public with sharing class DocGenBulkControllerTest {
         DocGen_Template__c temp = [SELECT Id FROM DocGen_Template__c LIMIT 1];
 
         Test.startTest();
-        DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(temp.Id, 10, 1, true);
+        DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(temp.Id, 10, 1, true, false);
         Test.stopTest();
 
         System.assertNotEquals(null, analysis, 'Analysis should not be null');
@@ -159,7 +159,7 @@ public with sharing class DocGenBulkControllerTest {
         DocGen_Template__c temp = [SELECT Id FROM DocGen_Template__c LIMIT 1];
 
         Test.startTest();
-        DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(temp.Id, 100, 200, false);
+        DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(temp.Id, 100, 200, false, false);
         Test.stopTest();
 
         System.assertNotEquals(null, analysis, 'Analysis should not be null');
@@ -189,7 +189,7 @@ public with sharing class DocGenBulkControllerTest {
         DocGen_Template__c temp = [SELECT Id FROM DocGen_Template__c LIMIT 1];
 
         Test.startTest();
-        DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(temp.Id, 60000, 1, false);
+        DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(temp.Id, 60000, 1, false, false);
         Test.stopTest();
 
         System.assertEquals(false, analysis.canProceed, 'Should not proceed with >50k records');
@@ -200,7 +200,7 @@ public with sharing class DocGenBulkControllerTest {
         DocGen_Template__c temp = [SELECT Id FROM DocGen_Template__c LIMIT 1];
 
         Test.startTest();
-        Id jobId = DocGenBulkController.submitJob(temp.Id, 'Name != null', 'Test Job', true, 10, false, null);
+        Id jobId = DocGenBulkController.submitJob(temp.Id, 'Name != null', 'Test Job', true, 10, false, null, null);
         Test.stopTest();
 
         System.assertNotEquals(null, jobId, 'Job ID should be returned');

--- a/force-app/main/default/classes/DocGenBulkFlowAction.cls
+++ b/force-app/main/default/classes/DocGenBulkFlowAction.cls
@@ -53,6 +53,12 @@ global with sharing class DocGenBulkFlowAction { // NOPMD AvoidGlobalModifier â€
         global Boolean keepIndividualFiles;
 
         @InvocableVariable(
+            label='Duplex Padding'
+            description='Combined PDF only. Append one blank page after any document with an odd page count so every document starts on the front of a sheet when printed double-sided. Page numbers count real pages only. Ignored for Individual Files. Default: false.'
+        )
+        global Boolean duplexPadding;
+
+        @InvocableVariable(
             label='Batch Size'
             description='Records per batch transaction. Use 1 for complex templates, 10-50 for simple ones. Default: 1'
         )
@@ -116,7 +122,8 @@ global with sharing class DocGenBulkFlowAction { // NOPMD AvoidGlobalModifier â€
                     mergePdf,
                     batchSize,
                     mergeOnly,
-                    req.sortOrder
+                    req.sortOrder,
+                    req.duplexPadding
                 );
                 res.jobId = jobId;
                 res.success = true;

--- a/force-app/main/default/classes/DocGenBulkFlowActionTest.cls
+++ b/force-app/main/default/classes/DocGenBulkFlowActionTest.cls
@@ -40,6 +40,44 @@ private class DocGenBulkFlowActionTest {
     }
 
     @IsTest
+    static void duplexPaddingInputReachesTheJob() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c temp = [SELECT Id FROM DocGen_Template__c LIMIT 1];
+
+            // Combined PDF + duplex on → the flag is persisted.
+            DocGenBulkFlowAction.Request mergeReq = new DocGenBulkFlowAction.Request();
+            mergeReq.templateId = temp.Id;
+            mergeReq.queryCondition = 'Name = \'Test Account 1\'';
+            mergeReq.combinedPdfOnly = true;
+            mergeReq.duplexPadding = true;
+
+            // Individual Files only (no combined bundle) + duplex on → forced off.
+            DocGenBulkFlowAction.Request indivReq = new DocGenBulkFlowAction.Request();
+            indivReq.templateId = temp.Id;
+            indivReq.queryCondition = 'Name = \'Test Account 2\'';
+            indivReq.combinedPdfOnly = false;
+            indivReq.keepIndividualFiles = false;
+            indivReq.duplexPadding = true;
+
+            Test.startTest();
+            List<DocGenBulkFlowAction.Response> res = DocGenBulkFlowAction.generateBulkDocuments(
+                new List<DocGenBulkFlowAction.Request>{ mergeReq, indivReq }
+            );
+            Test.stopTest();
+
+            DocGen_Job__c onJob = [SELECT Duplex_Padding__c FROM DocGen_Job__c WHERE Id = :res[0].jobId];
+            DocGen_Job__c offJob = [SELECT Duplex_Padding__c FROM DocGen_Job__c WHERE Id = :res[1].jobId];
+            System.assertEquals(true, onJob.Duplex_Padding__c, 'Combined PDF job should carry the duplex flag');
+            System.assertNotEquals(
+                true,
+                offJob.Duplex_Padding__c,
+                'Individual Files job must not carry the duplex flag'
+            );
+        }
+    }
+
+    @IsTest
     static void testGenerateBulkDocumentsErrorPath() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {

--- a/force-app/main/default/classes/DocGenBulkTests.cls
+++ b/force-app/main/default/classes/DocGenBulkTests.cls
@@ -67,8 +67,8 @@ private class DocGenBulkTests {
             DocGen_Template__c t = makeTypedTemplate('Excel');
 
             Test.startTest();
-            DocGenBulkController.JobAnalysis merged = DocGenBulkController.analyzeJob(t.Id, 10, 1, true);
-            DocGenBulkController.JobAnalysis individual = DocGenBulkController.analyzeJob(t.Id, 10, 1, false);
+            DocGenBulkController.JobAnalysis merged = DocGenBulkController.analyzeJob(t.Id, 10, 1, true, false);
+            DocGenBulkController.JobAnalysis individual = DocGenBulkController.analyzeJob(t.Id, 10, 1, false, false);
             Test.stopTest();
 
             System.assertEquals(false, merged.canProceed, 'Excel + combined PDF is a genuine hard blocker');
@@ -380,6 +380,7 @@ private class DocGenBulkTests {
                 false,
                 1,
                 false,
+                null,
                 null
             );
             Test.stopTest();
@@ -405,6 +406,7 @@ private class DocGenBulkTests {
                 false,
                 1,
                 false,
+                null,
                 null
             );
             Test.stopTest();
@@ -449,7 +451,7 @@ private class DocGenBulkTests {
         System.runAs(u) {
             DocGen_Template__c t = prepareAcroFormBulkTemplate();
 
-            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(t.Id, 1, 1, true);
+            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(t.Id, 1, 1, true, false);
             System.assertEquals(false, analysis.canProceed, 'Analyzer should block merged bulk AcroForm output.');
 
             Boolean sawFormatError = false;
@@ -468,6 +470,7 @@ private class DocGenBulkTests {
                     true,
                     1,
                     false,
+                    null,
                     null
                 );
                 System.assert(false, 'Merged AcroForm bulk jobs should be rejected before the batch queues.');
@@ -1241,6 +1244,7 @@ private class DocGenBulkTests {
                 true,
                 1,
                 false,
+                null,
                 null
             );
             Test.stopTest();
@@ -1382,6 +1386,7 @@ private class DocGenBulkTests {
                 true,
                 1,
                 false,
+                null,
                 null
             );
             Test.stopTest();
@@ -1424,6 +1429,7 @@ private class DocGenBulkTests {
                 false,
                 1,
                 true,
+                null,
                 null
             );
             Test.stopTest();
@@ -1456,6 +1462,7 @@ private class DocGenBulkTests {
                 false,
                 50,
                 false,
+                null,
                 null
             );
             Test.stopTest();
@@ -1479,7 +1486,7 @@ private class DocGenBulkTests {
 
             Test.startTest();
             // null batchSize should default to 1
-            Id jobId = DocGenBulkController.submitJob(t.Id, null, null, false, null, false, null);
+            Id jobId = DocGenBulkController.submitJob(t.Id, null, null, false, null, false, null, null);
             Test.stopTest();
 
             DocGen_Job__c job = [SELECT Id, Status__c FROM DocGen_Job__c WHERE Id = :jobId];
@@ -1740,6 +1747,7 @@ private class DocGenBulkTests {
                 false,
                 1,
                 true,
+                null,
                 null
             );
             Test.stopTest();
@@ -1761,7 +1769,7 @@ private class DocGenBulkTests {
             DocGen_Template__c t = TestDataFactory.getTestTemplate();
 
             Test.startTest();
-            Id jobId = DocGenBulkController.submitJob(t.Id, null, null, false, null, false, null);
+            Id jobId = DocGenBulkController.submitJob(t.Id, null, null, false, null, false, null, null);
             Test.stopTest();
 
             DocGen_Job__c job = [SELECT Id, Status__c FROM DocGen_Job__c WHERE Id = :jobId];
@@ -1983,7 +1991,7 @@ private class DocGenBulkTests {
             DocGen_Template__c t = TestDataFactory.getTestTemplate();
 
             Test.startTest();
-            Id jobId = DocGenBulkController.submitJob(t.Id, null, 'My Custom Label', false, 5, false, null);
+            Id jobId = DocGenBulkController.submitJob(t.Id, null, 'My Custom Label', false, 5, false, null, null);
             Test.stopTest();
 
             DocGen_Job__c job = [SELECT Label__c FROM DocGen_Job__c WHERE Id = :jobId];
@@ -2002,7 +2010,7 @@ private class DocGenBulkTests {
             DocGen_Template__c t = TestDataFactory.getTestTemplate();
 
             Test.startTest();
-            Id jobId = DocGenBulkController.submitJob(t.Id, null, '', false, 1, false, null);
+            Id jobId = DocGenBulkController.submitJob(t.Id, null, '', false, 1, false, null, null);
             Test.stopTest();
 
             DocGen_Job__c job = [SELECT Label__c FROM DocGen_Job__c WHERE Id = :jobId];
@@ -2218,7 +2226,7 @@ private class DocGenBulkTests {
             Test.startTest();
             // startTest/stopTest runs the batch, so this also proves DocGenBatch
             // .start() builds a QueryLocator the platform accepts with the clause on it.
-            Id jobId = DocGenBulkController.submitJob(t.Id, null, 'Sorted Job', false, 1, false, 'name desc');
+            Id jobId = DocGenBulkController.submitJob(t.Id, null, 'Sorted Job', false, 1, false, 'name desc', null);
             Test.stopTest();
 
             DocGen_Job__c job = [SELECT Sort_Order__c, Status__c FROM DocGen_Job__c WHERE Id = :jobId];
@@ -2239,7 +2247,7 @@ private class DocGenBulkTests {
             Boolean caught = false;
             Test.startTest();
             try {
-                DocGenBulkController.submitJob(t.Id, null, 'Bad Sort', false, 1, false, 'Bogus__c ASC');
+                DocGenBulkController.submitJob(t.Id, null, 'Bad Sort', false, 1, false, 'Bogus__c ASC', null);
             } catch (AuraHandledException e) {
                 caught = true;
             }
@@ -2260,7 +2268,7 @@ private class DocGenBulkTests {
             DocGen_Template__c t = TestDataFactory.getTestTemplate();
 
             Test.startTest();
-            Id jobId = DocGenBulkController.submitJob(t.Id, null, 'Unsorted Job', false, 1, false, null);
+            Id jobId = DocGenBulkController.submitJob(t.Id, null, 'Unsorted Job', false, 1, false, null, null);
             Test.stopTest();
 
             DocGen_Job__c job = [SELECT Sort_Order__c FROM DocGen_Job__c WHERE Id = :jobId];

--- a/force-app/main/default/classes/DocGenChartCvReaper.cls
+++ b/force-app/main/default/classes/DocGenChartCvReaper.cls
@@ -1,25 +1,29 @@
 /**
- * Deletes orphaned transient chart ContentVersions.
+ * Deletes orphaned transient bulk-generation ContentVersions.
  *
- * Chart rasterization uploads one `docgen_chart_*` ContentVersion per chart as a
- * render input, and the CALLER owns cleanup. The interactive runner reaps its own
- * in a finally; so does DocGenBatch. But a caller that dies mid-flow — an uncaught
- * limit exception, a killed batch, a browser tab closed between upload and
- * generate — leaves its CVs behind with nothing watching them.
+ * Two transient CV families are created as render inputs and the CALLER owns cleanup:
+ *   docgen_chart_*    — one per chart, from rasterization; life = one transaction
+ *   docgen_pdfpart_*  — one per record, from the duplex-padding merge (#382);
+ *                       life = the batch run + the chained DocGenMergeJob
+ * The runner and DocGenBatch/DocGenMergeJob reap their own on the happy path. A
+ * caller that dies mid-flow — an uncatchable heap/CPU limit in the merge job, a
+ * killed batch, a browser tab closed — leaves them behind with nothing watching.
  *
- * That was tolerable while the only producer was a human clicking Generate. Once
- * bulk generation rasterizes per record, the failure mode scales with the job:
- * N records x M charts of orphaned files. This is the backstop.
+ * Once bulk generation produces these per record, the failure mode scales with
+ * the job: a failed 500-record duplex merge leaves 500 part CVs. This is the
+ * backstop.
  *
- * Only reaps CVs older than the age threshold, so it can never delete one that a
- * render is actively using — a chart CV's useful life is a single transaction.
+ * Two guards keep it from ever deleting a live render input:
+ *   - Chart CVs: age only. An hour is far beyond any single-transaction render.
+ *   - PDF parts (docgen_pdfpart_<jobId>_<seq>): age AND job state. A large bulk
+ *     job's batch + merge can legitimately run past the hour, so a part is only
+ *     reaped once its DocGen_Job__c has reached a terminal state (or is gone) —
+ *     never while the job is still Processing/Merging.
  *
  * Schedule hourly:
  *   System.schedule('DocGen Chart CV Reaper', '0 0 * * * ?', new DocGenChartCvReaper());
  */
 global with sharing class DocGenChartCvReaper implements Schedulable { // NOPMD AvoidGlobalModifier — global so subscribers can schedule it in a managed package
-    private static final String CV_TITLE_PREFIX = 'docgen_chart_';
-
     // Chart CVs live for one transaction. An hour is far beyond any legitimate
     // render, including a batch chunk running at the async CPU ceiling, while
     // still keeping orphans short-lived.
@@ -41,7 +45,8 @@ global with sharing class DocGenChartCvReaper implements Schedulable { // NOPMD 
      */
     global static Integer reap() {
         DateTime cutoff = System.now().addMinutes(-ORPHAN_AGE_MINUTES);
-        String titlePattern = CV_TITLE_PREFIX + '%';
+        String chartLike = 'docgen_chart_%';
+        String partLike = 'docgen_pdfpart_%';
 
         // SYSTEM_MODE: these are package-internal render artifacts whose
         // ContentDocumentLinks default to Visibility=InternalUsers, which USER_MODE
@@ -50,9 +55,9 @@ global with sharing class DocGenChartCvReaper implements Schedulable { // NOPMD 
         DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title', 'ContentDocumentId' });
         /* code-analyzer-suppress ApexFlsViolation */
         List<ContentVersion> orphans = [
-            SELECT ContentDocumentId
+            SELECT Title, ContentDocumentId
             FROM ContentVersion
-            WHERE Title LIKE :titlePattern AND CreatedDate < :cutoff AND IsLatest = TRUE
+            WHERE (Title LIKE :chartLike OR Title LIKE :partLike) AND CreatedDate < :cutoff AND IsLatest = TRUE
             WITH SYSTEM_MODE
             LIMIT :MAX_PER_RUN
         ];
@@ -60,10 +65,40 @@ global with sharing class DocGenChartCvReaper implements Schedulable { // NOPMD 
             return 0;
         }
 
+        // docgen_pdfpart_<jobId>_<seq> parts belong to a specific bulk job whose
+        // batch + chained merge job can run longer than ORPHAN_AGE_MINUTES. Never
+        // reap a part while its job is still in flight, no matter how old — only
+        // once the job is terminal or gone. Chart CVs carry no job id and stay on
+        // the pure age rule.
+        Set<Id> partJobIds = new Set<Id>();
+        for (ContentVersion cv : orphans) {
+            Id jobId = parseJobId(cv.Title);
+            if (jobId != null) {
+                partJobIds.add(jobId);
+            }
+        }
+        Set<Id> liveJobIds = new Set<Id>();
+        if (!partJobIds.isEmpty()) {
+            DocGenFlsGuard.assertAccessible(DocGen_Job__c.sObjectType, new Set<String>{ 'Status__c' });
+            /* code-analyzer-suppress ApexFlsViolation */
+            for (DocGen_Job__c j : [
+                SELECT Id
+                FROM DocGen_Job__c
+                WHERE Id IN :partJobIds AND Status__c NOT IN ('Completed', 'Completed with Errors', 'Failed')
+                WITH SYSTEM_MODE
+            ]) {
+                liveJobIds.add(j.Id);
+            }
+        }
+
         // Delete the ContentDocument, not the ContentVersion — deleting the version
         // of a single-version document is not permitted.
         Set<Id> docIds = new Set<Id>();
         for (ContentVersion cv : orphans) {
+            Id jobId = parseJobId(cv.Title);
+            if (jobId != null && liveJobIds.contains(jobId)) {
+                continue; // job still running — its parts are not orphans yet
+            }
             if (cv.ContentDocumentId != null) {
                 docIds.add(cv.ContentDocumentId);
             }
@@ -80,5 +115,29 @@ global with sharing class DocGenChartCvReaper implements Schedulable { // NOPMD 
         // transaction, already reaped concurrently) must not block the rest.
         Database.delete(docs, false, AccessLevel.SYSTEM_MODE); // NOPMD ApexCRUDViolation — package-internal transient render artifacts
         return docs.size();
+    }
+
+    /**
+     * Pulls the DocGen_Job__c id out of a `docgen_pdfpart_<jobId>_<seq>` title.
+     * Returns null for any other title shape (chart CVs, malformed names) so the
+     * caller falls back to the pure age rule for those.
+     */
+    @TestVisible
+    private static Id parseJobId(String title) {
+        if (String.isBlank(title) || !title.startsWith('docgen_pdfpart_')) {
+            return null;
+        }
+        String rest = title.substring('docgen_pdfpart_'.length());
+        Integer lastUnderscore = rest.lastIndexOf('_');
+        if (lastUnderscore <= 0) {
+            return null;
+        }
+        String candidate = rest.substring(0, lastUnderscore);
+        try {
+            Id parsed = Id.valueOf(candidate);
+            return (parsed.getSObjectType() == DocGen_Job__c.sObjectType) ? parsed : null;
+        } catch (Exception ignored) {
+            return null;
+        }
     }
 }

--- a/force-app/main/default/classes/DocGenChartCvReaperTest.cls
+++ b/force-app/main/default/classes/DocGenChartCvReaperTest.cls
@@ -3,7 +3,7 @@
 private class DocGenChartCvReaperTest {
     @TestSetup
     static void setup() {
-        TestDataFactory.assignAdminPermissionSet();
+        TestDataFactory.createStandardTestData();
     }
 
     private static ContentVersion makeChartCv(String suffix) {
@@ -55,6 +55,67 @@ private class DocGenChartCvReaperTest {
             [SELECT COUNT() FROM ContentVersion WHERE Title = 'CustomerContract'],
             'A file without the docgen_chart_ prefix must never be reaped'
         );
+    }
+
+    private static ContentVersion makeAgedCv(String title) {
+        ContentVersion cv = new ContentVersion(
+            Title = title,
+            PathOnClient = title + '.pdf',
+            VersionData = Blob.valueOf('fake-pdf-bytes')
+        );
+        Database.insert(cv, AccessLevel.SYSTEM_MODE);
+        // The reaper's age filter is on ContentVersion.CreatedDate; the parent
+        // ContentDocument is only ever deleted by id, never date-filtered.
+        Test.setCreatedDate(cv.Id, System.now().addMinutes(-120));
+        return cv;
+    }
+
+    @IsTest
+    static void oldPdfPartOfTerminalJobIsReaped() {
+        DocGen_Job__c job = TestDataFactory.createTestJob();
+        job.Status__c = 'Completed';
+        Database.update(job, AccessLevel.SYSTEM_MODE);
+        makeAgedCv('docgen_pdfpart_' + job.Id + '_00000');
+
+        Test.startTest();
+        Integer reaped = DocGenChartCvReaper.reap();
+        Test.stopTest();
+
+        System.assertEquals(1, reaped, 'A stale part whose job has finished is an orphan and must be reaped');
+        System.assertEquals(
+            0,
+            [SELECT COUNT() FROM ContentVersion WHERE Title LIKE 'docgen_pdfpart_%'],
+            'The orphaned part should be gone'
+        );
+    }
+
+    @IsTest
+    static void oldPdfPartOfRunningJobIsLeftAlone() {
+        DocGen_Job__c job = TestDataFactory.createTestJob();
+        job.Status__c = 'Processing';
+        Database.update(job, AccessLevel.SYSTEM_MODE);
+        // Old enough to pass the age filter, but the job is still running — a large
+        // bulk job's batch + merge can legitimately outlast ORPHAN_AGE_MINUTES.
+        makeAgedCv('docgen_pdfpart_' + job.Id + '_00000');
+
+        Test.startTest();
+        Integer reaped = DocGenChartCvReaper.reap();
+        Test.stopTest();
+
+        System.assertEquals(0, reaped, 'A part whose job is still Processing must never be reaped');
+        System.assertEquals(
+            1,
+            [SELECT COUNT() FROM ContentVersion WHERE Title LIKE 'docgen_pdfpart_%'],
+            'The in-flight part should survive'
+        );
+    }
+
+    @IsTest
+    static void parseJobIdRejectsNonPartTitles() {
+        System.assertEquals(null, DocGenChartCvReaper.parseJobId('docgen_chart_001abc_deadbeef'));
+        System.assertEquals(null, DocGenChartCvReaper.parseJobId('CustomerContract'));
+        System.assertEquals(null, DocGenChartCvReaper.parseJobId('docgen_pdfpart_notanid_00000'));
+        System.assertEquals(null, DocGenChartCvReaper.parseJobId(null));
     }
 
     @IsTest

--- a/force-app/main/default/classes/DocGenMergeJob.cls
+++ b/force-app/main/default/classes/DocGenMergeJob.cls
@@ -28,6 +28,43 @@ public with sharing class DocGenMergeJob implements Queueable {
     public void execute(QueueableContext ctx) {
         System.attachFinalizer(new DocGenMergeJobFinalizer(this.jobId));
         try {
+            // Get job + template details (template type drives the merge strategy)
+            // v2.0.1 — per-field FLS enforcement on SOQL reads (see DocGenFlsGuard).
+            DocGenFlsGuard.assertAccessible(
+                DocGen_Job__c.sObjectType,
+                new Set<String>{
+                    'Label__c',
+                    'Name',
+                    'Success_Count__c',
+                    'Total_Records__c',
+                    'Template__c',
+                    'Duplex_Padding__c'
+                }
+            );
+            DocGen_Job__c job = [
+                SELECT
+                    Label__c,
+                    Name,
+                    CreatedById,
+                    Success_Count__c,
+                    Total_Records__c,
+                    Duplex_Padding__c,
+                    Template__r.Type__c
+                FROM DocGen_Job__c
+                WHERE Id = :jobId
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+
+            // Duplex padding (#382): the batch saved a PDF per record, not HTML
+            // snippets. Stitch them in Apex with DocGenPdfMerger, padding any
+            // odd-length document with a blank page. Falls through to the
+            // historical HTML-concatenation merge for every non-duplex job.
+            if (job.Duplex_Padding__c == true) {
+                mergeDuplexParts(job);
+                return;
+            }
+
             // Read all HTML snippets in order
             String prefix = 'docgen_merge_' + jobId + '_';
             List<ContentVersion> snippets = [
@@ -43,19 +80,6 @@ public with sharing class DocGenMergeJob implements Queueable {
                 return;
             }
 
-            // Get job + template details (template type drives the merge strategy)
-            // v2.0.1 — per-field FLS enforcement on SOQL reads (see DocGenFlsGuard).
-            DocGenFlsGuard.assertAccessible(
-                DocGen_Job__c.sObjectType,
-                new Set<String>{ 'Label__c', 'Name', 'Success_Count__c', 'Total_Records__c', 'Template__c' }
-            );
-            DocGen_Job__c job = [
-                SELECT Label__c, Name, CreatedById, Success_Count__c, Total_Records__c, Template__r.Type__c
-                FROM DocGen_Job__c
-                WHERE Id = :jobId
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ];
             Boolean isHtmlTemplate = job.Template__r != null && DocGenService.isHtmlBacked(job.Template__r.Type__c);
 
             // Concatenate snippets. For DOCX-source snippets, naive concat of
@@ -142,6 +166,77 @@ public with sharing class DocGenMergeJob implements Queueable {
         }
     }
 
+    /**
+     * Duplex-padding merge (#382). Reads the per-record PDF parts saved by
+     * DocGenBatch, hands them to DocGenPdfMerger with the job's padding mode, and
+     * saves the result as Merged_PDF_CV__c — same delivery as the HTML path.
+     */
+    private void mergeDuplexParts(DocGen_Job__c job) {
+        // IDs only — never `SELECT VersionData` for every part at once: the LOB
+        // query itself heap-crashes past ~400 parts. DocGenPdfMerger loads each
+        // blob by Id inside its streaming loop and releases it (#382).
+        List<ContentVersion> parts = [
+            SELECT Id, ContentDocumentId
+            FROM ContentVersion
+            WHERE Title LIKE :('docgen_pdfpart_' + jobId + '_%')
+            WITH USER_MODE
+            ORDER BY Title
+        ];
+        if (parts.isEmpty()) {
+            update new DocGen_Job__c(Id = jobId, Status__c = 'Completed'); // NOPMD ApexCRUDViolation — package-internal; CRUD controlled by permission sets
+            return;
+        }
+
+        List<Id> partIds = new List<Id>();
+        Set<Id> docIdsToDelete = new Set<Id>();
+        for (ContentVersion cv : parts) {
+            partIds.add(cv.Id);
+            docIdsToDelete.add(cv.ContentDocumentId);
+        }
+        Integer partCount = parts.size();
+        parts = null;
+
+        // Sweep any HTML snippets too, in case a job predates the DocGenBatch
+        // guard that stops "Combined + Individual" writing them under duplex.
+        for (ContentVersion snip : [
+            SELECT ContentDocumentId
+            FROM ContentVersion
+            WHERE Title LIKE :('docgen_merge_' + jobId + '_%')
+            WITH USER_MODE
+        ]) {
+            docIdsToDelete.add(snip.ContentDocumentId);
+        }
+
+        Blob merged = DocGenPdfMerger.mergePdfCvs(partIds, true);
+
+        String fileName = String.isNotBlank(job.Label__c) ? job.Label__c : 'Bulk Generation ' + job.Name;
+        ContentVersion pdfCv = new ContentVersion(
+            Title = fileName,
+            PathOnClient = fileName + '.pdf',
+            VersionData = merged,
+            IsMajorVersion = true,
+            FirstPublishLocationId = jobId
+        );
+        SObjectAccessDecision cvDec = Security.stripInaccessible(
+            AccessType.CREATABLE,
+            new List<ContentVersion>{ pdfCv }
+        );
+        insert cvDec.getRecords(); // NOPMD ApexCRUDViolation — FLS enforced by stripInaccessible
+        pdfCv.Id = cvDec.getRecords()[0].Id;
+
+        update new DocGen_Job__c(Id = jobId, Status__c = 'Completed', Merged_PDF_CV__c = pdfCv.Id); // NOPMD ApexCRUDViolation — package-internal; CRUD controlled by permission sets
+
+        List<ContentDocument> docsToDelete = new List<ContentDocument>();
+        for (Id docId : docIdsToDelete) {
+            docsToDelete.add(new ContentDocument(Id = docId));
+        }
+        if (Schema.sObjectType.ContentDocument.isDeletable()) {
+            delete docsToDelete; // NOPMD ApexCRUDViolation — CRUD checked above
+        }
+
+        sendCompletionNotification(job, fileName, partCount);
+    }
+
     private void sendCompletionNotification(DocGen_Job__c job, String fileName, Integer pageCount) {
         try {
             // Look up the custom notification type
@@ -179,13 +274,37 @@ public with sharing class DocGenMergeJob implements Queueable {
             this.jobId = jobId;
         }
         public void execute(FinalizerContext ctx) {
-            if (ctx.getResult() == ParentJobResult.UNHANDLED_EXCEPTION) {
-                try {
-                    update new DocGen_Job__c(Id = jobId, Status__c = 'Failed'); // NOPMD ApexCRUDViolation — package-internal; CRUD controlled by permission sets
-                } catch (Exception e) {
-                    // Intentionally swallowed — best-effort; job record may not exist
-                    String noop = e.getMessage(); // NOPMD UnusedLocalVariable — satisfies EmptyCatchBlock rule
+            if (ctx.getResult() != ParentJobResult.UNHANDLED_EXCEPTION) {
+                return;
+            }
+            // Heap / CPU LimitExceptions during the merge are uncatchable, so the
+            // job's own try/catch never runs — the reason only lands here. Surface
+            // it on Error_Log__c instead of leaving a bare "Failed" (#382).
+            String reason = '';
+            try {
+                Exception e = ctx.getException();
+                String m = (e == null) ? '' : String.valueOf(e.getMessage());
+                if (m.containsIgnoreCase('heap') || m.containsIgnoreCase('CPU') || m.containsIgnoreCase('SOQL')) {
+                    reason =
+                        'The combined PDF was too large to assemble in one job. ' +
+                        'Run this as Individual Files, or split it with a tighter filter. (' +
+                        m.abbreviate(120) +
+                        ')';
+                } else if (String.isNotBlank(m)) {
+                    reason = 'Merge failed: ' + m.abbreviate(180);
                 }
+            } catch (Exception ignored) {
+                reason = '';
+            }
+            try {
+                DocGen_Job__c u = new DocGen_Job__c(Id = jobId, Status__c = 'Failed');
+                if (String.isNotBlank(reason)) {
+                    u.Error_Log__c = reason;
+                }
+                update u; // NOPMD ApexCRUDViolation — package-internal; CRUD controlled by permission sets
+            } catch (Exception e) {
+                // Intentionally swallowed — best-effort; job record may not exist
+                String noop = e.getMessage(); // NOPMD UnusedLocalVariable — satisfies EmptyCatchBlock rule
             }
         }
     }

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -8393,7 +8393,7 @@ private class DocGenMiscTests {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
             Test.startTest();
-            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(null, 0, 1, false);
+            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(null, 0, 1, false, false);
             Test.stopTest();
 
             System.assertNotEquals(null, analysis, 'Should return an analysis even with null template');
@@ -8408,7 +8408,7 @@ private class DocGenMiscTests {
             DocGen_Template__c tpl = TestDataFactory.getTestTemplate();
 
             Test.startTest();
-            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, 0, 1, false);
+            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, 0, 1, false, false);
             Test.stopTest();
 
             System.assertEquals('No records to process.', analysis.summary, 'Should report no records for zero count');
@@ -8422,7 +8422,7 @@ private class DocGenMiscTests {
             DocGen_Template__c tpl = TestDataFactory.getTestTemplate();
 
             Test.startTest();
-            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, -5, 1, false);
+            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, -5, 1, false, false);
             Test.stopTest();
 
             System.assertEquals(
@@ -8440,7 +8440,7 @@ private class DocGenMiscTests {
             DocGen_Template__c tpl = TestDataFactory.getTestTemplate();
 
             Test.startTest();
-            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, 60000, 1, false);
+            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, 60000, 1, false, false);
             Test.stopTest();
 
             System.assertNotEquals(null, analysis, 'Should return analysis');
@@ -8519,7 +8519,7 @@ private class DocGenMiscTests {
             insert new ContentDocumentLink(LinkedEntityId = tpl.Id, ContentDocumentId = conDocId, ShareType = 'V');
 
             Test.startTest();
-            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, 100, 5, true);
+            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, 100, 5, true, false);
             Test.stopTest();
 
             System.assertNotEquals(null, analysis, 'Should return analysis');
@@ -8541,7 +8541,7 @@ private class DocGenMiscTests {
             DocGen_Template__c tpl = TestDataFactory.getTestTemplate();
 
             Test.startTest();
-            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, 10, 1, false);
+            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, 10, 1, false, false);
             Test.stopTest();
 
             System.assertNotEquals(null, analysis, 'Should return analysis');
@@ -8582,7 +8582,7 @@ private class DocGenMiscTests {
             );
             Database.insert(tpl, AccessLevel.SYSTEM_MODE);
             Test.startTest();
-            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, 10, 1, false);
+            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, 10, 1, false, false);
             Test.stopTest();
 
             System.assertNotEquals(null, analysis, 'Should return analysis for V2 config');
@@ -8637,7 +8637,7 @@ private class DocGenMiscTests {
             );
             Database.insert(tpl, AccessLevel.SYSTEM_MODE);
             Test.startTest();
-            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, 10, 1, false);
+            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, 10, 1, false, false);
             Test.stopTest();
 
             System.assertNotEquals(null, analysis, 'Should return analysis for V3 config');
@@ -8652,7 +8652,7 @@ private class DocGenMiscTests {
 
             Test.startTest();
             // Invalid batch size (0 or negative) should default to 1
-            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, 10, 0, false);
+            DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tpl.Id, 10, 0, false, false);
             Test.stopTest();
 
             System.assertNotEquals(null, analysis, 'Should return analysis with defaulted batch size');

--- a/force-app/main/default/classes/DocGenPdfMerger.cls
+++ b/force-app/main/default/classes/DocGenPdfMerger.cls
@@ -1,0 +1,509 @@
+/**
+ * Server-side PDF merge for the bulk "Combined PDF" duplex-padding feature (#382).
+ *
+ * Concatenates several single-document PDFs into one, and — when a duplex mode is
+ * given — appends ONE completely blank page after any document with an odd page
+ * count so every document starts on the front of a sheet under double-sided
+ * printing. The blank page has no content stream, so it draws nothing and carries
+ * no page number; real pages keep the numbering baked in when each document was
+ * rendered on its own.
+ *
+ * SCOPE: this targets PDFs produced by Portwood's own renderer (Flying Saucer /
+ * iText via Blob.toPdf) — %PDF-1.4, a classic cross-reference table, a flat
+ * /Pages tree, explicit /MediaBox per page, direct /Length on streams, no
+ * encryption and no cross-reference or object streams. It is NOT a general-
+ * purpose PDF library. Arbitrary user-uploaded PDFs go through the client-side
+ * docGenPdfMerger.js instead.
+ *
+ * The byte-level string handling (hex round-trip, latin1 1:1 char/byte mapping)
+ * mirrors DocGenAcroFormService, which already does this class of work in Apex.
+ */
+global with sharing class DocGenPdfMerger {
+    global class DocGenPdfMergeException extends Exception {
+    }
+
+    // 256-entry lookup: byte value -> lowercase 2-char hex. Built once.
+    private static final List<String> HEX2;
+    static {
+        HEX2 = new List<String>();
+        String h = '0123456789abcdef';
+        for (Integer i = 0; i < 256; i++) {
+            HEX2.add(h.substring(i / 16, i / 16 + 1) + h.substring(Math.mod(i, 16), Math.mod(i, 16) + 1));
+        }
+    }
+
+    // %PDF-1.4\n%<e2 e3 cf d3>\n  — header + binary-file marker comment
+    private static final String HEADER_HEX = '255044462d312e340a25e2e3cfd30a';
+
+    private class ObjRec {
+        Integer num;
+        String dictPart; // ASCII: everything from after "N 0 obj" up to "stream" (or up to "endobj")
+        String streamHex; // hex of "stream ... endstream\n" bytes, or '' for a plain object
+        Boolean isPage = false;
+    }
+
+    private class Src {
+        Map<Integer, ObjRec> objs = new Map<Integer, ObjRec>();
+        List<Integer> pageOrder = new List<Integer>();
+        String lastMediaBox = '/MediaBox [0 0 612 792]';
+        // Object numbers of embedded font PROGRAMS (/FontFile, /FontFile2,
+        // /FontFile3 targets). These are the only streams safe to deduplicate
+        // across parts: a font subset is byte-identical for every render of the
+        // same template and is referenced by exactly one FontDescriptor. Page
+        // content streams and image XObjects are NEVER deduped — two records
+        // that render identical page text produce byte-identical content
+        // streams, and collapsing those corrupts the page tree (#382).
+        Set<Integer> fontFileObjs = new Set<Integer>();
+    }
+
+    /**
+     * @param pdfs  single-document PDFs, in final packet order
+     * @param padOddDocuments  when true, every document with an odd page count
+     *        (including the last) gets one blank page appended before the merge
+     * @return the merged PDF
+     */
+    global static Blob mergePdfs(List<Blob> pdfs, Boolean padOddDocuments) {
+        if (pdfs == null || pdfs.isEmpty()) {
+            throw new DocGenPdfMergeException('No PDFs supplied to merge.');
+        }
+        if (pdfs.size() == 1 && padOddDocuments != true) {
+            return pdfs[0];
+        }
+        return mergeCore(pdfs, null, padOddDocuments == true);
+    }
+
+    /**
+     * As mergePdfs, but the parts are ContentVersion Ids. Each blob is loaded by
+     * Id inside the merge loop and released before the next — a single
+     * `SELECT VersionData` for hundreds of parts heap-crashes the query itself.
+     * @param partCvIds  ContentVersion Ids of the single-document PDFs, in order
+     */
+    global static Blob mergePdfCvs(List<Id> partCvIds, Boolean padOddDocuments) {
+        if (partCvIds == null || partCvIds.isEmpty()) {
+            throw new DocGenPdfMergeException('No PDFs supplied to merge.');
+        }
+        return mergeCore(null, partCvIds, padOddDocuments == true);
+    }
+
+    // Load part blobs in chunks: one SELECT VersionData per part blows the async
+    // SOQL cap (200) past ~200 parts, and one SELECT for all of them blows heap.
+    private static final Integer PART_CHUNK = 40;
+
+    private static Blob mergeCore(List<Blob> blobs, List<Id> cvIds, Boolean pad) {
+        Integer partCount = (blobs != null) ? blobs.size() : cvIds.size();
+
+        // ---- parse + renumber + dedupe, ONE part at a time ----
+        //
+        // Streamed on purpose (#382): the merge runs in a Queueable (12 MB async
+        // heap). Parsing every part up front and holding them all is what
+        // heap-crashes an ~90-100 record packet. Instead each part is parsed,
+        // folded into the global object list, and released before the next.
+        //
+        // Font deduplication: every part carries its own embedded font subset
+        // (~60 KB of Arial Unicode MS), byte-identical across parts from the same
+        // template. Only embedded font PROGRAMS (Src.fontFileObjs) are
+        // fingerprinted; the first copy is kept. A dropped object's slot becomes
+        // "N 0 obj null endobj" so numbering stays contiguous, and the one
+        // FontDescriptor reference to it is repointed at the survivor. Content
+        // streams and images are deliberately left alone — see Src.fontFileObjs.
+        Integer next = 1;
+        List<ObjRec> allObjs = new List<ObjRec>();
+        Map<Integer, ObjRec> byNum = new Map<Integer, ObjRec>();
+        List<List<Integer>> docPages = new List<List<Integer>>();
+        List<String> docMediaBoxes = new List<String>();
+        Map<String, Integer> streamFingerprints = new Map<String, Integer>();
+        Map<Integer, Integer> dedupeRemap = new Map<Integer, Integer>();
+
+        for (Integer chunkStart = 0; chunkStart < partCount; chunkStart += PART_CHUNK) {
+            Integer chunkEnd = Math.min(chunkStart + PART_CHUNK, partCount);
+            List<Blob> chunkBlobs = new List<Blob>();
+            if (blobs != null) {
+                for (Integer k = chunkStart; k < chunkEnd; k++) {
+                    chunkBlobs.add(blobs[k]);
+                    blobs.set(k, null);
+                }
+            } else {
+                List<Id> ids = new List<Id>();
+                for (Integer k = chunkStart; k < chunkEnd; k++) {
+                    ids.add(cvIds[k]);
+                }
+                Map<Id, ContentVersion> loaded = new Map<Id, ContentVersion>(
+                    [SELECT VersionData FROM ContentVersion WHERE Id IN :ids WITH USER_MODE]
+                );
+                for (Id id : ids) {
+                    chunkBlobs.add(loaded.get(id).VersionData);
+                }
+            }
+
+            for (Integer ci = 0; ci < chunkBlobs.size(); ci++) {
+                Src s = parse(chunkBlobs[ci]);
+                chunkBlobs[ci] = null;
+
+                List<Integer> keys = new List<Integer>(s.objs.keySet());
+                keys.sort();
+                Map<Integer, Integer> remap = new Map<Integer, Integer>();
+                for (Integer k : keys) {
+                    remap.put(k, next++);
+                }
+                for (Integer k : keys) {
+                    ObjRec o = s.objs.get(k);
+                    Integer newNum = remap.get(k);
+                    ObjRec n = new ObjRec();
+                    n.num = newNum;
+                    n.isPage = o.isPage;
+
+                    if (String.isNotBlank(o.streamHex) && s.fontFileObjs.contains(k)) {
+                        String fp = EncodingUtil.convertToHex(
+                            Crypto.generateDigest('SHA-256', Blob.valueOf(o.dictPart + '~' + o.streamHex))
+                        );
+                        Integer canonical = streamFingerprints.get(fp);
+                        if (canonical != null) {
+                            dedupeRemap.put(newNum, canonical);
+                            n.dictPart = ' null ';
+                            n.streamHex = '';
+                            allObjs.add(n);
+                            byNum.put(newNum, n);
+                            continue;
+                        }
+                        streamFingerprints.put(fp, newNum);
+                    }
+
+                    String d = renumberRefs(o.dictPart, remap);
+                    if (!dedupeRemap.isEmpty() && d.contains(' 0 R')) {
+                        d = renumberRefs(d, dedupeRemap); // repoint refs to a dropped duplicate in this part
+                    }
+                    n.dictPart = d;
+                    n.streamHex = o.streamHex;
+                    allObjs.add(n);
+                    byNum.put(newNum, n);
+                }
+
+                List<Integer> pn = new List<Integer>();
+                for (Integer p : s.pageOrder) {
+                    pn.add(remap.get(p));
+                }
+                docPages.add(pn);
+                docMediaBoxes.add(s.lastMediaBox);
+                s = null;
+            }
+        }
+
+        Integer pagesNum = next++;
+        Integer catNum = next++;
+
+        // ---- build the padded /Kids list + blank-page objects ----
+        List<Integer> kids = new List<Integer>();
+        List<ObjRec> blanks = new List<ObjRec>();
+        for (Integer d = 0; d < docPages.size(); d++) {
+            List<Integer> pn = docPages.get(d);
+            for (Integer p : pn) {
+                ObjRec pg = byNum.get(p);
+                if (pg != null) {
+                    pg.dictPart = setParent(pg.dictPart, pagesNum);
+                }
+                kids.add(p);
+            }
+            if (pad && Math.mod(pn.size(), 2) == 1) {
+                ObjRec blank = new ObjRec();
+                blank.num = next++;
+                blank.dictPart =
+                    '\n<< /Type /Page /Parent ' +
+                    pagesNum +
+                    ' 0 R ' +
+                    docMediaBoxes.get(d) +
+                    ' /Resources << >> >>\n';
+                blank.streamHex = '';
+                blanks.add(blank);
+                kids.add(blank.num);
+            }
+        }
+
+        byNum = null;
+        docPages = null;
+
+        // ---- assemble, entirely in the hex domain ----
+        List<String> hx = new List<String>{ HEADER_HEX };
+        Integer bytePos = HEADER_HEX.length() / 2;
+        Map<Integer, Integer> offsets = new Map<Integer, Integer>();
+
+        allObjs.addAll(blanks);
+        for (Integer oi = 0; oi < allObjs.size(); oi++) {
+            ObjRec o = allObjs[oi];
+            offsets.put(o.num, bytePos);
+            String head = o.num + ' 0 obj';
+            hx.add(ah(head));
+            hx.add(ah(o.dictPart));
+            bytePos += head.length() + o.dictPart.length();
+            if (String.isNotBlank(o.streamHex)) {
+                hx.add(o.streamHex);
+                bytePos += o.streamHex.length() / 2;
+            }
+            hx.add(ah('endobj\n'));
+            bytePos += 7;
+            allObjs[oi] = null; // release each object once its bytes are emitted
+        }
+
+        offsets.put(pagesNum, bytePos);
+        String pagesObj =
+            pagesNum +
+            ' 0 obj\n<< /Type /Pages /Kids [' +
+            joinRefs(kids) +
+            '] /Count ' +
+            kids.size() +
+            ' >>\nendobj\n';
+        hx.add(ah(pagesObj));
+        bytePos += pagesObj.length();
+
+        offsets.put(catNum, bytePos);
+        String catObj = catNum + ' 0 obj\n<< /Type /Catalog /Pages ' + pagesNum + ' 0 R >>\nendobj\n';
+        hx.add(ah(catObj));
+        bytePos += catObj.length();
+
+        // ---- classic cross-reference table + trailer ----
+        Integer size = next; // objects 0 .. next-1
+        Integer xrefStart = bytePos;
+        String xref = 'xref\n0 ' + size + '\n0000000000 65535 f \n';
+        for (Integer i = 1; i < size; i++) {
+            Integer off = offsets.containsKey(i) ? offsets.get(i) : 0;
+            xref += String.valueOf(off).leftPad(10, '0') + ' 00000 n \n';
+        }
+        xref += 'trailer\n<< /Size ' + size + ' /Root ' + catNum + ' 0 R >>\nstartxref\n' + xrefStart + '\n%%EOF\n';
+        hx.add(ah(xref));
+
+        String joined = String.join(hx, '');
+        hx = null; // free the piece list before the final byte allocation
+        return EncodingUtil.convertFromHex(joined);
+    }
+
+    /** Page count of a Portwood-generated PDF, without a full merge. */
+    global static Integer pageCount(Blob pdf) {
+        return parse(pdf).pageOrder.size();
+    }
+
+    // ------------------------------------------------------------------
+    // parsing
+    // ------------------------------------------------------------------
+
+    /** Number of pages with no content stream — the blank fillers. Test hook. */
+    @TestVisible
+    private static Integer blankPageCount(Blob pdf) {
+        Src s = parse(pdf);
+        Integer n = 0;
+        for (Integer p : s.pageOrder) {
+            ObjRec o = s.objs.get(p);
+            if (o != null && !o.dictPart.contains('/Contents')) {
+                n++;
+            }
+        }
+        return n;
+    }
+
+    private static Src parse(Blob pdfBlob) {
+        String hex = EncodingUtil.convertToHex(pdfBlob).toLowerCase();
+        String s = latin1FromHex(hex);
+
+        if (!s.startsWith('%PDF-')) {
+            throw new DocGenPdfMergeException('Not a PDF file.');
+        }
+        if (s.contains('/Encrypt')) {
+            throw new DocGenPdfMergeException('Encrypted PDFs cannot be merged.');
+        }
+        if (s.contains('/ObjStm') || s.contains('/Type/XRef') || s.contains('/Type /XRef')) {
+            throw new DocGenPdfMergeException(
+                'This PDF uses compressed object/cross-reference streams and cannot be merged server-side.'
+            );
+        }
+
+        Src src = new Src();
+        Integer cursor = 0;
+        while (true) {
+            Integer ob = s.indexOf(' 0 obj', cursor);
+            if (ob == -1) {
+                break;
+            }
+            Integer ns = ob;
+            while (ns > 0 && isDigit(s.charAt(ns - 1))) {
+                ns--;
+            }
+            if (ns == ob) {
+                cursor = ob + 6;
+                continue;
+            }
+            Integer num = Integer.valueOf(s.substring(ns, ob));
+            Integer bodyStart = ob + 6;
+
+            Integer si = s.indexOf('stream', bodyStart);
+            Integer eob = s.indexOf('endobj', bodyStart);
+            if (eob == -1) {
+                break;
+            }
+
+            ObjRec o = new ObjRec();
+            o.num = num;
+            if (si != -1 && si < eob) {
+                String dict = s.substring(bodyStart, si);
+                Integer len = parseLength(dict);
+                Integer dStart = si + 6;
+                if (dStart < s.length() && s.charAt(dStart) == 13) {
+                    dStart++;
+                }
+                if (dStart < s.length() && s.charAt(dStart) == 10) {
+                    dStart++;
+                }
+                Integer dEnd = (len != null) ? dStart + len : s.indexOf('endstream', dStart);
+                Integer eo = s.indexOf('endobj', dEnd);
+                if (eo == -1) {
+                    break;
+                }
+                o.dictPart = dict;
+                o.streamHex = hex.substring(si * 2, eo * 2);
+                src.objs.put(num, o);
+                cursor = eo + 6;
+            } else {
+                o.dictPart = s.substring(bodyStart, eob);
+                o.streamHex = '';
+                src.objs.put(num, o);
+                cursor = eob + 6;
+            }
+        }
+
+        // Embedded font programs — the only streams safe to dedupe (see Src).
+        // FontDescriptor dicts reference them as /FontFile[23]? N 0 R.
+        Matcher ffm = Pattern.compile('/FontFile[23]?\\s+(\\d+)\\s+0\\s+R').matcher(s);
+        while (ffm.find()) {
+            src.fontFileObjs.add(Integer.valueOf(ffm.group(1)));
+        }
+
+        // root /Pages -> flat page order
+        Integer pagesRoot = null;
+        Matcher rm = Pattern.compile('/Root\\s+(\\d+)\\s+0\\s+R').matcher(s);
+        if (rm.find() && src.objs.containsKey(Integer.valueOf(rm.group(1)))) {
+            Matcher pm = Pattern.compile('/Pages\\s+(\\d+)\\s+0\\s+R')
+                .matcher(src.objs.get(Integer.valueOf(rm.group(1))).dictPart);
+            if (pm.find()) {
+                pagesRoot = Integer.valueOf(pm.group(1));
+            }
+        }
+        if (pagesRoot == null) {
+            for (ObjRec o : src.objs.values()) {
+                if (o.dictPart.contains('/Type/Pages') || o.dictPart.contains('/Type /Pages')) {
+                    pagesRoot = o.num;
+                    break;
+                }
+            }
+        }
+        if (pagesRoot != null) {
+            collectPages(src, pagesRoot, src.pageOrder, new Set<Integer>());
+        }
+        if (src.pageOrder.isEmpty()) {
+            throw new DocGenPdfMergeException('No pages found in PDF.');
+        }
+
+        for (Integer i = 0; i < src.pageOrder.size(); i++) {
+            ObjRec pg = src.objs.get(src.pageOrder.get(i));
+            if (pg == null) {
+                continue;
+            }
+            pg.isPage = true;
+            if (i == src.pageOrder.size() - 1) {
+                Matcher mb = Pattern.compile('/MediaBox\\s*\\[[^\\]]+\\]').matcher(pg.dictPart);
+                if (mb.find()) {
+                    src.lastMediaBox = mb.group();
+                }
+            }
+        }
+        return src;
+    }
+
+    private static void collectPages(Src src, Integer objNum, List<Integer> out, Set<Integer> seen) {
+        if (seen.contains(objNum)) {
+            return;
+        }
+        seen.add(objNum);
+        ObjRec o = src.objs.get(objNum);
+        if (o == null) {
+            return;
+        }
+        Matcher km = Pattern.compile('/Kids\\s*\\[([^\\]]*)\\]').matcher(o.dictPart);
+        if (km.find()) {
+            Matcher rr = Pattern.compile('(\\d+)\\s+0\\s+R').matcher(km.group(1));
+            while (rr.find()) {
+                collectPages(src, Integer.valueOf(rr.group(1)), out, seen);
+            }
+        } else {
+            out.add(objNum);
+        }
+    }
+
+    private static Integer parseLength(String dict) {
+        Matcher lm = Pattern.compile('/Length\\s+(\\d+)(?!\\s*\\d+\\s+R)').matcher(dict);
+        return lm.find() ? Integer.valueOf(lm.group(1)) : null;
+    }
+
+    // ------------------------------------------------------------------
+    // reference rewriting
+    // ------------------------------------------------------------------
+
+    private static String renumberRefs(String text, Map<Integer, Integer> remap) {
+        Matcher m = Pattern.compile('(\\d+)\\s+0\\s+R').matcher(text);
+        String out = '';
+        Integer last = 0;
+        while (m.find()) {
+            out += text.substring(last, m.start());
+            Integer oldNum = Integer.valueOf(m.group(1));
+            out += remap.containsKey(oldNum) ? (remap.get(oldNum) + ' 0 R') : m.group();
+            last = m.end();
+        }
+        out += text.substring(last);
+        return out;
+    }
+
+    private static String setParent(String dict, Integer pagesNum) {
+        Matcher m = Pattern.compile('/Parent\\s+\\d+\\s+0\\s+R').matcher(dict);
+        if (m.find()) {
+            return dict.substring(0, m.start()) + '/Parent ' + pagesNum + ' 0 R' + dict.substring(m.end());
+        }
+        Integer lt = dict.indexOf('<<');
+        return lt == -1 ? dict : dict.substring(0, lt + 2) + ' /Parent ' + pagesNum + ' 0 R' + dict.substring(lt + 2);
+    }
+
+    // ------------------------------------------------------------------
+    // byte / hex helpers
+    // ------------------------------------------------------------------
+
+    private static String ah(String ascii) {
+        return EncodingUtil.convertToHex(Blob.valueOf(ascii)).toLowerCase();
+    }
+
+    private static String latin1FromHex(String hex) {
+        List<String> chunks = new List<String>();
+        List<Integer> chars = new List<Integer>();
+        for (Integer i = 0; i < hex.length(); i += 2) {
+            chars.add(nib(hex.charAt(i)) * 16 + nib(hex.charAt(i + 1)));
+            if (chars.size() == 2000) {
+                chunks.add(String.fromCharArray(chars));
+                chars.clear();
+            }
+        }
+        if (!chars.isEmpty()) {
+            chunks.add(String.fromCharArray(chars));
+        }
+        return String.join(chunks, '');
+    }
+
+    private static Integer nib(Integer code) {
+        return code <= 57 ? code - 48 : (code <= 70 ? code - 55 : code - 87);
+    }
+
+    private static Boolean isDigit(Integer c) {
+        return c >= 48 && c <= 57;
+    }
+
+    private static String joinRefs(List<Integer> nums) {
+        List<String> parts = new List<String>();
+        for (Integer n : nums) {
+            parts.add(n + ' 0 R');
+        }
+        return String.join(parts, ' ');
+    }
+}

--- a/force-app/main/default/classes/DocGenPdfMerger.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenPdfMerger.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenPdfMergerTest.cls
+++ b/force-app/main/default/classes/DocGenPdfMergerTest.cls
@@ -1,0 +1,169 @@
+/**
+ * DocGenPdfMerger — merges Portwood-generated PDFs and pads odd-length documents
+ * with a blank page for duplex printing (#382).
+ *
+ * Fixtures are real Blob.toPdf() output (Flying Saucer / iText) captured from a
+ * scratch org — 1-, 2- and 3-page documents — embedded as base64 so the tests
+ * do not depend on Blob.toPdf() working in an @IsTest context.
+ */
+@IsTest
+private class DocGenPdfMergerTest {
+    // 1-page PDF
+    private static final String FX1_B64 = 'JVBERi0xLjQKJeLjz9MKMyAwIG9iaiA8PC9GaWx0ZXIvRmxhdGVEZWNvZGUvTGVuZ3RoIDEyNz4+c3RyZWFtCnicVY69CsJQFIP3PEVGXa7n/h5dBR0EwcIBB3ErKsUKdfH1vW1xkCwfCSQZsDUIdRNoLXaGBgPESdTMDwIPNezghUdcrsIWsVBzYY+sMz0nisVJqhz/cM4fOONVe0a97+Pgau8ZEu0GP7meKVCDurym9Vic/NK635sGX7T6IQMKZW5kc3RyZWFtCmVuZG9iagoxIDAgb2JqPDwvQ29udGVudHMgMyAwIFIvVHlwZS9QYWdlL1Jlc291cmNlczw8L1Byb2NTZXQgWy9QREYgL1RleHQgL0ltYWdlQiAvSW1hZ2VDIC9JbWFnZUldL0ZvbnQ8PC9GMSAyIDAgUj4+Pj4vUGFyZW50IDQgMCBSL01lZGlhQm94WzAgMCA2MTIgNzkyXT4+CmVuZG9iagoyIDAgb2JqPDwvU3VidHlwZS9UeXBlMS9UeXBlL0ZvbnQvQmFzZUZvbnQvVGltZXMtQm9sZC9FbmNvZGluZy9XaW5BbnNpRW5jb2Rpbmc+PgplbmRvYmoKNCAwIG9iajw8L0tpZHNbMSAwIFJdL1R5cGUvUGFnZXMvQ291bnQgMT4+CmVuZG9iago1IDAgb2JqPDwvVHlwZS9DYXRhbG9nL1BhZ2VzIDQgMCBSPj4KZW5kb2JqCjYgMCBvYmo8PC9Nb2REYXRlKEQ6MjAyNjA5MDgxMDM1NDZaKS9DcmVhdGlvbkRhdGUoRDoyMDI2MDkwODEwMzU0NlopL1Byb2R1Y2VyKGlUZXh0IDIuMC44IFwoYnkgbG93YWdpZS5jb21cKSk+PgplbmRvYmoKeHJlZgowIDcKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMjA5IDAwMDAwIG4gCjAwMDAwMDAzNjUgMDAwMDAgbiAKMDAwMDAwMDAxNSAwMDAwMCBuIAowMDAwMDAwNDUzIDAwMDAwIG4gCjAwMDAwMDA1MDMgMDAwMDAgbiAKMDAwMDAwMDU0NyAwMDAwMCBuIAp0cmFpbGVyCjw8L0luZm8gNiAwIFIvSUQgWzxhMmI2OWVlNGM5NTQzYmRmNTc2N2VkZjU3MTU5ZDkzNz48NzQxYmRhZGU1ZTZhOGI2MjE4NmFjMGFlZDJkZDgyMTQ+XS9Sb290IDUgMCBSL1NpemUgNz4+CnN0YXJ0eHJlZgo2NjYKJSVFT0YK';
+
+    // 2-page PDF
+    private static final String FX2_B64 = 'JVBERi0xLjQKJeLjz9MKMyAwIG9iaiA8PC9GaWx0ZXIvRmxhdGVEZWNvZGUvTGVuZ3RoIDEyOD4+c3RyZWFtCnicVY69CsJQFIP3PEVGXa7n/h4dFXQQHAoHHMStqBQr1MXX97bFQbJ8JJBkwM4g1E2gtdgbGgwQJ1EzPwg81rCDF55wuQpbxELNhT2yzvScKBYnqXL8wzl/4IxX7Rn1vo+Dq4NnSLQb/OR6pkAN6vKa1mOx9Uvrfm8afAG0GSD0CmVuZHN0cmVhbQplbmRvYmoKMSAwIG9iajw8L0NvbnRlbnRzIDMgMCBSL1R5cGUvUGFnZS9SZXNvdXJjZXM8PC9Qcm9jU2V0IFsvUERGIC9UZXh0IC9JbWFnZUIgL0ltYWdlQyAvSW1hZ2VJXS9Gb250PDwvRjEgMiAwIFI+Pj4+L1BhcmVudCA0IDAgUi9NZWRpYUJveFswIDAgNjEyIDc5Ml0+PgplbmRvYmoKNSAwIG9iaiA8PC9GaWx0ZXIvRmxhdGVEZWNvZGUvTGVuZ3RoIDEyNz4+c3RyZWFtCnicVY69CsJQFIP3PEVGXa7n/h46KuggOBQOOIhbUSlWqIuv722Lg2T5SCDJiJ1BqE2gddgbWowQJ1EzPwg81rCHF55wuQo7xELNhQOyLvScKRYnqXL8wyV/4IxX7Zn0vk+Dm4NnSLQb/Ox6pkD16lJDG7DahrX1vzctvrQNIPQKZW5kc3RyZWFtCmVuZG9iago2IDAgb2JqPDwvQ29udGVudHMgNSAwIFIvVHlwZS9QYWdlL1Jlc291cmNlczw8L1Byb2NTZXQgWy9QREYgL1RleHQgL0ltYWdlQiAvSW1hZ2VDIC9JbWFnZUldL0ZvbnQ8PC9GMSAyIDAgUj4+Pj4vUGFyZW50IDQgMCBSL01lZGlhQm94WzAgMCA2MTIgNzkyXT4+CmVuZG9iagoyIDAgb2JqPDwvU3VidHlwZS9UeXBlMS9UeXBlL0ZvbnQvQmFzZUZvbnQvVGltZXMtQm9sZC9FbmNvZGluZy9XaW5BbnNpRW5jb2Rpbmc+PgplbmRvYmoKNCAwIG9iajw8L0tpZHNbMSAwIFIgNiAwIFJdL1R5cGUvUGFnZXMvQ291bnQgMj4+CmVuZG9iago3IDAgb2JqPDwvVHlwZS9DYXRhbG9nL1BhZ2VzIDQgMCBSPj4KZW5kb2JqCjggMCBvYmo8PC9Nb2REYXRlKEQ6MjAyNjA5MDgxMDM1NDZaKS9DcmVhdGlvbkRhdGUoRDoyMDI2MDkwODEwMzU0NlopL1Byb2R1Y2VyKGlUZXh0IDIuMC44IFwoYnkgbG93YWdpZS5jb21cKSk+PgplbmRvYmoKeHJlZgowIDkKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMjEwIDAwMDAwIG4gCjAwMDAwMDA3MTYgMDAwMDAgbiAKMDAwMDAwMDAxNSAwMDAwMCBuIAowMDAwMDAwODA0IDAwMDAwIG4gCjAwMDAwMDAzNjYgMDAwMDAgbiAKMDAwMDAwMDU2MCAwMDAwMCBuIAowMDAwMDAwODYwIDAwMDAwIG4gCjAwMDAwMDA5MDQgMDAwMDAgbiAKdHJhaWxlcgo8PC9JbmZvIDggMCBSL0lEIFs8ZWFlMTE4ZjJjNDljMmNmMmI3YWFhYWZkYmYyNWQxMWM+PDJmYzhlZjI4NmQwNTA5NjdiZjA4NDYwNWJhN2Q4N2EwPl0vUm9vdCA3IDAgUi9TaXplIDk+PgpzdGFydHhyZWYKMTAyMwolJUVPRgo=';
+
+    // 3-page PDF
+    private static final String FX3_B64 = 'JVBERi0xLjQKJeLjz9MKMyAwIG9iaiA8PC9GaWx0ZXIvRmxhdGVEZWNvZGUvTGVuZ3RoIDEyNz4+c3RyZWFtCnicVY69CsJQFIP3PEVGXa7n/h5dCzoIDoUDDuJWVIoV6uLre9viIFk+EkgyojEIdRdoHfaGFiPESdTMDwKPNezhhSdcrsIOsVBz4YCsCz1nisVJqhz/cMkfOONVeya979Pg5uAZEu0GP7ueKVCDurylDVg1fm39702LL7QoIPUKZW5kc3RyZWFtCmVuZG9iagoxIDAgb2JqPDwvQ29udGVudHMgMyAwIFIvVHlwZS9QYWdlL1Jlc291cmNlczw8L1Byb2NTZXQgWy9QREYgL1RleHQgL0ltYWdlQiAvSW1hZ2VDIC9JbWFnZUldL0ZvbnQ8PC9GMSAyIDAgUj4+Pj4vUGFyZW50IDQgMCBSL01lZGlhQm94WzAgMCA2MTIgNzkyXT4+CmVuZG9iago1IDAgb2JqIDw8L0ZpbHRlci9GbGF0ZURlY29kZS9MZW5ndGggMTI3Pj5zdHJlYW0KeJxVjr0KwlAUg/c8RUZdruf+HroWdBAcCgccxK2oFCvUxdf3tsVBsnwkkGRCaxBqE2g99oYOE8RJ1MwPAo81HOCFJ1yuwh6xUHPhiKwrPReKxUmqHP9wzR8441V7Zr3v8+Du4BkS7Qa/uJ4pUL261NBGbNqwteH3psMXtBwg9QplbmRzdHJlYW0KZW5kb2JqCjYgMCBvYmo8PC9Db250ZW50cyA1IDAgUi9UeXBlL1BhZ2UvUmVzb3VyY2VzPDwvUHJvY1NldCBbL1BERiAvVGV4dCAvSW1hZ2VCIC9JbWFnZUMgL0ltYWdlSV0vRm9udDw8L0YxIDIgMCBSPj4+Pi9QYXJlbnQgNCAwIFIvTWVkaWFCb3hbMCAwIDYxMiA3OTJdPj4KZW5kb2JqCjcgMCBvYmogPDwvRmlsdGVyL0ZsYXRlRGVjb2RlL0xlbmd0aCAxMjc+PnN0cmVhbQp4nFWOvQrCUBSD9zxFRl2u5/4euhZ0EBwKBxzEragUK9TF1/e2xUGyfCSQZEJrEGoTaD32hg4TxEnUzA8CjzUc4IUnXK7CHrFQc+GIrCs9F4rFSaoc/3DNHzjjVXtmve/z4O7gGRLtBr+4nilQvbrU0EZs2ri14femwxe0KiD2CmVuZHN0cmVhbQplbmRvYmoKOCAwIG9iajw8L0NvbnRlbnRzIDcgMCBSL1R5cGUvUGFnZS9SZXNvdXJjZXM8PC9Qcm9jU2V0IFsvUERGIC9UZXh0IC9JbWFnZUIgL0ltYWdlQyAvSW1hZ2VJXS9Gb250PDwvRjEgMiAwIFI+Pj4+L1BhcmVudCA0IDAgUi9NZWRpYUJveFswIDAgNjEyIDc5Ml0+PgplbmRvYmoKMiAwIG9iajw8L1N1YnR5cGUvVHlwZTEvVHlwZS9Gb250L0Jhc2VGb250L1RpbWVzLUJvbGQvRW5jb2RpbmcvV2luQW5zaUVuY29kaW5nPj4KZW5kb2JqCjQgMCBvYmo8PC9LaWRzWzEgMCBSIDYgMCBSIDggMCBSXS9UeXBlL1BhZ2VzL0NvdW50IDM+PgplbmRvYmoKOSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyA0IDAgUj4+CmVuZG9iagoxMCAwIG9iajw8L01vZERhdGUoRDoyMDI2MDkwODEwMzU0NlopL0NyZWF0aW9uRGF0ZShEOjIwMjYwOTA4MTAzNTQ2WikvUHJvZHVjZXIoaVRleHQgMi4wLjggXChieSBsb3dhZ2llLmNvbVwpKT4+CmVuZG9iagp4cmVmCjAgMTEKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMjA5IDAwMDAwIG4gCjAwMDAwMDEwNjUgMDAwMDAgbiAKMDAwMDAwMDAxNSAwMDAwMCBuIAowMDAwMDAxMTUzIDAwMDAwIG4gCjAwMDAwMDAzNjUgMDAwMDAgbiAKMDAwMDAwMDU1OSAwMDAwMCBuIAowMDAwMDAwNzE1IDAwMDAwIG4gCjAwMDAwMDA5MDkgMDAwMDAgbiAKMDAwMDAwMTIxNSAwMDAwMCBuIAowMDAwMDAxMjU5IDAwMDAwIG4gCnRyYWlsZXIKPDwvSW5mbyAxMCAwIFIvSUQgWzw2ZDIzMTQ1MmMyYWRjNWJlMTJjMWJlOTVmM2JkZWZlMD48YWQwNDBmOWQ4YTQ2MjczOGVlZmY3MTZkNjRjZGJhNGY+XS9Sb290IDkgMCBSL1NpemUgMTE+PgpzdGFydHhyZWYKMTM3OQolJUVPRgo=';
+
+    private static Blob fx(String b64) {
+        return EncodingUtil.base64Decode(b64);
+    }
+
+    @IsTest
+    static void pageCountReadsEachDocument() {
+        Test.startTest();
+        System.assertEquals(1, DocGenPdfMerger.pageCount(fx(FX1_B64)), '1-page fixture');
+        System.assertEquals(2, DocGenPdfMerger.pageCount(fx(FX2_B64)), '2-page fixture');
+        System.assertEquals(3, DocGenPdfMerger.pageCount(fx(FX3_B64)), '3-page fixture');
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void padFalseConcatenatesWithNoPadding() {
+        Test.startTest();
+        Blob merged = DocGenPdfMerger.mergePdfs(new List<Blob>{ fx(FX2_B64), fx(FX3_B64), fx(FX2_B64) }, false);
+        Test.stopTest();
+        System.assertEquals(7, DocGenPdfMerger.pageCount(merged), '2 + 3 + 2, no blanks');
+        System.assertEquals(0, DocGenPdfMerger.blankPageCount(merged), 'padding off adds no blank pages');
+    }
+
+    @IsTest
+    static void padTrueAddsOneBlankToEveryOddDocument() {
+        Test.startTest();
+        // [3, 2, 3] — both 3-page documents are odd (including the last one)
+        Blob merged = DocGenPdfMerger.mergePdfs(new List<Blob>{ fx(FX3_B64), fx(FX2_B64), fx(FX3_B64) }, true);
+        Test.stopTest();
+        System.assertEquals(10, DocGenPdfMerger.pageCount(merged), '(3+1) + 2 + (3+1)');
+        System.assertEquals(2, DocGenPdfMerger.blankPageCount(merged), 'one blank per odd document, last included');
+    }
+
+    @IsTest
+    static void evenDocumentsAreNeverPadded() {
+        Test.startTest();
+        Blob merged = DocGenPdfMerger.mergePdfs(new List<Blob>{ fx(FX2_B64), fx(FX2_B64) }, true);
+        Test.stopTest();
+        System.assertEquals(4, DocGenPdfMerger.pageCount(merged), '2 + 2');
+        System.assertEquals(0, DocGenPdfMerger.blankPageCount(merged), 'padding only acts on odd documents');
+    }
+
+    @IsTest
+    static void everyOddDocumentGetsExactlyOneBlank() {
+        Test.startTest();
+        Blob merged = DocGenPdfMerger.mergePdfs(new List<Blob>{ fx(FX1_B64), fx(FX1_B64), fx(FX1_B64) }, true);
+        Test.stopTest();
+        System.assertEquals(6, DocGenPdfMerger.pageCount(merged), '3 x (1 + 1 blank)');
+        System.assertEquals(3, DocGenPdfMerger.blankPageCount(merged), 'one blank per odd document');
+    }
+
+    @IsTest
+    static void mergedOutputReParsesCleanly() {
+        Test.startTest();
+        Blob merged = DocGenPdfMerger.mergePdfs(new List<Blob>{ fx(FX3_B64), fx(FX2_B64) }, true);
+        // feed the merged PDF back through the merger as a source — proves the
+        // object graph, /Kids, xref and trailer we wrote are all well-formed
+        Blob remerged = DocGenPdfMerger.mergePdfs(new List<Blob>{ merged, merged }, false);
+        Test.stopTest();
+        System.assertEquals(6, DocGenPdfMerger.pageCount(merged), '(3+1) + 2');
+        System.assertEquals(12, DocGenPdfMerger.pageCount(remerged), 'merged PDF is itself parseable');
+    }
+
+    @IsTest
+    static void singleDocumentUnpaddedIsReturnedUntouched() {
+        Blob src = fx(FX2_B64);
+        Test.startTest();
+        Blob out = DocGenPdfMerger.mergePdfs(new List<Blob>{ src }, false);
+        Test.stopTest();
+        System.assertEquals(src.size(), out.size(), 'single PDF + no padding is a pass-through');
+    }
+
+    @IsTest
+    static void singleOddDocumentIsPaddedWhenRequested() {
+        Test.startTest();
+        Blob out = DocGenPdfMerger.mergePdfs(new List<Blob>{ fx(FX1_B64) }, true);
+        Test.stopTest();
+        System.assertEquals(2, DocGenPdfMerger.pageCount(out), '1-page document padded to 2');
+        System.assertEquals(1, DocGenPdfMerger.blankPageCount(out), 'one blank added');
+    }
+
+    @IsTest
+    static void nullOrEmptyInputThrows() {
+        Test.startTest();
+        try {
+            DocGenPdfMerger.mergePdfs(null, false);
+            System.assert(false, 'null input should throw');
+        } catch (DocGenPdfMerger.DocGenPdfMergeException e) {
+            System.assert(e.getMessage().containsIgnoreCase('no pdf'), e.getMessage());
+        }
+        try {
+            DocGenPdfMerger.mergePdfs(new List<Blob>(), false);
+            System.assert(false, 'empty input should throw');
+        } catch (DocGenPdfMerger.DocGenPdfMergeException e) {
+            System.assert(e.getMessage().containsIgnoreCase('no pdf'), e.getMessage());
+        }
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void nonPdfAndEncryptedInputAreRejected() {
+        Test.startTest();
+        try {
+            DocGenPdfMerger.mergePdfs(new List<Blob>{ Blob.valueOf('not a pdf at all'), fx(FX2_B64) }, false);
+            System.assert(false, 'non-PDF should throw');
+        } catch (DocGenPdfMerger.DocGenPdfMergeException e) {
+            System.assert(e.getMessage().containsIgnoreCase('not a pdf'), e.getMessage());
+        }
+        try {
+            DocGenPdfMerger.mergePdfs(
+                new List<Blob>{ Blob.valueOf('%PDF-1.4\n<< /Encrypt 9 0 R >>'), fx(FX2_B64) },
+                false
+            );
+            System.assert(false, 'encrypted PDF should throw');
+        } catch (DocGenPdfMerger.DocGenPdfMergeException e) {
+            System.assert(e.getMessage().containsIgnoreCase('encrypt'), e.getMessage());
+        }
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void identicalContentDocumentsKeepEveryPage() {
+        // #382 regression: a template that renders byte-identical page content
+        // for every record (a static contract, T&Cs, a cover letter with no
+        // effective merge fields) produces parts whose content streams match
+        // across documents. Dedup must NOT collapse those — only embedded font
+        // programs are safe to share. Earlier the stream dedup dropped the
+        // repeated pages, leaving a short, corrupt packet.
+        Blob one = fx(FX3_B64); // 3-page document
+        Test.startTest();
+        Blob merged = DocGenPdfMerger.mergePdfs(new List<Blob>{ one, one, one }, false);
+        Test.stopTest();
+
+        System.assertEquals(
+            9,
+            DocGenPdfMerger.pageCount(merged),
+            'all 3x3 pages must survive an identical-content merge'
+        );
+        System.assertEquals(0, DocGenPdfMerger.blankPageCount(merged), 'no page should lose its content stream');
+        // Every page keeps its own content: the merged size tracks 3x the source,
+        // not the ~1x an over-eager content-stream dedup would collapse it to.
+        System.assert(
+            merged.size() > one.size() * 2,
+            'identical documents must not be deduped down to one copy (got ' +
+                merged.size() +
+                ' from 3x ' +
+                one.size() +
+                ')'
+        );
+    }
+}

--- a/force-app/main/default/classes/DocGenPdfMergerTest.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenPdfMergerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -3065,6 +3065,21 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
     }
 
     /**
+     * Renders a PDF blob (no save) from pre-cached record data, keeping the real
+     * recordId so chart context and image tags resolve as they do for a live
+     * record. Used by DocGenBatch's duplex-padding path (#382).
+     * @return Map with keys: blob (PDF Blob), title (String)
+     */
+    global static Map<String, Object> generatePdfBlobFromData(
+        Id templateId,
+        Id recordId,
+        Map<String, Object> preloadedRecordData
+    ) {
+        preloadedRecordDataOverride = preloadedRecordData;
+        return generatePdfBlob(templateId, recordId);
+    }
+
+    /**
      * Renders a PDF directly from a caller-supplied data map — no SOQL, no recordId required.
      * Lets Flows/Apex assemble custom data wrappers (external API responses, computed totals,
      * cross-object aggregations) and render them straight into a template without persisting

--- a/force-app/main/default/lwc/docGenBulkRunner/docGenBulkRunner.html
+++ b/force-app/main/default/lwc/docGenBulkRunner/docGenBulkRunner.html
@@ -399,7 +399,7 @@
                 <div class="divider"></div>
                 <h3 class="section-title">Step 3: Run Generation</h3>
                 <div
-                    class="run-bar slds-var-m-top_medium slds-grid slds-grid_align-center slds-grid_vertical-align-end slds-gutters_small"
+                    class="run-bar slds-var-m-top_medium slds-grid slds-grid_align-spread slds-grid_vertical-align-end slds-wrap slds-gutters_medium"
                 >
                     <div class="slds-col slds-size_1-of-3">
                         <lightning-input
@@ -436,9 +436,36 @@
                         </lightning-combobox>
                     </div>
 
-                    <div class="slds-col slds-var-m-top_small">
+                    <template if:true={showDuplexPadding}>
+                        <div class="slds-col slds-shrink-none">
+                            <div
+                                class="slds-form-element__label slds-grid slds-grid_vertical-align-center"
+                                style="gap: 0.25rem; margin-bottom: 0.125rem"
+                            >
+                                <span>Duplex Padding</span>
+                                <lightning-helptext
+                                    content="For double-sided printing — adds a blank page after any document with an odd page count so every document starts on the front of a sheet."
+                                ></lightning-helptext>
+                            </div>
+                            <lightning-input
+                                type="toggle"
+                                label="Duplex Padding"
+                                variant="label-hidden"
+                                message-toggle-active="On"
+                                message-toggle-inactive="Off"
+                                checked={duplexPadding}
+                                onchange={handleDuplexPaddingChange}
+                                disabled={isProcessing}
+                            >
+                            </lightning-input>
+                        </div>
+                    </template>
+                </div>
+
+                <div class="slds-align_absolute-center slds-var-m-top_large">
+                    <div class="slds-text-align_center">
                         <template if:false={filterValidated}>
-                            <p class="slds-text-color_weak slds-text-body_small">
+                            <p class="slds-text-color_weak slds-text-body_small slds-var-m-bottom_xx-small">
                                 Validate your filter to enable generation.
                             </p>
                         </template>

--- a/force-app/main/default/lwc/docGenBulkRunner/docGenBulkRunner.js
+++ b/force-app/main/default/lwc/docGenBulkRunner/docGenBulkRunner.js
@@ -139,7 +139,8 @@ export default class DocGenBulkRunner extends NavigationMixin(LightningElement) 
                 templateId: this.selectedTemplateId,
                 recordCount: this.recordCount,
                 batchSize: this.batchSize || 1,
-                mergePdf: this.mergePdf || false
+                mergePdf: this.mergePdf || false,
+                duplexPadding: (this.mergePdf && this.duplexPadding) || false
             });
         } catch (error) {
             console.error('Job analysis failed', error);
@@ -300,6 +301,24 @@ export default class DocGenBulkRunner extends NavigationMixin(LightningElement) 
 
     handleOutputModeChange(event) {
         this.outputMode = event.detail.value;
+        if (!this.mergePdf) {
+            this.duplexPadding = false;
+        }
+        if (this.filterValidated) {
+            this.runAnalysis();
+        }
+    }
+
+    // Duplex padding (#382) — Combined PDF only. Appends one blank page to any
+    // odd-length document before the merge so it starts on the front of a sheet.
+    @track duplexPadding = false;
+
+    get showDuplexPadding() {
+        return this.mergePdf;
+    }
+
+    handleDuplexPaddingChange(event) {
+        this.duplexPadding = event.target.checked;
         if (this.filterValidated) {
             this.runAnalysis();
         }
@@ -585,7 +604,8 @@ export default class DocGenBulkRunner extends NavigationMixin(LightningElement) 
                 mergePdf: this.mergePdf || false,
                 batchSize: this.batchSize || 1,
                 mergeOnly: this.mergeOnly || false,
-                sortOrder: this.sortOrderClause
+                sortOrder: this.sortOrderClause,
+                duplexPadding: this.mergePdf && this.duplexPadding
             });
             this.showToast('Success', 'Job started. Status will auto-refresh every 5 seconds.', 'success');
             this.startPolling();

--- a/force-app/main/default/objects/DocGen_Job__c/fields/Duplex_Padding__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Job__c/fields/Duplex_Padding__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Duplex_Padding__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description
+    >Combined PDF only. When true, each record's document is rendered as its own PDF and any document with an odd page count gets one blank page appended before the final merge, so every document starts on the front of a sheet when the packet is printed double-sided. When false, the existing HTML-concatenation merge is used unchanged.</description>
+    <label>Duplex Padding</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
@@ -265,6 +265,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>DocGen_Job__c.Duplex_Padding__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>DocGen_Job__c.Error_Count__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
@@ -247,6 +247,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>DocGen_Job__c.Duplex_Padding__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>DocGen_Job__c.Error_Count__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/scripts/e2e-01-permissions.apex
+++ b/scripts/e2e-01-permissions.apex
@@ -430,6 +430,17 @@ try {
             fail++;
             System.debug('USER FLD DocGen_Job__c.Sort_Order__c edit: FAIL');
         }
+
+        // #382 — DocGenBulkController.submitJobInternal and DocGenBatch/DocGenMergeJob
+        // read Duplex_Padding__c on every bulk job. A missing grant fails bulk
+        // generation for standard users (see the Sort_Order__c note above).
+        Boolean userJobDuplexOk = containsNs(editableJobFields, 'DocGen_Job__c.Duplex_Padding__c');
+        if (userJobDuplexOk) {
+            pass++;
+        } else {
+            fail++;
+            System.debug('USER FLD DocGen_Job__c.Duplex_Padding__c edit: FAIL');
+        }
     }
 } catch (Exception e) {
     fail++;

--- a/scripts/e2e-05-generate-bulk.apex
+++ b/scripts/e2e-05-generate-bulk.apex
@@ -68,6 +68,7 @@ try {
         false,
         1,
         false,
+        null,
         null
     );
     if (jobId != null) {
@@ -199,7 +200,7 @@ try {
 
 // ===== Analyze Job =====
 try {
-    DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tmplId, 1, 1, false);
+    DocGenBulkController.JobAnalysis analysis = DocGenBulkController.analyzeJob(tmplId, 1, 1, false, false);
     if (analysis != null && analysis.canProceed != null) {
         pass++;
         System.debug('ANALYZE JOB: PASS — canProceed: ' + analysis.canProceed + ', summary: ' + analysis.summary);
@@ -210,6 +211,65 @@ try {
 } catch (Exception e) {
     fail++;
     System.debug('ANALYZE JOB: FAIL — ' + e.getMessage());
+}
+
+// ===== Duplex padding (#382) — Combined-PDF only, forced off otherwise =====
+try {
+    // Combined PDF + duplex on: the flag is persisted on the job.
+    Id dpxJob = DocGenBulkController.submitJob(
+        tmplId,
+        'Name = \'E2E Test Corp\'',
+        'E2E Duplex On',
+        true,
+        1,
+        true,
+        null,
+        true
+    );
+    DocGen_Job__c dpxRec = [SELECT Duplex_Padding__c FROM DocGen_Job__c WHERE Id = :dpxJob];
+    if (dpxRec.Duplex_Padding__c == true) {
+        pass++;
+        System.debug('DUPLEX FLAG PERSISTED: PASS');
+    } else {
+        fail++;
+        System.debug('DUPLEX FLAG PERSISTED: FAIL — flag not set on Combined-PDF job');
+    }
+    delete [SELECT Id FROM DocGen_Job__c WHERE Id = :dpxJob];
+
+    // Individual Files + duplex on: submitJobInternal must force it off (no merge to pad).
+    Id noMergeJob = DocGenBulkController.submitJob(
+        tmplId,
+        'Name = \'E2E Test Corp\'',
+        'E2E Duplex Forced Off',
+        false,
+        1,
+        false,
+        null,
+        true
+    );
+    DocGen_Job__c noMergeRec = [SELECT Duplex_Padding__c FROM DocGen_Job__c WHERE Id = :noMergeJob];
+    if (noMergeRec.Duplex_Padding__c != true) {
+        pass++;
+        System.debug('DUPLEX FORCED OFF FOR INDIVIDUAL FILES: PASS');
+    } else {
+        fail++;
+        System.debug('DUPLEX FORCED OFF FOR INDIVIDUAL FILES: FAIL — flag survived on a non-merge job');
+    }
+    delete [SELECT Id FROM DocGen_Job__c WHERE Id = :noMergeJob];
+
+    // analyzeJob accepts the duplex flag without faulting (ceiling logic itself is
+    // unit-tested in DocGenBulkControllerTest — it needs a template Test Record).
+    DocGenBulkController.JobAnalysis dpxAnalysis = DocGenBulkController.analyzeJob(tmplId, 10, 1, true, true);
+    if (dpxAnalysis != null) {
+        pass++;
+        System.debug('DUPLEX ANALYZE OK: PASS');
+    } else {
+        fail++;
+        System.debug('DUPLEX ANALYZE OK: FAIL — null analysis for duplex job');
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('DUPLEX PADDING: FAIL — ' + e.getMessage());
 }
 
 // ===== Save Query =====


### PR DESCRIPTION
## Summary

Bulk generation's **Combined PDF** can now start every document on the front of a sheet for double-sided printing. When **Duplex Padding** is on, each record is rendered as its own PDF, `DocGenPdfMerger` stitches them, and any document with an **odd** page count gets one completely blank page appended before the next. Off by default; when off, the Combined PDF path is byte-for-byte unchanged.

Closes Feature 1 of #382. (Feature 2 — rich-text `<br>`/`<table>` rendering — is a separate subsystem and will be filed as its own issue.)

## Changes

- **`DocGenPdfMerger` (new, `global`)** — Apex PDF concatenation targeting Portwood's own Flying Saucer output. Streamed parse (40 parts per SOQL, each blob freed after `parse()`), classic xref table out. Deduplicates **embedded font programs only** (`/FontFile`, `/FontFile2`, `/FontFile3` targets) so an N-record packet doesn't carry N copies of the ~60 KB Arial Unicode MS subset — never page content streams or images (that corrupts documents that render identical content per record).
- **`Duplex_Padding__c`** checkbox on `DocGen_Job__c`; field permissions added to `DocGen_Admin` and `DocGen_User`.
- **`DocGenBatch`** — under duplex, saves one `docgen_pdfpart_*` PDF per record instead of an HTML snippet; in "Combined + Individual" it still writes the per-record file.
- **`DocGenMergeJob.mergeDuplexParts`** — stitches the parts by title order with `DocGenPdfMerger`, pads odd-length documents, saves as `Merged_PDF_CV__c`. The non-duplex HTML-concatenation merge below it is untouched.
- **`analyzeJob`** — a "Duplex Packet" item: warns above ~250 documents, hard-blocks above ~400 (the packet assembles in a single job).
- **`DocGenMergeJobFinalizer`** — now writes a plain-English reason to `Error_Log__c` when a merge dies on an uncaught heap/CPU/SOQL limit (applies to every merge job, not just duplex — additive).
- **`DocGenChartCvReaper`** — also sweeps orphaned `docgen_pdfpart_*` CVs, but only once their parent `DocGen_Job__c` is terminal (`Completed` / `Completed with Errors` / `Failed`) or gone — never mid-run, regardless of age.
- **`DocGenService.generatePdfBlobFromData(Id, Id, Map)`** — new `global` overload so the batch can render a per-record PDF from a preloaded data map. The existing 2-arg overload is unchanged.
- **Flow** — `Generate Bulk Documents` gains a **Duplex Padding** checkbox input; ignored unless the job produces a Combined PDF.
- **LWC `docGenBulkRunner`** — a toggle under the output mode, shown only for Combined PDF, forced off for Individual Files.
- **`submitJob` / `analyzeJob`** signatures gained one trailing param; all positional callers (`e2e-05`, `DocGenBulkFlowAction`, test classes) updated. Both are `public` (not `global`), so no subscriber Apex is affected.

### Page numbering

`{PageNumber}` / `{TotalPages}` and the `Page X of Y` header/footer fields read **per document** in a duplex packet, because each record is rendered on its own — a 3-page statement numbers `1 of 3, 2 of 3, 3 of 3`, and the blank filler carries no number. A plain (non-duplex) Combined PDF still numbers continuously across the whole bundle.

## Testing

- [x] `RunLocalTests` — **2049 / 100% / 78%** org-wide coverage
- [x] `e2e-01` … `e2e-08` + `e2e-07-syntax1..5` — all `PASS  FAIL: 0` (e2e-01 gains a `Duplex_Padding__c` FLS check; e2e-05 gains duplex-flag assertions)
- [x] `DocGenPdfMergerTest` (11, incl. `identicalContentDocumentsKeepEveryPage`), `DocGenChartCvReaperTest` (+4 for job-status-aware reaping)
- [x] End-to-end in `docgen-verify` against real Accounts + HTML and Word templates: 3-page HTML invoice ×5 duplex → 20 pp (15 real + 5 blank), per-doc numbering; 2-page even HTML letter ×5 → 10 pp, no padding; Word contract ×5 Combined → 30 pp, every document complete; duplex-off control → unchanged 15-pp continuous-numbered bundle.
- [ ] `sf code-analyzer` — ran locally; the paths analysed had 0 unsuppressed Security/AppExchange violations, but the `sfge` engine crashed partway and `flow` needs Python. **Needs a clean CI run.**
- [ ] Namespaced package-build validation — **not yet done.** New `global` class + FLS-guarded field; per CLAUDE.md this class of change only reproduces its failure modes in a namespaced org.

## Related Issues

Related to #382 (Feature 1).

## Checklist

- [x] No hardcoded IDs, URLs, or credentials
- [x] No `VersionData` in PDF image queries
- [x] SOQL uses `WITH USER_MODE` / `Security.stripInaccessible()` / documented internal-CV `SYSTEM_MODE` pattern
- [x] No new external dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
