### PR TITLE
fix(watermark): strength control works after upload — completes #313 (supersedes #357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,27 @@ Two small fixes where the editor promised something the PDF did not deliver.
 
 ### Fixed
 
+- **Watermark strength now changes after the image is uploaded** (#313). Opacity is baked
+  into the watermark PNG's pixels at upload (Flying Saucer has no CSS opacity), so once an
+  image was stored the strength dropdown had nothing to act on — changing it did nothing,
+  silently, and the reporter's workaround was to set the value _before_ uploading. The
+  unbaked original is now kept: in memory for the session and persisted as
+  `docgen_watermark_src_<versionId>`, so a later change re-bakes from the original rather
+  than washing an already-washed image (30% of an already-30% image is 9%, and every
+  change would compound). The chosen wash is encoded into the baked file name
+  (`watermark-p50.png`) and `getWatermarkOpacity` reads it back, so the dropdown reflects
+  what is stored after a reload instead of snapping to the default. Extends the work on
+  the closed PR #357: the persisted-source path now decodes the stored bytes to a `Blob`
+  directly (the old `fetch('data:…')` produced a nameless blob that threw in the bake for
+  every wash but 100%); `getWatermarkSource` / `getWatermarkOpacity` enforce the same
+  per-version access check as `saveWatermarkImage` (an unauthenticated-read IDOR
+  otherwise); each save sweeps the previous baked image + source so opacity changes don't
+  accumulate ContentVersions; Save-as-New-Version and cross-org export/import carry the
+  source forward; and Clear Watermark drops it. Pixel-alpha correctness of the re-bake is
+  unchanged and still verified by hand (it needs a real canvas). New
+  `scripts/qa/watermark-opacity-route-check.mjs`; `DocGenControllerTests` gains the two
+  IDOR-denial cases, the file-name round-trip, and the accumulation sweep.
+
 - **Bold on `'Arial Unicode MS'` was a no-op** (#281, PR #286 by @ssk42). The PDF engine
   embeds that family with no bold face, so a bold it carried printed regular — the
   control looked on and did nothing. It is now disabled for that font, and no bold is

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -2436,7 +2436,7 @@ Plain multiline (long text, textarea) fields work too — newlines in the field 
 
 Two ways to add a full-page watermark or background image to your PDF output:
 
-**Option A: Upload via the template builder (recommended).** In the template editor, click the **Watermark / Background** tab and upload a pre-sized image. This bypasses Word's Watermark dialog entirely and gives you exact pixel-level control over the output.
+**Option A: Upload via the template builder (recommended).** In the template editor, click the **Watermark / Background** tab and upload a pre-sized image. This bypasses Word's Watermark dialog entirely and gives you exact pixel-level control over the output. A **Watermark strength** control (Light 15% / Medium 30% / Strong 50% / Original) fades the image — the opacity is baked into the stored PNG because Flying Saucer has no CSS opacity, and Portwood keeps the unfaded original so changing the strength after upload re-fades from it rather than compounding. The new setting applies immediately and survives a page reload (v3.57+).
 
 **Option B: Insert via Word's Design → Watermark dialog.** Word's built-in watermark works too, with these constraints:
 

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -770,8 +770,44 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
      * @param base64Data  Base64-encoded image bytes
      * @return The created ContentVersion ID
      */
-    @AuraEnabled
+    /**
+     * Apex-side convenience with no retained source. NOT @AuraEnabled — Apex
+     * forbids overloading an @AuraEnabled method, so the LWC entry point is the
+     * four-argument form below and passes null when there is no source (#313).
+     */
     public static Id saveWatermarkImage(Id versionId, String fileName, String base64Data) {
+        return saveWatermarkImage(versionId, fileName, base64Data, null);
+    }
+
+    /** Title prefix for the retained, unbaked watermark source (#313). */
+    private static final String WATERMARK_SOURCE_PREFIX = 'docgen_watermark_src_';
+
+    /**
+     * Returns the retained unbaked watermark source for a version, or null when
+     * there is none — a watermark uploaded before #313, or one saved without a
+     * source. The caller re-bakes from this rather than from the stored image,
+     * which is already washed (#313).
+     */
+    @AuraEnabled
+    public static String getWatermarkSource(Id versionId) {
+        if (versionId == null) {
+            return null;
+        }
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title', 'VersionData' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<ContentVersion> cvs = [
+            SELECT VersionData
+            FROM ContentVersion
+            WHERE Title = :(WATERMARK_SOURCE_PREFIX + versionId)
+            WITH SYSTEM_MODE
+            ORDER BY CreatedDate DESC
+            LIMIT 1
+        ];
+        return cvs.isEmpty() || cvs[0].VersionData == null ? null : EncodingUtil.base64Encode(cvs[0].VersionData);
+    }
+
+    @AuraEnabled
+    public static Id saveWatermarkImage(Id versionId, String fileName, String base64Data, String sourceBase64) {
         if (versionId == null) {
             throw new DocGenException('Version ID is required.');
         }
@@ -811,6 +847,24 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             FirstPublishLocationId = versionId
         );
         Database.insert(cv, AccessLevel.USER_MODE);
+
+        // Keep the UNBAKED original alongside the washed image (#313).
+        //
+        // Opacity is baked into the stored PNG's pixels — Flying Saucer has no CSS
+        // opacity, so pre-multiplied alpha is the only thing that renders. That
+        // means the stored image cannot be re-washed: 30% of an already-30% image
+        // is 9%, and every change would compound. Persisting the source is what
+        // lets the opacity control keep working after the page is reloaded, or in
+        // a later session, instead of asking the author to upload the file again.
+        if (String.isNotBlank(sourceBase64)) {
+            ContentVersion src = new ContentVersion(
+                Title = WATERMARK_SOURCE_PREFIX + versionId,
+                PathOnClient = 'watermark-source.png',
+                VersionData = EncodingUtil.base64Decode(sourceBase64),
+                FirstPublishLocationId = versionId
+            );
+            Database.insert(src, AccessLevel.USER_MODE);
+        }
         // Persist the CV ID on the template version so the renderer knows about it.
         // SYSTEM_MODE on the namespaced custom-field update — Schema check above
         // gates access; USER_MODE strict-FLS strips Watermark_Image_CV_Id__c when

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -779,53 +779,32 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         return saveWatermarkImage(versionId, fileName, base64Data, null);
     }
 
+    /** Title prefix for the baked (washed) watermark image. */
+    private static final String WATERMARK_PREFIX = 'docgen_watermark_';
     /** Title prefix for the retained, unbaked watermark source (#313). */
     private static final String WATERMARK_SOURCE_PREFIX = 'docgen_watermark_src_';
+    /**
+     * Pulls the baked opacity out of a watermark file name — "watermark-p50.png"
+     * yields 50. The designer encodes the wash it applied into PathOnClient so it
+     * can seed the strength control on reload rather than snapping to the default
+     * over an image that is actually at some other value (#313).
+     */
+    private static final Pattern WATERMARK_PCT_PATTERN = Pattern.compile('-p(\\d{1,3})(?:\\.|$)');
 
     /**
-     * Returns the retained unbaked watermark source for a version, or null when
-     * there is none — a watermark uploaded before #313, or one saved without a
-     * source. The caller re-bakes from this rather than from the stored image,
-     * which is already washed (#313).
+     * Confirms the caller can see this template version before any watermark
+     * read or write touches it. Without this the watermark endpoints would let
+     * any authenticated user reach another admin's template version by Id — the
+     * IDOR class the v1.75 sweep closed on saveWatermarkImage, which the #313
+     * read endpoints have to honour too.
      */
-    @AuraEnabled
-    public static String getWatermarkSource(Id versionId) {
-        if (versionId == null) {
-            return null;
-        }
-        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title', 'VersionData' });
-        /* code-analyzer-suppress ApexFlsViolation */
-        List<ContentVersion> cvs = [
-            SELECT VersionData
-            FROM ContentVersion
-            WHERE Title = :(WATERMARK_SOURCE_PREFIX + versionId)
-            WITH SYSTEM_MODE
-            ORDER BY CreatedDate DESC
-            LIMIT 1
-        ];
-        return cvs.isEmpty() || cvs[0].VersionData == null ? null : EncodingUtil.base64Encode(cvs[0].VersionData);
-    }
-
-    @AuraEnabled
-    public static Id saveWatermarkImage(Id versionId, String fileName, String base64Data, String sourceBase64) {
-        if (versionId == null) {
-            throw new DocGenException('Version ID is required.');
-        }
-        if (String.isBlank(base64Data)) {
-            throw new DocGenException('Image data is required.');
-        }
-        // SECURITY (v1.75): verify the caller actually has access to this template
-        // version. Without this, any authenticated user could attach a watermark
-        // (and a ContentVersion) to any other admin's template version by Id.
-        // USER_MODE on a custom object the caller can't see throws QueryException —
-        // catch and convert to AuraHandledException so the LWC error handler reports
-        // a clean denial.
+    private static void assertWatermarkVersionAccess(Id versionId) {
         List<DocGen_Template_Version__c> ownerCheck;
         try {
             DocGenFlsGuard.assertAccessible(DocGen_Template_Version__c.sObjectType, new Set<String>{ 'Template__c' });
             /* code-analyzer-suppress ApexFlsViolation */
             ownerCheck = [
-                SELECT Id, Template__c
+                SELECT Id
                 FROM DocGen_Template_Version__c
                 WHERE Id = :versionId
                 WITH SYSTEM_MODE
@@ -839,9 +818,207 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         if (ownerCheck.isEmpty()) {
             throw DocGenService.ahe('Template version not found or access denied.');
         }
+    }
+
+    /**
+     * Returns the retained unbaked watermark source for a version, or null when
+     * there is none — a watermark uploaded before #313, or one saved without a
+     * source. The caller re-bakes from this rather than from the stored image,
+     * which is already washed (#313).
+     */
+    @AuraEnabled
+    public static String getWatermarkSource(Id versionId) {
+        if (versionId == null) {
+            return null;
+        }
+        assertWatermarkVersionAccess(versionId);
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title', 'VersionData' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<ContentVersion> cvs = [
+            SELECT VersionData
+            FROM ContentVersion
+            WHERE Title = :(WATERMARK_SOURCE_PREFIX + versionId)
+            WITH SYSTEM_MODE
+            ORDER BY CreatedDate DESC
+            LIMIT 1
+        ];
+        return cvs.isEmpty() || cvs[0].VersionData == null ? null : EncodingUtil.base64Encode(cvs[0].VersionData);
+    }
+
+    /**
+     * The baked opacity of the version's current watermark (15 / 30 / 50 / 100),
+     * or null when it can't be determined — a watermark with no percent in its
+     * file name, or none at all. Read from the ContentVersion the version
+     * actually references, so it still resolves after a Save-as-New-Version
+     * carries the id forward under the previous version's title (#313).
+     */
+    @AuraEnabled
+    public static Integer getWatermarkOpacity(Id versionId) {
+        if (versionId == null) {
+            return null;
+        }
+        assertWatermarkVersionAccess(versionId);
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Template_Version__c> vers = [
+            SELECT Watermark_Image_CV_Id__c
+            FROM DocGen_Template_Version__c
+            WHERE Id = :versionId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (vers.isEmpty() || String.isBlank(vers[0].Watermark_Image_CV_Id__c)) {
+            return null;
+        }
+        Id wmCvId;
+        try {
+            wmCvId = Id.valueOf(vers[0].Watermark_Image_CV_Id__c);
+        } catch (Exception badId) {
+            return null;
+        }
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Id', 'PathOnClient' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<ContentVersion> cvs = [
+            SELECT PathOnClient
+            FROM ContentVersion
+            WHERE Id = :wmCvId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (cvs.isEmpty() || String.isBlank(cvs[0].PathOnClient)) {
+            return null;
+        }
+        Matcher pctMatch = WATERMARK_PCT_PATTERN.matcher(cvs[0].PathOnClient);
+        return pctMatch.find() ? Integer.valueOf(pctMatch.group(1)) : null;
+    }
+
+    /**
+     * Deletes the baked image and retained source left by a prior watermark save
+     * for this version. Each opacity change re-uploads, so without this the pair
+     * accumulates one set per change and nothing reclaims it. The titles are
+     * version-keyed, so this only touches this version's own files — but a
+     * different version can still point at the same baked CV id (Save-as-New-
+     * Version shares it forward), so a CV another version references is left
+     * alone. Best-effort — a failed sweep must never fail the save (#313).
+     */
+    private static void purgePriorWatermarkFiles(Id versionId) {
+        try {
+            Set<String> staleTitles = new Set<String>{
+                WATERMARK_PREFIX + versionId,
+                WATERMARK_SOURCE_PREFIX + versionId
+            };
+            /* code-analyzer-suppress ApexFlsViolation */
+            List<ContentVersion> prior = [
+                SELECT Id, ContentDocumentId
+                FROM ContentVersion
+                WHERE Title IN :staleTitles
+                WITH SYSTEM_MODE
+            ];
+            if (prior.isEmpty()) {
+                return;
+            }
+            // Apex forbids an inner and outer SELECT on the same object, so the
+            // template is looked up first, then its other versions.
+            /* code-analyzer-suppress ApexFlsViolation */
+            List<DocGen_Template_Version__c> self = [
+                SELECT Template__c
+                FROM DocGen_Template_Version__c
+                WHERE Id = :versionId
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+            Set<String> referencedByOtherVersions = new Set<String>();
+            if (!self.isEmpty() && self[0].Template__c != null) {
+                /* code-analyzer-suppress ApexFlsViolation */
+                for (DocGen_Template_Version__c other : [
+                    SELECT Watermark_Image_CV_Id__c
+                    FROM DocGen_Template_Version__c
+                    WHERE Template__c = :self[0].Template__c AND Id != :versionId AND Watermark_Image_CV_Id__c != NULL
+                    WITH SYSTEM_MODE
+                ]) {
+                    referencedByOtherVersions.add(other.Watermark_Image_CV_Id__c);
+                }
+            }
+            List<ContentDocument> docs = new List<ContentDocument>();
+            for (ContentVersion cv : prior) {
+                if (cv.ContentDocumentId == null) {
+                    continue;
+                }
+                String cvId18 = String.valueOf(cv.Id);
+                if (
+                    referencedByOtherVersions.contains(cvId18) ||
+                    referencedByOtherVersions.contains(cvId18.substring(0, 15))
+                ) {
+                    continue;
+                }
+                docs.add(new ContentDocument(Id = cv.ContentDocumentId));
+            }
+            if (!docs.isEmpty()) {
+                /* code-analyzer-suppress ApexFlsViolation */
+                Database.delete(docs, AccessLevel.SYSTEM_MODE);
+            }
+        } catch (Exception cleanupFailed) {
+            // Orphaned watermark files are harmless; the save must still land.
+        }
+    }
+
+    /**
+     * Copies the retained watermark source from one version to another under the
+     * new version's title. Save-as-New-Version carries the baked image's CV id
+     * forward but the source is title-keyed to a version, so without this copy
+     * the opacity control on the new version reports "re-upload to change" even
+     * though the original is sitting in the org (#313). Best-effort.
+     */
+    private static void copyWatermarkSourceForward(Id fromVersionId, Id toVersionId) {
+        if (fromVersionId == null || toVersionId == null) {
+            return;
+        }
+        try {
+            /* code-analyzer-suppress ApexFlsViolation */
+            List<ContentVersion> src = [
+                SELECT VersionData
+                FROM ContentVersion
+                WHERE Title = :(WATERMARK_SOURCE_PREFIX + fromVersionId)
+                WITH SYSTEM_MODE
+                ORDER BY CreatedDate DESC
+                LIMIT 1
+            ];
+            if (src.isEmpty() || src[0].VersionData == null) {
+                return;
+            }
+            ContentVersion copy = new ContentVersion(
+                Title = WATERMARK_SOURCE_PREFIX + toVersionId,
+                PathOnClient = 'watermark-source.png',
+                VersionData = src[0].VersionData,
+                FirstPublishLocationId = toVersionId
+            );
+            /* code-analyzer-suppress ApexFlsViolation */
+            Database.insert(copy, AccessLevel.SYSTEM_MODE);
+        } catch (Exception copyFailed) {
+            // A missing source only costs one re-upload; never fail the save.
+        }
+    }
+
+    @AuraEnabled
+    public static Id saveWatermarkImage(Id versionId, String fileName, String base64Data, String sourceBase64) {
+        if (versionId == null) {
+            throw new DocGenException('Version ID is required.');
+        }
+        if (String.isBlank(base64Data)) {
+            throw new DocGenException('Image data is required.');
+        }
+        // SECURITY (v1.75): verify the caller actually has access to this template
+        // version before attaching anything to it. Extracted to a shared helper so
+        // the #313 read endpoints enforce the same gate.
+        assertWatermarkVersionAccess(versionId);
+
+        // This save supersedes any prior watermark for the version — sweep the
+        // old baked image + retained source so opacity changes don't pile up
+        // ContentVersions (#313).
+        purgePriorWatermarkFiles(versionId);
+
         Blob imgBlob = EncodingUtil.base64Decode(base64Data);
         ContentVersion cv = new ContentVersion(
-            Title = 'docgen_watermark_' + versionId,
+            Title = WATERMARK_PREFIX + versionId,
             PathOnClient = String.isNotBlank(fileName) ? fileName : 'watermark.png',
             VersionData = imgBlob,
             FirstPublishLocationId = versionId
@@ -921,6 +1098,31 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         DocGenFlsGuard.assertUpdateable(v, new Set<String>{ 'Watermark_Image_CV_Id__c' });
         /* code-analyzer-suppress ApexFlsViolation */
         Database.update(v, AccessLevel.SYSTEM_MODE);
+
+        // Drop the retained unbaked source too — otherwise a later opacity change
+        // could re-bake it onto a template whose watermark was removed (#313).
+        // The baked image is deliberately kept (see method doc).
+        try {
+            /* code-analyzer-suppress ApexFlsViolation */
+            List<ContentVersion> srcCvs = [
+                SELECT ContentDocumentId
+                FROM ContentVersion
+                WHERE Title = :(WATERMARK_SOURCE_PREFIX + versionId)
+                WITH SYSTEM_MODE
+            ];
+            List<ContentDocument> srcDocs = new List<ContentDocument>();
+            for (ContentVersion cv : srcCvs) {
+                if (cv.ContentDocumentId != null) {
+                    srcDocs.add(new ContentDocument(Id = cv.ContentDocumentId));
+                }
+            }
+            if (!srcDocs.isEmpty()) {
+                /* code-analyzer-suppress ApexFlsViolation */
+                Database.delete(srcDocs, AccessLevel.SYSTEM_MODE);
+            }
+        } catch (Exception cleanupFailed) {
+            // Best-effort — a lingering source file is harmless on its own.
+        }
     }
 
     @AuraEnabled
@@ -3019,6 +3221,12 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 /* code-analyzer-suppress ApexFlsViolation */
                 Database.insert(version, AccessLevel.SYSTEM_MODE);
                 createdVersionId = version.Id;
+
+                // Bring the retained watermark source across too, so opacity stays
+                // adjustable on the new version and not just the image (#313).
+                if (String.isNotBlank(priorWatermarkCvId)) {
+                    copyWatermarkSourceForward(priorVersionId, version.Id);
+                }
 
                 if (
                     String.isBlank(contentVersionId) &&
@@ -7703,6 +7911,24 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                     // Malformed CV ID — skip, don't fail the whole export.
                 }
             }
+            // The retained watermark source (#313) — carried so opacity stays
+            // adjustable on the imported/cloned copy, not just the baked image.
+            Id watermarkSourceCvId = null;
+            if (ver != null) {
+                DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Id', 'Title' });
+                /* code-analyzer-suppress ApexFlsViolation */
+                List<ContentVersion> srcCvs = [
+                    SELECT Id
+                    FROM ContentVersion
+                    WHERE Title = :(WATERMARK_SOURCE_PREFIX + ver.Id) AND IsLatest = TRUE
+                    WITH SYSTEM_MODE
+                    LIMIT 1
+                ];
+                if (!srcCvs.isEmpty()) {
+                    watermarkSourceCvId = srcCvs[0].Id;
+                    assetCvIds.add(watermarkSourceCvId);
+                }
+            }
             if (!assetCvIds.isEmpty()) {
                 // SYSTEM_MODE for the same #114 reason as the template-file read above —
                 // these CVs are linked to the template with Visibility=InternalUsers.
@@ -7730,6 +7956,9 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             }
             if (watermarkCvId != null) {
                 bundle.put('watermarkOriginalCvId', String.valueOf(watermarkCvId));
+            }
+            if (watermarkSourceCvId != null) {
+                bundle.put('watermarkSourceOriginalCvId', String.valueOf(watermarkSourceCvId));
             }
 
             // Saved queries
@@ -7997,6 +8226,24 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             );
             /* code-analyzer-suppress ApexFlsViolation */
             Database.insert(ver, AccessLevel.SYSTEM_MODE);
+
+            // The watermark source (#313) was re-uploaded as an asset above, but
+            // under the SOURCE version's title. Re-title it to this version so
+            // getWatermarkSource / getWatermarkOpacity resolve it.
+            String watermarkSourceOriginalCvId = (String) bundle.get('watermarkSourceOriginalCvId');
+            if (String.isNotBlank(watermarkSourceOriginalCvId) && cvIdMap.containsKey(watermarkSourceOriginalCvId)) {
+                try {
+                    ContentVersion retitled = new ContentVersion(
+                        Id = (Id) cvIdMap.get(watermarkSourceOriginalCvId),
+                        Title = WATERMARK_SOURCE_PREFIX + ver.Id
+                    );
+                    /* code-analyzer-suppress ApexFlsViolation */
+                    Database.update(retitled, AccessLevel.SYSTEM_MODE);
+                } catch (Exception retitleFailed) {
+                    // Non-fatal — the baked watermark still imported; only the
+                    // adjustable-opacity affordance is lost.
+                }
+            }
 
             // 4. Extract images and pre-decompose — async (12 MB heap).
             DocGenService.enqueueTemplateImageExtraction(tmpl.Id, ver.Id);

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -998,6 +998,15 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         }
     }
 
+    /**
+     * Ceiling on each base64 watermark payload (#313). saveWatermarkImage runs in
+     * the synchronous 6 MB heap and now carries TWO images (baked + unbaked
+     * source); a base64 string is ~2.6x the image and Apex holds it as UTF-16, so
+     * even one large payload can blow the governor. ~4 MB of base64 ≈ a ~3 MB
+     * image — far more than any real watermark logo/stamp.
+     */
+    private static final Integer WATERMARK_BASE64_MAX = 4 * 1024 * 1024;
+
     @AuraEnabled
     public static Id saveWatermarkImage(Id versionId, String fileName, String base64Data, String sourceBase64) {
         if (versionId == null) {
@@ -1005,6 +1014,14 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         }
         if (String.isBlank(base64Data)) {
             throw new DocGenException('Image data is required.');
+        }
+        if (
+            base64Data.length() > WATERMARK_BASE64_MAX ||
+            (String.isNotBlank(sourceBase64) && sourceBase64.length() > WATERMARK_BASE64_MAX)
+        ) {
+            throw new DocGenException(
+                'Watermark image is too large. Use an image under ~3 MB — a logo or stamp at screen resolution is plenty.'
+            );
         }
         // SECURITY (v1.75): verify the caller actually has access to this template
         // version before attaching anything to it. Extracted to a shared helper so
@@ -1016,7 +1033,10 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         // ContentVersions (#313).
         purgePriorWatermarkFiles(versionId);
 
+        // Decode + insert one image at a time, releasing each base64 string and
+        // blob before touching the next — never hold both in the 6 MB sync heap.
         Blob imgBlob = EncodingUtil.base64Decode(base64Data);
+        base64Data = null;
         ContentVersion cv = new ContentVersion(
             Title = WATERMARK_PREFIX + versionId,
             PathOnClient = String.isNotBlank(fileName) ? fileName : 'watermark.png',
@@ -1024,6 +1044,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             FirstPublishLocationId = versionId
         );
         Database.insert(cv, AccessLevel.USER_MODE);
+        imgBlob = null;
 
         // Keep the UNBAKED original alongside the washed image (#313).
         //
@@ -1034,10 +1055,12 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         // lets the opacity control keep working after the page is reloaded, or in
         // a later session, instead of asking the author to upload the file again.
         if (String.isNotBlank(sourceBase64)) {
+            Blob srcBlob = EncodingUtil.base64Decode(sourceBase64);
+            sourceBase64 = null;
             ContentVersion src = new ContentVersion(
                 Title = WATERMARK_SOURCE_PREFIX + versionId,
                 PathOnClient = 'watermark-source.png',
-                VersionData = EncodingUtil.base64Decode(sourceBase64),
+                VersionData = srcBlob,
                 FirstPublishLocationId = versionId
             );
             Database.insert(src, AccessLevel.USER_MODE);

--- a/force-app/main/default/classes/DocGenControllerTests.cls
+++ b/force-app/main/default/classes/DocGenControllerTests.cls
@@ -6587,6 +6587,125 @@ private class DocGenControllerTests {
     }
 
     // -----------------------------------------------------------------------
+    // getWatermarkSource / getWatermarkOpacity — #313 read endpoints
+    // -----------------------------------------------------------------------
+
+    @IsTest
+    static void testGetWatermarkOpacity_readsBakedPercentFromFileName() {
+        User admin = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(admin) {
+            DocGen_Template_Version__c ver = TestDataFactory.getTestTemplateVersion();
+            String pngB64 = EncodingUtil.base64Encode(Blob.valueOf('PNG'));
+
+            Test.startTest();
+            DocGenController.saveWatermarkImage(ver.Id, 'watermark-p50.png', pngB64, pngB64);
+            Integer pct = DocGenController.getWatermarkOpacity(ver.Id);
+            Test.stopTest();
+
+            System.assertEquals(50, pct, 'Opacity must come back from the encoded file name');
+        }
+    }
+
+    @IsTest
+    static void testGetWatermarkOpacity_nullWhenNoPercentEncoded() {
+        User admin = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(admin) {
+            DocGen_Template_Version__c ver = TestDataFactory.getTestTemplateVersion();
+            String pngB64 = EncodingUtil.base64Encode(Blob.valueOf('PNG'));
+
+            Test.startTest();
+            DocGenController.saveWatermarkImage(ver.Id, 'legacy-logo.png', pngB64, null);
+            Integer pct = DocGenController.getWatermarkOpacity(ver.Id);
+            Test.stopTest();
+
+            System.assertEquals(null, pct, 'A watermark with no encoded percent reports null, not a guess');
+        }
+    }
+
+    @IsTest
+    static void testGetWatermarkSource_roundtripsTheOriginal() {
+        User admin = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(admin) {
+            DocGen_Template_Version__c ver = TestDataFactory.getTestTemplateVersion();
+            String washed = EncodingUtil.base64Encode(Blob.valueOf('WASHED'));
+            String original = EncodingUtil.base64Encode(Blob.valueOf('ORIGINAL'));
+
+            Test.startTest();
+            DocGenController.saveWatermarkImage(ver.Id, 'watermark-p30.png', washed, original);
+            String back = DocGenController.getWatermarkSource(ver.Id);
+            Test.stopTest();
+
+            System.assertEquals(original, back, 'getWatermarkSource must return the unbaked original, not the wash');
+        }
+    }
+
+    @IsTest
+    static void testGetWatermarkSource_unauthorizedAccessDenied() {
+        DocGen_Template_Version__c ver = TestDataFactory.getTestTemplateVersion();
+        Id targetId = ver.Id;
+
+        User low = buildLowPrivUser();
+        System.runAs(low) {
+            Test.startTest();
+            Boolean threw = false;
+            try {
+                DocGenController.getWatermarkSource(targetId);
+            } catch (AuraHandledException e) {
+                threw = true;
+            }
+            Test.stopTest();
+            System.assert(threw, 'Low-priv user must not read another template version watermark source by Id');
+        }
+    }
+
+    @IsTest
+    static void testGetWatermarkOpacity_unauthorizedAccessDenied() {
+        DocGen_Template_Version__c ver = TestDataFactory.getTestTemplateVersion();
+        Id targetId = ver.Id;
+
+        User low = buildLowPrivUser();
+        System.runAs(low) {
+            Test.startTest();
+            Boolean threw = false;
+            try {
+                DocGenController.getWatermarkOpacity(targetId);
+            } catch (AuraHandledException e) {
+                threw = true;
+            }
+            Test.stopTest();
+            System.assert(threw, 'Low-priv user must not probe another template version watermark opacity by Id');
+        }
+    }
+
+    @IsTest
+    static void testSaveWatermarkImage_purgesPriorSourceAndImage() {
+        User admin = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(admin) {
+            DocGen_Template_Version__c ver = TestDataFactory.getTestTemplateVersion();
+            String b64 = EncodingUtil.base64Encode(Blob.valueOf('PNG'));
+
+            Test.startTest();
+            DocGenController.saveWatermarkImage(ver.Id, 'watermark-p30.png', b64, b64);
+            DocGenController.saveWatermarkImage(ver.Id, 'watermark-p50.png', b64, b64);
+            DocGenController.saveWatermarkImage(ver.Id, 'watermark-p15.png', b64, b64);
+            Test.stopTest();
+
+            Integer washed = [
+                SELECT COUNT()
+                FROM ContentVersion
+                WHERE Title = :('docgen_watermark_' + ver.Id) AND IsLatest = TRUE
+            ];
+            Integer sources = [
+                SELECT COUNT()
+                FROM ContentVersion
+                WHERE Title = :('docgen_watermark_src_' + ver.Id) AND IsLatest = TRUE
+            ];
+            System.assertEquals(1, washed, 'Three opacity changes must leave exactly one baked image');
+            System.assertEquals(1, sources, 'Three opacity changes must leave exactly one retained source');
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // saveHtmlTemplateImage / saveHtmlTemplateBody — template-binding fix
     // -----------------------------------------------------------------------
 

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -3477,8 +3477,9 @@
                                                 >
                                                 <select
                                                     class="dg-page-select"
-                                                    title="Opacity is baked into the image on upload so the PDF matches exactly"
+                                                    title="Applied to the image and re-applied when you change it — the PDF matches exactly"
                                                     onchange={handleWatermarkOpacityChange}
+                                                    disabled={isUploadingWatermark}
                                                 >
                                                     <template for:each={watermarkOpacityOptions} for:item="opt">
                                                         <option
@@ -3993,8 +3994,9 @@
                                             <label class="slds-form-element__label">Watermark strength</label>
                                             <select
                                                 class="dg-page-select"
-                                                title="Opacity is baked into the image on upload so the PDF matches exactly"
+                                                title="Applied to the image and re-applied when you change it — the PDF matches exactly"
                                                 onchange={handleWatermarkOpacityChange}
+                                                disabled={isUploadingWatermark}
                                             >
                                                 <template for:each={watermarkOpacityOptions} for:item="opt">
                                                     <option key={opt.value} value={opt.value} selected={opt.selected}>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -83,6 +83,7 @@ import getObjectOptions from '@salesforce/apex/DocGenController.getObjectOptions
 import getChildRelationships from '@salesforce/apex/DocGenController.getChildRelationships';
 import previewRecordData from '@salesforce/apex/DocGenController.previewRecordData';
 import saveWatermarkImage from '@salesforce/apex/DocGenController.saveWatermarkImage';
+import getWatermarkSource from '@salesforce/apex/DocGenController.getWatermarkSource';
 import clearWatermarkImage from '@salesforce/apex/DocGenController.clearWatermarkImage';
 import searchDataProviders from '@salesforce/apex/DocGenController.searchDataProviders';
 import getHtmlTemplateBody from '@salesforce/apex/DocGenController.getHtmlTemplateBody';
@@ -15272,18 +15273,6 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         if (!this.editTemplateWatermarkCvId) {
             return;
         }
-        if (!this._watermarkSourceFile) {
-            // Uploaded in an earlier session, so the unbaked original is gone.
-            // Say so rather than leaving the control looking like it worked.
-            this.showToast(
-                'Re-upload to change the wash',
-                'The opacity is baked into the stored image, and the original from this upload is not in this session. Upload the image again to apply ' +
-                    this.watermarkOpacityPct +
-                    '%.',
-                'warning'
-            );
-            return;
-        }
         await this._reuploadWatermarkAtCurrentOpacity();
     }
 
@@ -15296,11 +15285,30 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         this.isUploadingWatermark = true;
         try {
             const pct = parseInt(this.watermarkOpacityPct, 10) || 100;
-            const baked = await this._bakeWatermarkOpacity(this._watermarkSourceFile, pct);
+            // In-session file first; otherwise the original persisted at upload
+            // time, which is what makes this work after a reload (#313).
+            let source = this._watermarkSourceFile;
+            if (!source) {
+                const stored = await getWatermarkSource({ versionId: active.Id });
+                if (!stored) {
+                    this.showToast(
+                        'Re-upload to change the wash',
+                        'This watermark was uploaded before Portwood started keeping the original, so the opacity is baked in. Upload the image again to apply ' +
+                            pct +
+                            '%.',
+                        'warning'
+                    );
+                    return;
+                }
+                source = await (await fetch('data:image/png;base64,' + stored)).blob();
+            }
+            const baked = await this._bakeWatermarkOpacity(source, pct);
+            const original = await this._bakeWatermarkOpacity(source, 100);
             this.editTemplateWatermarkCvId = await saveWatermarkImage({
                 versionId: active.Id,
-                fileName: baked.fileName,
-                base64Data: baked.base64
+                fileName: baked.fileName || 'watermark.png',
+                base64Data: baked.base64,
+                sourceBase64: original.base64
             });
             this.showToast('Watermark updated', 'Re-applied at ' + pct + '%.', 'success');
         } catch (err) {
@@ -15378,10 +15386,14 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         try {
             const pct = parseInt(this.watermarkOpacityPct, 10) || 100;
             const baked = await this._bakeWatermarkOpacity(file, pct);
+            // Persist the UNBAKED original too, so the opacity stays adjustable in
+            // any later session — not just this one (#313).
+            const source = await this._bakeWatermarkOpacity(file, 100);
             const newCvId = await saveWatermarkImage({
                 versionId: active.Id,
                 fileName: baked.fileName,
-                base64Data: baked.base64
+                base64Data: baked.base64,
+                sourceBase64: source.base64
             });
             this.editTemplateWatermarkCvId = newCvId;
             // Retain the UNBAKED original so a later opacity change can re-bake

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -15249,8 +15249,67 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         ].map((o) => ({ ...o, selected: o.value === this.watermarkOpacityPct }));
     }
 
-    handleWatermarkOpacityChange(event) {
+    /**
+     * The file the author picked, kept UNBAKED for the session (#313).
+     *
+     * Opacity is baked into the PNG's pixels at upload time, so once an image is
+     * stored the control had nothing left to act on — changing it did nothing,
+     * silently:
+     *
+     *   "When I try to update the Watermark percentage after I uploaded the
+     *    image it doesn't update this value. It works when I change it before I
+     *    upload the file."
+     *
+     * Keeping the original means a later change can re-bake from it. Re-baking
+     * the STORED image would compound the wash — 30% of an already-30% image is
+     * 9% — so the original is the only correct source.
+     */
+    _watermarkSourceFile = null;
+
+    async handleWatermarkOpacityChange(event) {
         this.watermarkOpacityPct = event.currentTarget.value;
+        // Nothing uploaded yet: the value is picked up when they do upload.
+        if (!this.editTemplateWatermarkCvId) {
+            return;
+        }
+        if (!this._watermarkSourceFile) {
+            // Uploaded in an earlier session, so the unbaked original is gone.
+            // Say so rather than leaving the control looking like it worked.
+            this.showToast(
+                'Re-upload to change the wash',
+                'The opacity is baked into the stored image, and the original from this upload is not in this session. Upload the image again to apply ' +
+                    this.watermarkOpacityPct +
+                    '%.',
+                'warning'
+            );
+            return;
+        }
+        await this._reuploadWatermarkAtCurrentOpacity();
+    }
+
+    /** Re-bakes the retained original at the current setting and replaces the stored image. */
+    async _reuploadWatermarkAtCurrentOpacity() {
+        const active = (this.versions || []).find((v) => v[F.VerIsActive]);
+        if (!active) {
+            return;
+        }
+        this.isUploadingWatermark = true;
+        try {
+            const pct = parseInt(this.watermarkOpacityPct, 10) || 100;
+            const baked = await this._bakeWatermarkOpacity(this._watermarkSourceFile, pct);
+            this.editTemplateWatermarkCvId = await saveWatermarkImage({
+                versionId: active.Id,
+                fileName: baked.fileName,
+                base64Data: baked.base64
+            });
+            this.showToast('Watermark updated', 'Re-applied at ' + pct + '%.', 'success');
+        } catch (err) {
+            const msg =
+                err && err.body && err.body.message ? err.body.message : (err && err.message) || 'Update failed';
+            this.showToast('Could not update the watermark', msg, 'error');
+        } finally {
+            this.isUploadingWatermark = false;
+        }
     }
 
     /** Redraws the image at the chosen opacity on a canvas → PNG base64.
@@ -15325,6 +15384,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 base64Data: baked.base64
             });
             this.editTemplateWatermarkCvId = newCvId;
+            // Retain the UNBAKED original so a later opacity change can re-bake
+            // from it rather than washing an already-washed image (#313).
+            this._watermarkSourceFile = file;
             this.showToast('Success', 'Watermark uploaded.', 'success');
         } catch (err) {
             const msg =
@@ -15345,6 +15407,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         try {
             await clearWatermarkImage({ versionId: active.Id });
             this.editTemplateWatermarkCvId = null;
+            this._watermarkSourceFile = null;
             this.showToast('Removed', 'Watermark cleared.', 'success');
         } catch (err) {
             const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || 'Clear failed';

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -84,6 +84,7 @@ import getChildRelationships from '@salesforce/apex/DocGenController.getChildRel
 import previewRecordData from '@salesforce/apex/DocGenController.previewRecordData';
 import saveWatermarkImage from '@salesforce/apex/DocGenController.saveWatermarkImage';
 import getWatermarkSource from '@salesforce/apex/DocGenController.getWatermarkSource';
+import getWatermarkOpacity from '@salesforce/apex/DocGenController.getWatermarkOpacity';
 import clearWatermarkImage from '@salesforce/apex/DocGenController.clearWatermarkImage';
 import searchDataProviders from '@salesforce/apex/DocGenController.searchDataProviders';
 import getHtmlTemplateBody from '@salesforce/apex/DocGenController.getHtmlTemplateBody';
@@ -5380,6 +5381,20 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 // Sync watermark CV from the active version so the tab shows current state
                 const active = data.find((v) => v[F.VerIsActive]);
                 this.editTemplateWatermarkCvId = active ? active[F.VerWatermarkCv] || null : null;
+                this._watermarkSourceFile = null;
+                // Seed the strength control from what's actually stored, so it
+                // doesn't report the default over an image at another value (#313).
+                if (this.editTemplateWatermarkCvId && active) {
+                    getWatermarkOpacity({ versionId: active.Id })
+                        .then((pct) => {
+                            if (pct) {
+                                this.watermarkOpacityPct = String(pct);
+                            }
+                        })
+                        .catch(() => {
+                            // Non-fatal — leave the control at its default.
+                        });
+                }
 
                 // Enrich with the body ContentVersion's number + filename so the table
                 // shows which underlying file each version points at (diagnostic).
@@ -15273,7 +15288,31 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         if (!this.editTemplateWatermarkCvId) {
             return;
         }
+        // Already re-baking a previous change — let it finish; the select is
+        // disabled in the template while isUploadingWatermark is true.
+        if (this.isUploadingWatermark) {
+            return;
+        }
         await this._reuploadWatermarkAtCurrentOpacity();
+    }
+
+    /** The saved file name encodes the wash so the control can seed from it on
+     *  reload — "watermark-p50.png" (#313). */
+    _watermarkFileName(pct) {
+        return 'watermark-p' + (parseInt(pct, 10) || 100) + '.png';
+    }
+
+    /** base64 PNG -> Blob, without fetch() on a data: URI (awkward under the
+     *  managed-package security sandbox). _bakeWatermarkOpacity tolerates a
+     *  nameless Blob; the upload name is passed explicitly. Mirrors
+     *  docGenButton.base64ToBlob. */
+    _base64ToBlob(base64) {
+        const binary = atob(base64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        return new Blob([bytes], { type: 'image/png' });
     }
 
     /** Re-bakes the retained original at the current setting and replaces the stored image. */
@@ -15300,13 +15339,13 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                     );
                     return;
                 }
-                source = await (await fetch('data:image/png;base64,' + stored)).blob();
+                source = this._base64ToBlob(stored);
             }
             const baked = await this._bakeWatermarkOpacity(source, pct);
             const original = await this._bakeWatermarkOpacity(source, 100);
             this.editTemplateWatermarkCvId = await saveWatermarkImage({
                 versionId: active.Id,
-                fileName: baked.fileName || 'watermark.png',
+                fileName: this._watermarkFileName(pct),
                 base64Data: baked.base64,
                 sourceBase64: original.base64
             });
@@ -15334,8 +15373,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 reader.onerror = () => reject(new Error('FileReader failed'));
                 reader.readAsDataURL(blobOrFile);
             });
+        const baseName = (file.name || 'watermark').replace(/\.[^.]+$/, '');
         if (pct >= 100) {
-            return { base64: await readAsBase64(file), fileName: file.name };
+            return { base64: await readAsBase64(file), fileName: baseName + '.png' };
         }
         const url = URL.createObjectURL(file);
         try {
@@ -15355,7 +15395,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             const commaIdx = dataUrl.indexOf(',');
             return {
                 base64: dataUrl.substring(commaIdx + 1),
-                fileName: file.name.replace(/\.[^.]+$/, '') + '.png'
+                fileName: baseName + '.png'
             };
         } finally {
             URL.revokeObjectURL(url);
@@ -15391,7 +15431,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             const source = await this._bakeWatermarkOpacity(file, 100);
             const newCvId = await saveWatermarkImage({
                 versionId: active.Id,
-                fileName: baked.fileName,
+                // Encode the wash into the name so the control seeds from it on
+                // reload rather than snapping to the default (#313).
+                fileName: this._watermarkFileName(pct),
                 base64Data: baked.base64,
                 sourceBase64: source.base64
             });

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -15412,6 +15412,17 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             event.target.value = '';
             return;
         }
+        // The save carries the baked image AND the unbaked source; both are
+        // base64 in the synchronous Apex heap. Keep watermarks small (#313).
+        if (file.size > 3 * 1024 * 1024) {
+            this.showToast(
+                'Image too large',
+                'Use a watermark image under 3 MB — a logo or stamp at screen resolution is plenty.',
+                'error'
+            );
+            event.target.value = '';
+            return;
+        }
         const active = (this.versions || []).find((v) => v[F.VerIsActive]);
         if (!active) {
             this.showToast(

--- a/scripts/qa/watermark-opacity-browser-check.mjs
+++ b/scripts/qa/watermark-opacity-browser-check.mjs
@@ -1,0 +1,550 @@
+/**
+ * Watermark opacity, end to end in a real browser (#313).
+ *
+ *   node scripts/qa/watermark-opacity-browser-check.mjs [--org docgen-verify] [--headed]
+ *
+ * The unit tests cover the Apex; the pure-node check covers the file-name
+ * contract. Neither runs the actual designer flow — the canvas bake, the toast,
+ * the dropdown seeding after a reload. This does:
+ *
+ *   1. upload a watermark at 30%   -> baked watermark-p30.png, ONE source,
+ *                                     stored PNG pixels ~30% opaque
+ *   2. change the strength to 50%  -> re-baked watermark-p50.png, no CV pile-up,
+ *                                     stored PNG now ~50% opaque
+ *   3. reload the page, reopen     -> the dropdown reads 50%, not the default
+ *   4. change to 15%               -> re-baked from the ORIGINAL: ~15% opaque,
+ *                                     NOT 15% of the 50% wash
+ *
+ * The uploaded source is a fully opaque red PNG, so a correct bake leaves every
+ * stored pixel at alpha ~= round(255 * pct/100). The stored bytes are pulled
+ * back through anonymous Apex and the PNG is decoded in Node (no canvas, no CORS).
+ *
+ * Still manual on a namespaced install: atob/Blob/createObjectURL under
+ * Lightning Web Security.
+ */
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { inflateSync, deflateSync } from 'node:zlib';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { chromium } from 'playwright';
+import { inPage } from './lib/browser.mjs';
+
+/** Own launcher so --headed can add slowMo for a watchable demo. */
+async function launch({ headed = false } = {}) {
+    const browser = await chromium.launch({ headless: !headed, slowMo: headed ? 400 : 0 });
+    const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    const page = await ctx.newPage();
+    return { browser, page };
+}
+
+const arg = (name, def) => {
+    const i = process.argv.indexOf(name);
+    return i > -1 ? process.argv[i + 1] : def;
+};
+const ORG = arg('--org', 'docgen-verify');
+const HEADED = process.argv.includes('--headed');
+const NAME = 'QAWM-opacity-' + Date.now();
+let APP = 'DocGen_Template_Manager';
+
+// The QA lib spawns `sf` with execFile, which does not resolve `sf.cmd` on
+// native Windows. This check calls the CLI itself, cross-platform.
+const CLI = (s) => execSync(s, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] });
+function runAnonymous(org, apex) {
+    const dir = mkdtempSync(join(tmpdir(), 'qawm-apex-'));
+    const f = join(dir, 'run.apex');
+    writeFileSync(f, apex, 'utf8');
+    try {
+        return CLI(`sf apex run --target-org ${org} -f "${f}"`);
+    } catch (e) {
+        return String(e.stdout || '') + String(e.stderr || '');
+    }
+}
+function soql(org, q) {
+    try {
+        const raw = CLI(`sf data query --target-org ${org} --json -q "${q.replace(/"/g, '\\"')}"`);
+        return JSON.parse(raw).result.records || [];
+    } catch (e) {
+        return [];
+    }
+}
+function debugMap(log) {
+    const map = {};
+    for (const line of String(log || '').split('\n')) {
+        const m = /\|USER_DEBUG\|\[\d+\]\|[A-Z]+\|([A-Z0-9_]+)=([\s\S]*)$/.exec(line);
+        if (m) map[m[1]] = m[2].trim();
+    }
+    return map;
+}
+function frontDoorUrl(org) {
+    return JSON.parse(CLI(`sf org open --target-org ${org} --url-only --json`)).result.url;
+}
+/** The Template Manager tab api name — prefixed only in a namespaced/installed org. */
+function tabApiName(org) {
+    let ns = null;
+    try {
+        ns = JSON.parse(CLI(`sf org display --target-org ${org} --json`)).result.namespace || null;
+    } catch (e) {
+        /* ignore */
+    }
+    if (!ns) {
+        try {
+            const inst = JSON.parse(CLI(`sf package installed list --target-org ${org} --json`)).result || [];
+            const pkg = inst.find((p) => String(p.SubscriberPackageNamespace || '').length > 0);
+            if (pkg) ns = pkg.SubscriberPackageNamespace;
+        } catch (e) {
+            /* ignore */
+        }
+    }
+    return (ns ? ns + '__' : '') + 'DocGen_Template_Manager';
+}
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+let fail = 0;
+const ok = (c, m) => {
+    console.log((c ? '  ok  ' : ' FAIL ') + m);
+    if (!c) fail++;
+};
+
+// CRC32 + a minimal PNG encoder — so the source is a KNOWN fully-opaque image
+// (alpha 255 everywhere) and the expected baked alpha is unambiguous.
+const CRC_TABLE = (() => {
+    const t = new Uint32Array(256);
+    for (let n = 0; n < 256; n++) {
+        let c = n;
+        for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+        t[n] = c >>> 0;
+    }
+    return t;
+})();
+const crc32 = (buf) => {
+    let c = 0xffffffff;
+    for (const b of buf) c = CRC_TABLE[(c ^ b) & 0xff] ^ (c >>> 8);
+    return (c ^ 0xffffffff) >>> 0;
+};
+const pngChunk = (type, data) => {
+    const len = Buffer.alloc(4);
+    len.writeUInt32BE(data.length);
+    const td = Buffer.concat([Buffer.from(type, 'ascii'), data]);
+    const crc = Buffer.alloc(4);
+    crc.writeUInt32BE(crc32(td));
+    return Buffer.concat([len, td, crc]);
+};
+/** Solid RGBA PNG, `size` x `size`, colour `[r,g,b,a]`. */
+function makeSolidPng(size, [r, g, b, a]) {
+    const ihdr = Buffer.alloc(13);
+    ihdr.writeUInt32BE(size, 0);
+    ihdr.writeUInt32BE(size, 4);
+    ihdr[8] = 8; // bit depth
+    ihdr[9] = 6; // colour type RGBA
+    const stride = size * 4;
+    const raw = Buffer.alloc(size * (stride + 1));
+    for (let y = 0; y < size; y++) {
+        raw[y * (stride + 1)] = 0; // filter: none
+        for (let x = 0; x < size; x++) {
+            const o = y * (stride + 1) + 1 + x * 4;
+            raw[o] = r;
+            raw[o + 1] = g;
+            raw[o + 2] = b;
+            raw[o + 3] = a;
+        }
+    }
+    return Buffer.concat([
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+        pngChunk('IHDR', ihdr),
+        pngChunk('IDAT', deflateSync(raw)),
+        pngChunk('IEND', Buffer.alloc(0))
+    ]);
+}
+
+const DEEP = `
+  const __deep = (el) => {
+    if (!el) return '';
+    let s = '';
+    const walk = (n) => {
+      if (n.nodeType === 3) { s += n.nodeValue + ' '; return; }
+      if (n.nodeType === 1 && n.shadowRoot) walk(n.shadowRoot);
+      if (n.nodeType !== 1 && n.nodeType !== 11 && n.nodeType !== 9) return;
+      for (const c of n.childNodes) walk(c);
+    };
+    walk(el);
+    return s.split(/[ ]+/).join(' ').trim();
+  };
+  const __all = (sel) => {
+    const hit = [];
+    const walk = (root) => {
+      if (root.querySelectorAll) for (const el of root.querySelectorAll(sel)) hit.push(el);
+      for (const el of (root.querySelectorAll ? root.querySelectorAll('*') : []))
+        if (el.shadowRoot) walk(el.shadowRoot);
+    };
+    walk(document);
+    return hit;
+  };
+  const __vis = (el) => {
+    if (!el) return false;
+    const r = el.getBoundingClientRect();
+    if (r.width < 2 || r.height < 2) return false;
+    const cs = getComputedStyle(el);
+    return cs.visibility !== 'hidden' && cs.display !== 'none' && parseFloat(cs.opacity || '1') > 0.02;
+  };`;
+
+async function login(page, org) {
+    const url = frontDoorUrl(org);
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(4000);
+    await page
+        .evaluate(async () => {
+            try {
+                localStorage.clear();
+                sessionStorage.clear();
+            } catch (e) {
+                /* blocked */
+            }
+            if (indexedDB.databases) {
+                const dbs = await indexedDB.databases();
+                await Promise.all(
+                    dbs.map(
+                        (d) =>
+                            new Promise((res) => {
+                                const r = indexedDB.deleteDatabase(d.name);
+                                r.onsuccess = r.onerror = r.onblocked = () => res();
+                            })
+                    )
+                );
+            }
+        })
+        .catch(() => {});
+    return new URL(url).origin.replace('.my.salesforce.com', '.lightning.force.com');
+}
+async function openTab(page, base, apiName, waitMs = 6000) {
+    await page.goto(`${base}/lightning/n/${apiName}?qa=${Date.now()}`, { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(waitMs);
+}
+
+const ev = (page, body, fb = null) => page.evaluate(inPage(DEEP + '\n' + body)).catch(() => fb);
+
+const box = (page, body) =>
+    ev(
+        page,
+        `const el = (() => {${body}})();
+     if (!el) return null;
+     el.scrollIntoView({ block: 'center', inline: 'center' });
+     const r = el.getBoundingClientRect();
+     return { x: r.left + r.width / 2, y: r.top + r.height / 2 };`
+    );
+
+async function clickText(page, sel, text) {
+    const b = await box(
+        page,
+        `for (const el of __all(${JSON.stringify(sel)}))
+       if (__vis(el) && __deep(el).toLowerCase().includes(${JSON.stringify(text.toLowerCase())})) return el;
+     return null;`
+    );
+    if (!b) return false;
+    await page.mouse.click(b.x, b.y);
+    return true;
+}
+
+async function openEditModalOnWatermarkTab(page, base) {
+    await openTab(page, base, APP, 9000);
+    await clickText(page, '[role="tab"]', 'Your Templates');
+    await wait(4000);
+    // Narrow the list to our template if there is a search box.
+    const typedSearch = await ev(
+        page,
+        `const inp = __all('input[type="search"], lightning-input input').find(__vis);
+     if (!inp) return false;
+     inp.focus(); inp.value = ${JSON.stringify(NAME)};
+     inp.dispatchEvent(new Event('input', { bubbles: true }));
+     inp.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, key: 'Enter' }));
+     return true;`
+    );
+    await wait(typedSearch ? 3500 : 0);
+    const rowsSeen = await ev(
+        page,
+        `const dt = __all('lightning-datatable')[0];
+     if (!dt || !dt.shadowRoot) return { dt: false };
+     const rows = [...dt.shadowRoot.querySelectorAll('tbody tr')];
+     return { dt: true, count: rows.length, mine: rows.some((r) => __deep(r).includes(${JSON.stringify(NAME)})) };`,
+        { dt: false }
+    );
+    if (!rowsSeen.dt || !rowsSeen.mine) {
+        await page.screenshot({ path: join(tmpdir(), 'qawm-nolist.png') }).catch(() => {});
+        throw new Error(`template not in list — ${JSON.stringify(rowsSeen)} (search box used: ${typedSearch})`);
+    }
+    // Row menu -> Edit
+    const trig = await box(
+        page,
+        `const deepQ = (root, sel, out) => {
+       if (root.querySelectorAll) for (const el of root.querySelectorAll(sel)) out.push(el);
+       for (const el of (root.querySelectorAll ? root.querySelectorAll('*') : []))
+         if (el.shadowRoot) deepQ(el.shadowRoot, sel, out);
+       return out;
+     };
+     const dt = __all('lightning-datatable')[0];
+     if (!dt || !dt.shadowRoot) return null;
+     const row = [...dt.shadowRoot.querySelectorAll('tbody tr')].find((tr) => __deep(tr).includes(${JSON.stringify(NAME)}));
+     if (!row) return null;
+     return deepQ(row, 'button[aria-haspopup="true"], button.slds-button_icon-x-small, lightning-button-menu button', [])[0] || null;`
+    );
+    if (!trig) throw new Error('row menu trigger not found for ' + NAME);
+    await page.mouse.click(trig.x, trig.y);
+    await wait(1200);
+    if (!(await clickText(page, '[role="menuitem"]', 'edit'))) throw new Error('Edit menu item not found');
+    await wait(5000);
+    if (!(await clickText(page, '[role="tab"]', 'Watermark'))) throw new Error('Watermark tab not found');
+    await wait(2500);
+}
+
+async function washedFileName(versionId) {
+    const rows = await soql(
+        ORG,
+        `SELECT PathOnClient FROM ContentVersion WHERE Title = 'docgen_watermark_${versionId}' AND IsLatest = true ORDER BY CreatedDate DESC`
+    );
+    return rows.length ? rows[0].PathOnClient : null;
+}
+async function washedCount(versionId) {
+    const rows = await soql(
+        ORG,
+        `SELECT Id FROM ContentVersion WHERE Title = 'docgen_watermark_${versionId}' AND IsLatest = true`
+    );
+    return rows.length;
+}
+async function sourceCount(versionId) {
+    const rows = await soql(
+        ORG,
+        `SELECT Id FROM ContentVersion WHERE Title = 'docgen_watermark_src_${versionId}' AND IsLatest = true`
+    );
+    return rows.length;
+}
+async function pollWashed(versionId, want, timeout = 25000) {
+    const end = Date.now() + timeout;
+    for (;;) {
+        if ((await washedFileName(versionId)) === want) return true;
+        if (Date.now() > end) return false;
+        await wait(1500);
+    }
+}
+/** Pull the stored BAKED watermark PNG bytes for a version (base64) via Apex. */
+function storedWatermarkPngB64(versionId) {
+    const log = runAnonymous(
+        ORG,
+        `Id cv = [SELECT Watermark_Image_CV_Id__c FROM DocGen_Template_Version__c WHERE Id = '${versionId}'].Watermark_Image_CV_Id__c;
+Blob b = [SELECT VersionData FROM ContentVersion WHERE Id = :cv].VersionData;
+System.debug('B64=' + EncodingUtil.base64Encode(b));`
+    );
+    return debugMap(log).B64 || null;
+}
+/** Pull the retained UNBAKED source PNG bytes for a version (base64) via Apex. */
+function storedSourcePngB64(versionId) {
+    const log = runAnonymous(
+        ORG,
+        `Blob b = [SELECT VersionData FROM ContentVersion WHERE Title = 'docgen_watermark_src_${versionId}' AND IsLatest = true ORDER BY CreatedDate DESC LIMIT 1].VersionData;
+System.debug('B64=' + EncodingUtil.base64Encode(b));`
+    );
+    return debugMap(log).B64 || null;
+}
+/**
+ * Mean alpha (0-255) of a small RGBA PNG's pixels, decoded in Node — no canvas,
+ * no CORS. The source is a fully opaque red PNG, so after `ctx.globalAlpha =
+ * pct/100` every stored pixel carries alpha ~= round(255 * pct/100).
+ */
+function meanAlphaOfPng(b64) {
+    const buf = Buffer.from(b64, 'base64');
+    let p = 8; // skip signature
+    let w = 0;
+    let h = 0;
+    let colorType = 0;
+    const idat = [];
+    while (p < buf.length) {
+        const len = buf.readUInt32BE(p);
+        const type = buf.toString('ascii', p + 4, p + 8);
+        const data = buf.subarray(p + 8, p + 8 + len);
+        if (type === 'IHDR') {
+            w = data.readUInt32BE(0);
+            h = data.readUInt32BE(4);
+            colorType = data[9];
+        } else if (type === 'IDAT') {
+            idat.push(data);
+        } else if (type === 'IEND') {
+            break;
+        }
+        p += 12 + len;
+    }
+    if (colorType !== 6) throw new Error('expected RGBA PNG (colorType 6), got ' + colorType);
+    const raw = inflateSync(Buffer.concat(idat));
+    const bpp = 4;
+    const stride = w * bpp;
+    const out = Buffer.alloc(h * stride);
+    const pa = (r, c) => (r < 0 || c < 0 ? 0 : out[r * stride + c]);
+    for (let y = 0; y < h; y++) {
+        const filter = raw[y * (stride + 1)];
+        const rowIn = raw.subarray(y * (stride + 1) + 1, y * (stride + 1) + 1 + stride);
+        for (let x = 0; x < stride; x++) {
+            const a = x >= bpp ? out[y * stride + x - bpp] : 0;
+            const b = pa(y - 1, x);
+            const cc = x >= bpp ? pa(y - 1, x - bpp) : 0;
+            let v = rowIn[x];
+            if (filter === 1) v += a;
+            else if (filter === 2) v += b;
+            else if (filter === 3) v += (a + b) >> 1;
+            else if (filter === 4) {
+                const pp = a + b - cc;
+                const pa1 = Math.abs(pp - a);
+                const pb = Math.abs(pp - b);
+                const pc = Math.abs(pp - cc);
+                v += pa1 <= pb && pa1 <= pc ? a : pb <= pc ? b : cc;
+            }
+            out[y * stride + x] = v & 0xff;
+        }
+    }
+    let sum = 0;
+    let n = 0;
+    for (let i = 3; i < out.length; i += 4) {
+        sum += out[i];
+        n++;
+    }
+    return n ? Math.round(sum / n) : 0;
+}
+const safeAlpha = (b64) => {
+    if (!b64) return -1;
+    try {
+        return meanAlphaOfPng(b64);
+    } catch (e) {
+        return -1;
+    }
+};
+const bakedAlpha = (versionId) => safeAlpha(storedWatermarkPngB64(versionId));
+const sourceAlpha = (versionId) => safeAlpha(storedSourcePngB64(versionId));
+/** got is within tol of (base * pct/100) — the alpha a correct bake produces. */
+const nearPct = (got, base, pct, tol = 14) => Math.abs(got - (base * pct) / 100) <= tol;
+
+async function main() {
+    // ---- setup -------------------------------------------------------------
+    const setup = await runAnonymous(
+        ORG,
+        `DocGen_Template__c t = new DocGen_Template__c(Name = '${NAME}', Base_Object_API__c = 'Account', Type__c = 'Word', Output_Format__c = 'PDF', Query_Config__c = 'Name', Category__c = 'QA');
+insert t;
+DocGen_Template_Version__c v = new DocGen_Template_Version__c(Template__c = t.Id, Is_Active__c = true, Type__c = 'Word', Base_Object_API__c = 'Account', Query_Config__c = 'Name', Category__c = 'QA');
+insert v;
+System.debug('TID=' + t.Id);
+System.debug('VID=' + v.Id);`
+    );
+    const { TID, VID } = debugMap(setup);
+    if (!VID) throw new Error('setup did not return a version id:\n' + setup);
+    console.log(`\ntemplate ${TID}  version ${VID}\n`);
+
+    const dir = mkdtempSync(join(tmpdir(), 'qawm-'));
+    const png = join(dir, 'wm.png');
+    // A fully opaque (alpha 255) 8x8 red square, so a correct bake at N% leaves
+    // the stored pixels at alpha ~= 255 * N/100 with nothing to explain away.
+    writeFileSync(png, makeSolidPng(8, [220, 40, 40, 255]));
+
+    APP = tabApiName(ORG);
+    console.log(`app tab: ${APP}\n`);
+
+    const beat = HEADED ? (m) => (console.log('\n>>> ' + m), wait(2500)) : () => Promise.resolve();
+
+    const { browser, page } = await launch({ headed: HEADED });
+    try {
+        const base = await login(page, ORG);
+
+        // ---- 1. upload at 30% ---------------------------------------------
+        await beat('Open the template on its Watermark tab');
+        await openEditModalOnWatermarkTab(page, base);
+        await beat('Upload a watermark image with the strength dropdown on 30%');
+        await page.locator('input[data-id="watermarkFileInput"]').setInputFiles(png);
+        const uploaded = await pollWashed(VID, 'watermark-p30.png');
+        ok(uploaded, `upload at 30% stores a baked image named watermark-p30.png (got ${await washedFileName(VID)})`);
+        ok(
+            (await sourceCount(VID)) === 1,
+            `the unbaked original is retained (source CV count = ${await sourceCount(VID)})`
+        );
+        const src = sourceAlpha(VID);
+        ok(src >= 245, `the retained original is stored UNBAKED (source alpha ${src}/255)`);
+        const a30 = bakedAlpha(VID);
+        ok(
+            nearPct(a30, src, 30),
+            `the stored image's pixels are baked to 30% (alpha ${a30}/255, expected ~${Math.round((src * 30) / 100)})`
+        );
+
+        // ---- 2. change to 50% -------------------------------------------
+        await beat('Now change the strength to 50% — the bug: this used to do nothing');
+        await page
+            .locator('.slds-modal select')
+            .filter({ hasText: 'wash' })
+            .first()
+            .selectOption('50')
+            .catch(async () => {
+                // fallback: first dg-page-select inside the modal
+                await page.locator('.slds-modal select.dg-page-select').first().selectOption('50');
+            });
+        const rebaked = await pollWashed(VID, 'watermark-p50.png');
+        ok(rebaked, `changing the strength to 50% re-bakes the image (got ${await washedFileName(VID)})`);
+        ok(
+            (await washedCount(VID)) === 1 && (await sourceCount(VID)) === 1,
+            `no ContentVersion pile-up after the change (baked=${await washedCount(VID)}, source=${await sourceCount(VID)})`
+        );
+        const a50 = bakedAlpha(VID);
+        ok(
+            nearPct(a50, src, 50),
+            `the stored image is now baked to 50% (alpha ${a50}/255, expected ~${Math.round((src * 50) / 100)})`
+        );
+        ok(
+            sourceAlpha(VID) >= 245,
+            `the retained original is STILL unbaked, not re-washed (source alpha ${sourceAlpha(VID)})`
+        );
+        ok(a50 > a30 + 15, `50% is visibly more opaque than the earlier 30% (${a50} vs ${a30})`);
+
+        // ---- 3. reload, reopen -----------------------------------------
+        await beat('Reload the whole page and reopen the tab — dropdown should still say 50%');
+        const seeded = await (async () => {
+            await openEditModalOnWatermarkTab(page, base);
+            return ev(
+                page,
+                `const s = __all('.slds-modal select.dg-page-select').filter(__vis)[0] ||
+                  __all('select.dg-page-select').filter(__vis)[0];
+         return s ? s.value : null;`
+            );
+        })();
+        ok(seeded === '50', `after a page reload the strength control reads 50%, not the default (got ${seeded})`);
+
+        // ---- 4. change to 15% — must bake from the ORIGINAL ------------
+        await beat('Change it again to 15% — the post-reload path that threw a TypeError on PR #357');
+        await page.locator('.slds-modal select.dg-page-select').first().selectOption('15');
+        const rebaked15 = await pollWashed(VID, 'watermark-p15.png');
+        ok(rebaked15, `a second change (15%) re-bakes again (got ${await washedFileName(VID)})`);
+        ok(
+            (await washedCount(VID)) === 1 && (await sourceCount(VID)) === 1,
+            `still exactly one baked image and one source after two changes`
+        );
+        const a15 = bakedAlpha(VID);
+        ok(
+            nearPct(a15, src, 15),
+            `the stored image is baked to 15% (alpha ${a15}/255, expected ~${Math.round((src * 15) / 100)})`
+        );
+        // Compounded (15% of the stored 50% wash) would be ~0.15*a50; from the
+        // original it is ~0.15*src. src is ~1.7x a50, so the two are far apart.
+        ok(
+            Math.abs(a15 - (src * 15) / 100) < Math.abs(a15 - (a50 * 15) / 100),
+            `15% baked from the ORIGINAL (~${Math.round((src * 15) / 100)}), not compounded onto the 50% wash (~${Math.round((a50 * 15) / 100)}); got ${a15}`
+        );
+        await beat('Done — all assertions passed');
+    } finally {
+        if (HEADED) await wait(4000);
+        await browser.close();
+        try {
+            runAnonymous(ORG, `delete [SELECT Id FROM DocGen_Template__c WHERE Name = '${NAME}'];`);
+        } catch (e) {
+            /* leave the QAWM- template for manual cleanup */
+        }
+    }
+
+    console.log(fail ? `\n${fail} FAILED` : '\nwatermark opacity works end to end');
+    process.exit(fail ? 1 : 0);
+}
+
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});

--- a/scripts/qa/watermark-opacity-route-check.mjs
+++ b/scripts/qa/watermark-opacity-route-check.mjs
@@ -14,8 +14,10 @@
  * control has nothing left to act on. Changing it updated a field nobody read.
  *
  * Re-baking the STORED image is not a fix: 30% of an already-30% wash is 9%, and
- * every change would compound. The original is the only correct source, so the
- * unbaked file is retained for the session.
+ * every change would compound. The original is the only correct source, so it is
+ * PERSISTED at upload time as `docgen_watermark_src_<versionId>` — Dave's call
+ * over keeping it only for the session, which would have meant asking the author
+ * to re-upload after every page reload.
  *
  * This asserts the routing — which of the three situations each change lands in —
  * because that is where the silence was.
@@ -36,11 +38,14 @@ function onOpacityChange(state, pct) {
     if (!state.editTemplateWatermarkCvId) {
         return 'stored-for-upload';
     }
-    if (!state._watermarkSourceFile) {
+    // In-session file first, then the source persisted at upload time. Only a
+    // watermark saved before #313 has neither.
+    const source = state._watermarkSourceFile || state.storedSource;
+    if (!source) {
         return 'told-to-reupload';
     }
     // Re-bakes from the ORIGINAL, never from the stored (already-washed) image.
-    state.bakedFrom = state._watermarkSourceFile;
+    state.bakedFrom = source;
     state.bakedAt = pct;
     return 'rebaked';
 }
@@ -49,6 +54,7 @@ function onOpacityChange(state, pct) {
 function onUpload(state, file, cvId) {
     state.editTemplateWatermarkCvId = cvId;
     state._watermarkSourceFile = file;
+    state.storedSource = file; // persisted server-side as docgen_watermark_src_<versionId>
     state.bakedFrom = file;
     state.bakedAt = state.watermarkOpacityPct;
 }
@@ -82,10 +88,29 @@ console.log('\nthe re-bake must start from the ORIGINAL, never the stored wash')
     ok(s.bakedAt === '15', 'ending at exactly what was asked for');
 }
 
-console.log('\nan image from an earlier session cannot be re-baked, and says so');
+console.log('\nafter a page reload the stored original still drives the re-bake');
 {
-    // Page reloaded: the CV is on the record but the unbaked original is gone.
-    const s = { watermarkOpacityPct: '30', editTemplateWatermarkCvId: '068AAA', _watermarkSourceFile: null };
+    // The in-session file is gone, but the source persisted at upload time is not.
+    const s = {
+        watermarkOpacityPct: '30',
+        editTemplateWatermarkCvId: '068AAA',
+        _watermarkSourceFile: null,
+        storedSource: 'logo.png'
+    };
+    ok(onOpacityChange(s, '50') === 'rebaked', 'a reload no longer costs the author a re-upload');
+    ok(s.bakedFrom === 'logo.png', 'and it re-bakes from the stored ORIGINAL, not the washed image');
+    ok(s.bakedAt === '50', 'landing at exactly what was asked for');
+}
+
+console.log('\nonly a pre-#313 watermark has no source, and that one says so');
+{
+    // Uploaded before the source was retained: nothing to re-bake from.
+    const s = {
+        watermarkOpacityPct: '30',
+        editTemplateWatermarkCvId: '068AAA',
+        _watermarkSourceFile: null,
+        storedSource: null
+    };
     ok(
         onOpacityChange(s, '50') === 'told-to-reupload',
         'the author is told to re-upload rather than left thinking it applied'
@@ -99,6 +124,7 @@ console.log('\nclearing the watermark forgets the original too');
     // Mirrors handleClearWatermark.
     s.editTemplateWatermarkCvId = null;
     s._watermarkSourceFile = null;
+    s.storedSource = null;
     ok(
         onOpacityChange(s, '50') === 'stored-for-upload',
         'after a clear it is back to recording the value for the next upload'

--- a/scripts/qa/watermark-opacity-route-check.mjs
+++ b/scripts/qa/watermark-opacity-route-check.mjs
@@ -1,0 +1,109 @@
+/**
+ * Watermark opacity — changing it after upload must do something, or say why not.
+ *
+ *   node scripts/qa/watermark-opacity-route-check.mjs
+ *
+ * Issue #313, reported by untangleportwood:
+ *
+ *   "When I try to update the Watermark percentage after I uploaded the image it
+ *    doesn't update this value. It works when I change it before I upload the file."
+ *
+ * The order-dependence is the whole diagnosis. Opacity is baked into the PNG's
+ * PIXELS at upload time — Flying Saucer has no CSS opacity, so pre-multiplied
+ * alpha is the only thing that renders — which means once an image is stored the
+ * control has nothing left to act on. Changing it updated a field nobody read.
+ *
+ * Re-baking the STORED image is not a fix: 30% of an already-30% wash is 9%, and
+ * every change would compound. The original is the only correct source, so the
+ * unbaked file is retained for the session.
+ *
+ * This asserts the routing — which of the three situations each change lands in —
+ * because that is where the silence was.
+ */
+
+let fail = 0;
+const ok = (c, m) => {
+    console.log((c ? '  ok  ' : ' FAIL ') + m);
+    if (!c) fail++;
+};
+
+/**
+ * Mirrors docGenAdmin.handleWatermarkOpacityChange.
+ * Returns what the component does: 'stored-for-upload' | 'rebaked' | 'told-to-reupload'.
+ */
+function onOpacityChange(state, pct) {
+    state.watermarkOpacityPct = pct;
+    if (!state.editTemplateWatermarkCvId) {
+        return 'stored-for-upload';
+    }
+    if (!state._watermarkSourceFile) {
+        return 'told-to-reupload';
+    }
+    // Re-bakes from the ORIGINAL, never from the stored (already-washed) image.
+    state.bakedFrom = state._watermarkSourceFile;
+    state.bakedAt = pct;
+    return 'rebaked';
+}
+
+/** Mirrors the upload handler retaining the unbaked original. */
+function onUpload(state, file, cvId) {
+    state.editTemplateWatermarkCvId = cvId;
+    state._watermarkSourceFile = file;
+    state.bakedFrom = file;
+    state.bakedAt = state.watermarkOpacityPct;
+}
+
+console.log('\nthe order that used to matter');
+{
+    // BEFORE upload — the case that always worked.
+    const s = { watermarkOpacityPct: '30', editTemplateWatermarkCvId: null, _watermarkSourceFile: null };
+    ok(onOpacityChange(s, '50') === 'stored-for-upload', 'changing it before upload just records the value');
+    onUpload(s, 'logo.png', '068AAA');
+    ok(s.bakedAt === '50', 'and the upload bakes at that value');
+}
+{
+    // AFTER upload — the reported case.
+    const s = { watermarkOpacityPct: '30', editTemplateWatermarkCvId: null, _watermarkSourceFile: null };
+    onUpload(s, 'logo.png', '068AAA');
+    ok(s.bakedAt === '30', 'uploaded at 30%');
+    const outcome = onOpacityChange(s, '50');
+    ok(outcome === 'rebaked', 'changing it after upload now re-bakes rather than doing nothing silently');
+    ok(s.bakedAt === '50', 'and the stored image is at the new value');
+}
+
+console.log('\nthe re-bake must start from the ORIGINAL, never the stored wash');
+{
+    const s = { watermarkOpacityPct: '30', editTemplateWatermarkCvId: null, _watermarkSourceFile: null };
+    onUpload(s, 'logo.png', '068AAA');
+    onOpacityChange(s, '50');
+    ok(s.bakedFrom === 'logo.png', 'first change bakes from the original');
+    onOpacityChange(s, '15');
+    ok(s.bakedFrom === 'logo.png', 'and so does the second — 30% of an already-30% image would be 9%');
+    ok(s.bakedAt === '15', 'ending at exactly what was asked for');
+}
+
+console.log('\nan image from an earlier session cannot be re-baked, and says so');
+{
+    // Page reloaded: the CV is on the record but the unbaked original is gone.
+    const s = { watermarkOpacityPct: '30', editTemplateWatermarkCvId: '068AAA', _watermarkSourceFile: null };
+    ok(
+        onOpacityChange(s, '50') === 'told-to-reupload',
+        'the author is told to re-upload rather than left thinking it applied'
+    );
+}
+
+console.log('\nclearing the watermark forgets the original too');
+{
+    const s = { watermarkOpacityPct: '30', editTemplateWatermarkCvId: null, _watermarkSourceFile: null };
+    onUpload(s, 'logo.png', '068AAA');
+    // Mirrors handleClearWatermark.
+    s.editTemplateWatermarkCvId = null;
+    s._watermarkSourceFile = null;
+    ok(
+        onOpacityChange(s, '50') === 'stored-for-upload',
+        'after a clear it is back to recording the value for the next upload'
+    );
+}
+
+console.log(fail ? `\n${fail} FAILED` : '\nwatermark opacity routing OK');
+process.exit(fail ? 1 : 0);

--- a/scripts/qa/watermark-opacity-route-check.mjs
+++ b/scripts/qa/watermark-opacity-route-check.mjs
@@ -1,5 +1,6 @@
 /**
- * Watermark opacity — changing it after upload must do something, or say why not.
+ * Watermark opacity — changing it after upload must actually apply, in every
+ * session, and the strength control must reflect what is stored.
  *
  *   node scripts/qa/watermark-opacity-route-check.mjs
  *
@@ -8,19 +9,19 @@
  *   "When I try to update the Watermark percentage after I uploaded the image it
  *    doesn't update this value. It works when I change it before I upload the file."
  *
- * The order-dependence is the whole diagnosis. Opacity is baked into the PNG's
- * PIXELS at upload time — Flying Saucer has no CSS opacity, so pre-multiplied
- * alpha is the only thing that renders — which means once an image is stored the
- * control has nothing left to act on. Changing it updated a field nobody read.
+ * Opacity is baked into the PNG's PIXELS at upload time — Flying Saucer has no
+ * CSS opacity, so pre-multiplied alpha is the only thing that renders — so once
+ * an image is stored the control has nothing to act on unless the UNBAKED
+ * original is kept and re-baked from. The original is persisted as
+ * `docgen_watermark_src_<versionId>` and the chosen wash is encoded into the
+ * baked image's file name (`watermark-p50.png`) so the control can seed from it
+ * on reload.
  *
- * Re-baking the STORED image is not a fix: 30% of an already-30% wash is 9%, and
- * every change would compound. The original is the only correct source, so it is
- * PERSISTED at upload time as `docgen_watermark_src_<versionId>` — Dave's call
- * over keeping it only for the session, which would have meant asking the author
- * to re-upload after every page reload.
- *
- * This asserts the routing — which of the three situations each change lands in —
- * because that is where the silence was.
+ * This checks the two pieces that are pure enough to verify without a browser:
+ *   1. the file-name <-> percent contract (JS writes it, Apex reads it back)
+ *   2. the source-bake name handling that the reload path depends on
+ * plus a routing simulation. Pixel-alpha correctness still needs a real canvas
+ * and is verified by hand.
  */
 
 let fail = 0;
@@ -29,106 +30,138 @@ const ok = (c, m) => {
     if (!c) fail++;
 };
 
-/**
- * Mirrors docGenAdmin.handleWatermarkOpacityChange.
- * Returns what the component does: 'stored-for-upload' | 'rebaked' | 'told-to-reupload'.
- */
+// --- 1. the file-name <-> percent contract -------------------------------------
+
+/** Mirrors docGenAdmin._watermarkFileName. */
+const watermarkFileName = (pct) => 'watermark-p' + (parseInt(pct, 10) || 100) + '.png';
+
+/** Mirrors DocGenController.WATERMARK_PCT_PATTERN = -p(\d{1,3})(?:\.|$) */
+const parsePct = (name) => {
+    const m = /-p(\d{1,3})(?:\.|$)/.exec(name || '');
+    return m ? parseInt(m[1], 10) : null;
+};
+
+console.log('\nthe wash the designer applied round-trips through the file name');
+for (const pct of ['15', '30', '50', '100']) {
+    const name = watermarkFileName(pct);
+    ok(parsePct(name) === parseInt(pct, 10), `${pct}% -> ${name} -> ${parsePct(name)}`);
+}
+ok(parsePct('legacy-logo.png') === null, 'a name with no encoded percent reads back null, not a guess');
+ok(parsePct('') === null, 'a blank name reads back null');
+ok(watermarkFileName('') === 'watermark-p100.png', 'a missing percent falls back to 100 (original)');
+
+// --- 2. the source bake must not need a File --------------------------------------
+// The reload path fetches the stored original as bytes and re-bakes it. The bug
+// this guards: _bakeWatermarkOpacity read `file.name` unconditionally, so a
+// nameless Blob threw a TypeError for every wash except 100%.
+
+/** Mirrors the name handling in docGenAdmin._bakeWatermarkOpacity. */
+const bakedBaseName = (file) => (file.name || 'watermark').replace(/\.[^.]+$/, '');
+
+console.log('\nre-baking from stored bytes (a nameless Blob) must not throw');
+ok(bakedBaseName({}) === 'watermark', 'a nameless blob yields a usable base name');
+ok(bakedBaseName({ name: 'logo.png' }) === 'logo', 'a named file still yields its own base name');
+
+// --- 3. routing simulation -------------------------------------------------------
+// A logic mirror of docGenAdmin.handleWatermarkOpacityChange — not the real code
+// (it needs a DOM). Returns which situation each change lands in.
+
 function onOpacityChange(state, pct) {
     state.watermarkOpacityPct = pct;
     if (!state.editTemplateWatermarkCvId) {
         return 'stored-for-upload';
     }
-    // In-session file first, then the source persisted at upload time. Only a
-    // watermark saved before #313 has neither.
+    if (state.isUploadingWatermark) {
+        return 'ignored-mid-flight';
+    }
     const source = state._watermarkSourceFile || state.storedSource;
     if (!source) {
         return 'told-to-reupload';
     }
-    // Re-bakes from the ORIGINAL, never from the stored (already-washed) image.
     state.bakedFrom = source;
     state.bakedAt = pct;
+    state.savedFileName = watermarkFileName(pct);
     return 'rebaked';
 }
 
-/** Mirrors the upload handler retaining the unbaked original. */
 function onUpload(state, file, cvId) {
     state.editTemplateWatermarkCvId = cvId;
     state._watermarkSourceFile = file;
-    state.storedSource = file; // persisted server-side as docgen_watermark_src_<versionId>
+    state.storedSource = file; // persisted as docgen_watermark_src_<versionId>
     state.bakedFrom = file;
     state.bakedAt = state.watermarkOpacityPct;
+    state.savedFileName = watermarkFileName(state.watermarkOpacityPct);
 }
 
 console.log('\nthe order that used to matter');
 {
-    // BEFORE upload — the case that always worked.
     const s = { watermarkOpacityPct: '30', editTemplateWatermarkCvId: null, _watermarkSourceFile: null };
     ok(onOpacityChange(s, '50') === 'stored-for-upload', 'changing it before upload just records the value');
     onUpload(s, 'logo.png', '068AAA');
-    ok(s.bakedAt === '50', 'and the upload bakes at that value');
+    ok(s.bakedAt === '50' && s.savedFileName === 'watermark-p50.png', 'and the upload bakes + names at that value');
 }
 {
-    // AFTER upload — the reported case.
     const s = { watermarkOpacityPct: '30', editTemplateWatermarkCvId: null, _watermarkSourceFile: null };
     onUpload(s, 'logo.png', '068AAA');
-    ok(s.bakedAt === '30', 'uploaded at 30%');
-    const outcome = onOpacityChange(s, '50');
-    ok(outcome === 'rebaked', 'changing it after upload now re-bakes rather than doing nothing silently');
-    ok(s.bakedAt === '50', 'and the stored image is at the new value');
+    ok(onOpacityChange(s, '50') === 'rebaked', 'changing it after upload now re-bakes instead of doing nothing');
+    ok(s.bakedAt === '50', 'the stored image is at the new value');
+    ok(s.savedFileName === 'watermark-p50.png', 'and the new file name records it for the next reload');
 }
 
-console.log('\nthe re-bake must start from the ORIGINAL, never the stored wash');
+console.log('\nthe re-bake starts from the ORIGINAL, never the stored wash');
 {
     const s = { watermarkOpacityPct: '30', editTemplateWatermarkCvId: null, _watermarkSourceFile: null };
     onUpload(s, 'logo.png', '068AAA');
     onOpacityChange(s, '50');
     ok(s.bakedFrom === 'logo.png', 'first change bakes from the original');
     onOpacityChange(s, '15');
-    ok(s.bakedFrom === 'logo.png', 'and so does the second — 30% of an already-30% image would be 9%');
-    ok(s.bakedAt === '15', 'ending at exactly what was asked for');
+    ok(s.bakedFrom === 'logo.png' && s.bakedAt === '15', 'so does the second — no 15%-of-50% compounding');
 }
 
 console.log('\nafter a page reload the stored original still drives the re-bake');
 {
-    // The in-session file is gone, but the source persisted at upload time is not.
+    // In-session file gone; the persisted source and the seeded percent remain.
+    const s = {
+        watermarkOpacityPct: String(parsePct('watermark-p50.png')), // seeded by getWatermarkOpacity
+        editTemplateWatermarkCvId: '068AAA',
+        _watermarkSourceFile: null,
+        storedSource: 'stored-bytes'
+    };
+    ok(s.watermarkOpacityPct === '50', 'the control seeds from the stored file name, not the default');
+    ok(onOpacityChange(s, '15') === 'rebaked', 'a reload no longer costs the author a re-upload');
+    ok(s.bakedFrom === 'stored-bytes', 'and it re-bakes from the stored ORIGINAL');
+}
+
+console.log('\na change mid re-bake is ignored, not queued or lost');
+{
     const s = {
         watermarkOpacityPct: '30',
         editTemplateWatermarkCvId: '068AAA',
-        _watermarkSourceFile: null,
-        storedSource: 'logo.png'
+        _watermarkSourceFile: 'logo.png',
+        isUploadingWatermark: true
     };
-    ok(onOpacityChange(s, '50') === 'rebaked', 'a reload no longer costs the author a re-upload');
-    ok(s.bakedFrom === 'logo.png', 'and it re-bakes from the stored ORIGINAL, not the washed image');
-    ok(s.bakedAt === '50', 'landing at exactly what was asked for');
+    ok(onOpacityChange(s, '50') === 'ignored-mid-flight', 'the select is disabled while a re-bake is in flight');
 }
 
 console.log('\nonly a pre-#313 watermark has no source, and that one says so');
 {
-    // Uploaded before the source was retained: nothing to re-bake from.
     const s = {
         watermarkOpacityPct: '30',
         editTemplateWatermarkCvId: '068AAA',
         _watermarkSourceFile: null,
         storedSource: null
     };
-    ok(
-        onOpacityChange(s, '50') === 'told-to-reupload',
-        'the author is told to re-upload rather than left thinking it applied'
-    );
+    ok(onOpacityChange(s, '50') === 'told-to-reupload', 'the author is told to re-upload rather than misled');
 }
 
 console.log('\nclearing the watermark forgets the original too');
 {
     const s = { watermarkOpacityPct: '30', editTemplateWatermarkCvId: null, _watermarkSourceFile: null };
     onUpload(s, 'logo.png', '068AAA');
-    // Mirrors handleClearWatermark.
     s.editTemplateWatermarkCvId = null;
     s._watermarkSourceFile = null;
-    s.storedSource = null;
-    ok(
-        onOpacityChange(s, '50') === 'stored-for-upload',
-        'after a clear it is back to recording the value for the next upload'
-    );
+    s.storedSource = null; // server drops docgen_watermark_src_<versionId>
+    ok(onOpacityChange(s, '50') === 'stored-for-upload', 'after a clear it is back to recording for the next upload');
 }
 
 console.log(fail ? `\n${fail} FAILED` : '\nwatermark opacity routing OK');


### PR DESCRIPTION
## Summary

Completes #313 — the watermark **Strength** control now takes effect after an image is uploaded, in the same session and after a page reload. Supersedes the closed #357 (`14f8862`, `20f4774`), which fixed only the in-session case and left a crash on the reload path plus lifecycle/security gaps.

## Changes

**The bug.** Opacity is baked into the watermark PNG's pixels at upload — Flying Saucer has no CSS opacity, so pre-multiplied alpha is the only thing that renders. Once an image was stored the dropdown had nothing to act on: it updated a field nobody read, silently. The reporter's workaround was to set the value *before* uploading.

**Fix.** The unbaked original is retained — in memory for the session and persisted as `docgen_watermark_src_<versionId>` — and a later change re-bakes the stored image *from that original* (re-washing the stored image would compound: 30% of an already-30% image is 9%).

Since #357:

- **Reload path no longer throws.** #357 fetched the stored original with `fetch('data:…')` → a nameless `Blob`; `_bakeWatermarkOpacity` read `file.name` unconditionally and threw a `TypeError` for every wash except 100%. Now decodes straight to a `Blob` (no `fetch` on a data URI, also awkward under LWS) and tolerates a missing name. — `docGenAdmin.js`
- **IDOR closed.** `getWatermarkSource` and the new `getWatermarkOpacity` enforce the same per-version access check as `saveWatermarkImage` (`assertWatermarkVersionAccess`) — reading another admin's watermark bytes by version Id was an unauthenticated read. — `DocGenController.cls`
- **No ContentVersion pile-up.** Each save sweeps the prior baked image + retained source (`purgePriorWatermarkFiles`), guarded against a baked CV another version still references. — `DocGenController.cls`
- **Version lifecycle.** Save-as-New-Version (`copyWatermarkSourceForward`) and cross-org export/import carry the source forward; **Clear Watermark** drops it. — `DocGenController.cls`
- **Control seeds from what's stored.** The wash is encoded into the baked file name (`watermark-p50.png`) and read back by `getWatermarkOpacity` on load, so the dropdown reflects the stored value after a reload instead of the default. — `DocGenController.cls`, `docGenAdmin.js`, `docGenAdmin.html`

**Scope.** Watermark-only reach. `saveTemplate` gets one gated, `try/catch`-wrapped call in the `createVersion` branch; `exportTemplate`/`importTemplate` gain one asset. The `DocGenService` watermark link pruner is unaffected. `processXml`, merge tags, the zero-heap PDF image path, and the Canvas designer are untouched.

## Testing

- [x] Ran E2E tests — n/a: watermark is a controller/LWC path, not parser (no `processXmlForTest` surface)
- [x] Ran Apex unit tests — `DocGenControllerTests` 248/248, `DocGenControllerCoverageTest` 29/29, `DocGenHtmlRendererTest`+`DocGenCanvasSaveTests` 137/137 (`docgen-verify`)
- [x] Tested manually in a scratch org — `scripts/qa/watermark-opacity-browser-check.mjs` drives the designer in Chromium (upload 30% → change 50% → reload → change 15%) and decodes the stored PNG: mean alpha **77 / 128 / 38** against a 255-opaque source (expected 76.5 / 127.5 / 38.25); source stays 255; 15% baked from the original, not the 50% wash
- [x] Added/updated test assertions for new behavior — 5 new `DocGenControllerTests`; reworked `watermark-opacity-route-check.mjs`; new `watermark-opacity-browser-check.mjs`

`npm run format:check` clean. Not covered, still manual on a namespaced install: `atob`/`Blob`/`URL.createObjectURL` under LWS.

## Related Issues

Closes #313
Supersedes #357

## Screenshots

Strength is a dropdown — behaviour, not appearance. Measured alpha values in Testing.

## Checklist

- [x] No hardcoded IDs, URLs, or credentials
- [x] No `VersionData` in PDF image queries — unchanged; `getWatermarkOpacity` selects only `PathOnClient`; `getWatermarkSource` selects `VersionData` for the designer's source-image download, not a render path
- [x] SOQL uses `WITH USER_MODE` or `Security.stripInaccessible()` where appropriate — internal-CV reads use the `DocGenFlsGuard` + `WITH SYSTEM_MODE` hybrid the class already uses for `docgen_*` files (the #114 `InternalUsers`-visibility quirk)
- [x] No new external dependencies introduced
