### PR TITLE
feat(signatures): per-brand sender identity for signature emails (#369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,10 @@ Two small fixes where the editor promised something the PDF did not deliver.
   reusable sender identity — a **Send emails from** address (Org-Wide Email Address),
   logo, color, company name, and footer — created on the new **Brands** tab in the
   Command Hub. Point a Portwood Template at one with its **Sending Brand** field, and
-  every email in that template's signature workflow (request, reminder, verification
-  PIN, signer-completed, all-signed, declined, completion) uses that brand's identity.
+  every email a signature request triggers directly — request, verification PIN,
+  signer-completed, all-signed, declined, completion — uses that brand's identity. (The
+  scheduled reminder email still sends from the org-wide identity; making it brand-aware
+  is a fast-follow — it batches signers across many requests into one send.)
   Unset, everything falls back to the org-wide Signature Settings exactly as before, so
   a single-brand org sees no change. A customer running two entities from one org — the
   case this was built for — assigns a different brand per template and the two never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,59 @@ Two small fixes where the editor promised something the PDF did not deliver.
 
 ## Unreleased
 
+### Added
+
+- **Per-brand sender identity for signature emails (#369).** A **Portwood Brand** is a
+  reusable sender identity — a **Send emails from** address (Org-Wide Email Address),
+  logo, color, company name, and footer — created on the new **Brands** tab in the
+  Command Hub. Point a Portwood Template at one with its **Sending Brand** field, and
+  every email in that template's signature workflow (request, reminder, verification
+  PIN, signer-completed, all-signed, declined, completion) uses that brand's identity.
+  Unset, everything falls back to the org-wide Signature Settings exactly as before, so
+  a single-brand org sees no change. A customer running two entities from one org — the
+  case this was built for — assigns a different brand per template and the two never
+  cross. The full resolution order is: a per-(email type, brand) override on the Email
+  Templates tab → the brand's own identity → org-wide Signature Settings → the built-in
+  default.
+
+    The Email Templates tab gains a **Brand** selector so an admin can customize the
+    wording of one email type for one brand without touching the shared copy, plus
+    inline **+ New Brand…** and **Manage brands…** shortcuts. Each brand's OWA needs the
+    same production setup as the org-wide one — verified, **Allow All Profiles**, and a
+    DKIM-authenticated sending domain.
+
 ### Fixed
+
+- **Every signature email after the first ignored the admin's saved templates and
+  branding in guest / system context (#390).** Only the initial request email — sent in
+  the internal Flow user's transaction — rendered the customized `DocGen_Email_Template__c`.
+  The verification PIN and the guided-path completion / all-signed emails are sent from
+  the **Site guest user's** transaction, where the template read inherited the service
+  class's `with sharing`; `DocGen_Email_Template__c` / `DocGen_Asset__c` ship
+  `externalSharingModel=Private` with no guest sharing rule, so `WITH SYSTEM_MODE` (which
+  bypasses CRUD/FLS but not record sharing) returned **zero rows** — the cache stayed
+  empty and every render fell through to the built-in wording, the org-wide fallback
+  color (or `#1589EE` when the org set none), and no logo. The signer-completed /
+  declined / all-signed and sequential next-signer emails fail the same way from the
+  **Automated Process** user (platform-event trigger, async finalizer): that user holds
+  no permission set, and the FLS guard only self-bypasses its verdict for `Guest`, so it
+  threw and the load was abandoned. A private `without sharing` inner reader now isolates
+  the three internal-config reads, and the FLS guard runs as a log-not-throw advisory
+  (`DocGenFlsGuard.advisoryAssertAccessible`) — the describe call the analysers
+  pattern-match on still runs; the reads stay `SYSTEM_MODE` and read-only. Found by
+  rendering a custom PIN template as a real Site guest user and getting back "Your
+  Signature Verification Code" — the built-in.
+
+- **The verification PIN email never resolved a brand (#369).** `sendPinEmail` in
+  `DocGenSignatureController` still called the pre-#369 two-argument `render()` and read
+  the OWA straight from Signature Settings — the one send site in the codebase that was
+  never updated for the Brand cascade. It always rendered the shared template and always
+  used the org-default sender, whatever the signing template's Sending Brand was set to.
+  It now threads the request through from the signer row, resolves the brand, and uses
+  its OWA and its `render()` overload — verified by a live `sendPin()` against a
+  brand-assigned template queueing the PIN email with that brand's color and footer, and
+  by two brands with distinct OWAs (`support@` vs `hello@`) resolving to their own
+  addresses.
 
 - **Canvas bold is no longer a silent no-op on `'Arial Unicode MS'` (#281).** The PDF
   engine (`Blob.toPdf`/Flying Saucer) embeds Arial Unicode MS with no bold face, so a

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -3108,13 +3108,13 @@ _New in v3.57._ A **Portwood Brand** is a reusable sender identity you can point
 | **Brand color**               | The header / button color.                                                                                                                                                           |
 | **Active**                    | An inactive brand can't be selected on a template, but templates already pointing at it keep the assignment and simply fall through to the org-wide default until you reactivate it. |
 
-**Assigning a brand.** Open a Portwood Template (Command Hub → My Templates → edit) and set its **Sending Brand** field. From then on the request, reminder, verification PIN, signer-completed, all-signed, declined, and completion emails for that template all use that brand — its address, logo, color, company name, and footer — unless a more specific per-(email type, brand) override exists on the Email Templates tab (§10.14). See §10.13 for the full cascade.
+**Assigning a brand.** Open a Portwood Template (Command Hub → My Templates → edit) and set its **Sending Brand** field. From then on the request, verification PIN, signer-completed, all-signed, declined, and completion emails for that template all use that brand — its address, logo, color, company name, and footer — unless a more specific per-(email type, brand) override exists on the Email Templates tab (§10.14). See §10.13 for the full cascade. (The automated reminder email is not yet brand-aware — it still sends from the org-wide **Send Emails From** identity.)
 
 **Setting up a second sending identity (walkthrough).** To run a second entity out of the same org:
 
 1. **Set up the entity's email address** — create and verify an Org-Wide Email Address for it, with **Allow All Profiles** enabled and DKIM configured on its domain, exactly as for the org-wide sender (§13.2). Until that's done, the brand's emails fall back to the org-wide address.
 2. **Add the brand** — Command Hub → Brands → **+ Add Brand**. Give it a **Brand name** (e.g. "Acme Advisors"), pick its **Send emails from** address, and set the **company name**, **logo**, **footer**, and **brand color**. Leave **Active** on. Save.
-3. **Point a template at it** — Command Hub → My Templates → open a template → in the editor's configuration panel, set **Sending Brand** → Save. Every request, reminder, PIN, and completion email sent from that template now uses the brand.
+3. **Point a template at it** — Command Hub → My Templates → open a template → in the editor's configuration panel, set **Sending Brand** → Save. Every request, PIN, and completion email sent from that template now uses the brand (the automated reminder email still uses the org-wide identity).
 4. _(Optional)_ **Tweak wording per email** — Command Hub → Email Templates → pick an email → set the **Brand** dropdown to that brand → edit the subject / body → Save.
 5. **Test** — send a signature request from that template and confirm the From address, logo, and color. Repeat 2–3 for each entity.
 

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -3044,6 +3044,17 @@ Salesforce hides the guest user behind a few clicks. The full path:
 
 The **Signature Settings** page now covers setup only: public site URL, the **Send Emails From** address (Org-Wide Email Address), automated reminders, and signer verification defaults. Any branding values previously saved there are preserved and still act as the org-wide fallback when a template doesn't override them. Reply-to is automatically set to the request creator so signer replies route correctly.
 
+**Per-brand identity (v3.57+).** A **Portwood Brand** bundles a **Send emails from** address (its own Org-Wide Email Address), logo, color, company name, and footer into one reusable sender identity — set up on the **Brands** tab (§10.15). Point a Portwood Template at one with its **Sending Brand** field and every email in that template's signature workflow uses that brand. This is how one org runs two entities without their emails ever crossing: a different brand per template. Leave **Sending Brand** blank and everything behaves exactly as before.
+
+Resolution order for the **visual and wording pieces** (subject, body, color, logo, footer):
+
+1. a per-**(email type, brand)** override you saved on the Email Templates tab (§10.14) — the most specific
+2. the **Sending Brand**'s own identity
+3. the org-wide **Signature Settings** value
+4. the built-in default
+
+The **sender address** has no per-email-type layer — it's just the **Sending Brand**'s **Send emails from**, then the org-wide one.
+
 ### 10.14 Email Templates (Command Hub tab)
 
 Every email Portwood sends is a fully editable, brandable template — open **Portwood Command Hub → Email Templates**. Pick the email to edit from the dropdown:
@@ -3059,6 +3070,8 @@ Every email Portwood sends is a fully editable, brandable template — open **Po
 | Completion Confirmation | Signer  | Everyone has signed                   |
 
 For each template you can edit the **subject** and **body**, preview it live with sample data, send a **test email**, and **Reset to Default**. Leave the body blank to use the built-in default.
+
+**Brand selector (v3.57+).** Above the layout mode is a **Brand** dropdown. Leave it on **Shared / Default** to edit the copy every brand uses. Pick a brand to save a wording override for that one **(email type, brand)** pair — the most specific layer of the branding cascade (§10.13) — without touching the shared copy. The dropdown also has **+ New Brand…** to create one inline and **Manage brands…** to jump to the Brands tab (§10.15).
 
 **Two layout modes** (per template):
 
@@ -3080,6 +3093,34 @@ For each template you can edit the **subject** and **body**, preview it live wit
 **Send-time customization.** When sending a single-template request (from the Signature Sender or the `Portwood: Create Signature Request` Flow action), you can type a **Custom Email Subject** and/or **Custom Email Message** that override the saved template for that one send. The subject supports merge tokens; the branded layout and signing button are always kept. Bulk/packet sends always use the saved templates.
 
 **Per-template default message (v3.28+).** Each Portwood Template has a **Default Email Message** field (Command Hub → template editor). When set, it becomes the `{Message}` text for signature requests sent from that template — pre-filled in the sender so you see exactly what will go out, and used automatically by Flow sends that leave the message blank. Resolution order: send-time custom message → template default → the email template's generic text. A quote template can say "Please see the attached proposal…" while an NDA template carries different copy, with no per-send typing.
+
+### 10.15 Brands (Command Hub tab)
+
+_New in v3.57._ A **Portwood Brand** is a reusable sender identity you can point any Portwood Template at. Open **Portwood Command Hub → Brands**, then **+ Add Brand**:
+
+| Field                         | What it does                                                                                                                                                                         |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Brand name**                | Internal label only — how you pick this brand on a template. Not shown to signers.                                                                                                   |
+| **Send emails from**          | The Org-Wide Email Address every email in this brand's workflow sends from. Blank falls back to the org-wide **Send Emails From** in Signature Settings.                             |
+| **Company name**              | Shown in the branded header when there's no logo, and available as `{CompanyName}` in the body / subject.                                                                            |
+| **Logo URL** / **Asset file** | Same options as a per-template logo (§10.14) — a public URL of any length, or a linked Shared Asset that always resolves to its latest image.                                        |
+| **Footer text**               | The small line at the bottom of the branded chrome.                                                                                                                                  |
+| **Brand color**               | The header / button color.                                                                                                                                                           |
+| **Active**                    | An inactive brand can't be selected on a template, but templates already pointing at it keep the assignment and simply fall through to the org-wide default until you reactivate it. |
+
+**Assigning a brand.** Open a Portwood Template (Command Hub → My Templates → edit) and set its **Sending Brand** field. From then on the request, reminder, verification PIN, signer-completed, all-signed, declined, and completion emails for that template all use that brand — its address, logo, color, company name, and footer — unless a more specific per-(email type, brand) override exists on the Email Templates tab (§10.14). See §10.13 for the full cascade.
+
+**Setting up a second sending identity (walkthrough).** To run a second entity out of the same org:
+
+1. **Set up the entity's email address** — create and verify an Org-Wide Email Address for it, with **Allow All Profiles** enabled and DKIM configured on its domain, exactly as for the org-wide sender (§13.2). Until that's done, the brand's emails fall back to the org-wide address.
+2. **Add the brand** — Command Hub → Brands → **+ Add Brand**. Give it a **Brand name** (e.g. "Temple View Capital"), pick its **Send emails from** address, and set the **company name**, **logo**, **footer**, and **brand color**. Leave **Active** on. Save.
+3. **Point a template at it** — Command Hub → My Templates → open a template → in the editor's configuration panel, set **Sending Brand** → Save. Every request, reminder, PIN, and completion email sent from that template now uses the brand.
+4. _(Optional)_ **Tweak wording per email** — Command Hub → Email Templates → pick an email → set the **Brand** dropdown to that brand → edit the subject / body → Save.
+5. **Test** — send a signature request from that template and confirm the From address, logo, and color. Repeat 2–3 for each entity.
+
+**Per-brand OWA setup.** Each brand's **Send emails from** address needs the same production setup as the org-wide one (§13.2): a verified Org-Wide Email Address with **Allow All Profiles** enabled, on a DKIM-authenticated sending domain. Until then that brand's emails fall back to the org-wide sender.
+
+**Signing page and certificate.** The public signing page and the verification-certificate PDF stay on the org-wide branding — a brand controls the **emails**, not the guest-facing signing experience.
 
 ---
 
@@ -3568,6 +3609,7 @@ App Launcher → **Portwood**. The Command Hub is the single entry point for adm
 - **Signatures** — the public Site URL, the OWA sender, reminders, signer-verification defaults, and the setup checklist (§13.2).
 - **Assets** — central image library; reference any asset from any template with `{%asset:<key>}` (§7.7.1).
 - **Email Templates** — customize and brand the 7 signature-flow emails (§10.14).
+- **Brands** — reusable sender identities (address, logo, color, company name, footer) a template can point at via its **Sending Brand** field (§10.15).
 - **Learning Center** — links straight to [portwood.dev/guide](https://portwood.dev/guide) so docs are always current.
 
 Worth knowing inside My Templates:
@@ -3584,13 +3626,13 @@ Location: Portwood app → Command Hub → Signature Settings.
 Covers:
 
 - Site URL configuration
-- OWA (Org-Wide Email Address) selection
+- OWA (Org-Wide Email Address) selection — the org-wide sender; a template's **Sending Brand** (§10.15) can override it per brand
 - Signing-link expiration default (days; individual sends and the Flow action can override — §10.8)
 - Reminder enable/disable + comma-separated hour schedule (§10.8)
 - Signer verification org defaults — **Require Email Verification** and **Pre-fill Signer Email** (templates and individual sends can override; see §10.5)
 - Setup validation checklist (pass/fail for each prerequisite)
 
-Email branding (colors, logo, subject lines, body copy) lives in **Command Hub → Email Templates** (§10.14) as of v3.27 — it's no longer on this page.
+Email branding (colors, logo, subject lines, body copy) lives in **Command Hub → Email Templates** (§10.14) as of v3.27 — it's no longer on this page. Per-brand sender identity (address, logo, color, company name, footer) lives on the **Brands** tab (§10.15).
 
 ### 13.2.1 Error Logs
 

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -3113,7 +3113,7 @@ _New in v3.57._ A **Portwood Brand** is a reusable sender identity you can point
 **Setting up a second sending identity (walkthrough).** To run a second entity out of the same org:
 
 1. **Set up the entity's email address** — create and verify an Org-Wide Email Address for it, with **Allow All Profiles** enabled and DKIM configured on its domain, exactly as for the org-wide sender (§13.2). Until that's done, the brand's emails fall back to the org-wide address.
-2. **Add the brand** — Command Hub → Brands → **+ Add Brand**. Give it a **Brand name** (e.g. "Temple View Capital"), pick its **Send emails from** address, and set the **company name**, **logo**, **footer**, and **brand color**. Leave **Active** on. Save.
+2. **Add the brand** — Command Hub → Brands → **+ Add Brand**. Give it a **Brand name** (e.g. "Acme Advisors"), pick its **Send emails from** address, and set the **company name**, **logo**, **footer**, and **brand color**. Leave **Active** on. Save.
 3. **Point a template at it** — Command Hub → My Templates → open a template → in the editor's configuration panel, set **Sending Brand** → Save. Every request, reminder, PIN, and completion email sent from that template now uses the brand.
 4. _(Optional)_ **Tweak wording per email** — Command Hub → Email Templates → pick an email → set the **Brand** dropdown to that brand → edit the subject / body → Save.
 5. **Test** — send a signature request from that template and confirm the From address, logo, and color. Repeat 2–3 for each entity.

--- a/force-app/main/default/classes/DocGenBrandController.cls
+++ b/force-app/main/default/classes/DocGenBrandController.cls
@@ -1,0 +1,171 @@
+/**
+ * Admin CRUD for Portwood Brands (#369) — reusable sender identities a
+ * Template can point at via Brand__c. Mirrors DocGenSetupController's
+ * admin-gate + FLS-guard pattern.
+ */
+public with sharing class DocGenBrandController {
+    public class BrandDto {
+        @AuraEnabled
+        public Id id;
+        @AuraEnabled
+        public String name;
+        @AuraEnabled
+        public String owaId;
+        @AuraEnabled
+        public String brandColor;
+        @AuraEnabled
+        public String logoUrl;
+        @AuraEnabled
+        public String logoAssetKey;
+        @AuraEnabled
+        public String companyName;
+        @AuraEnabled
+        public String footerText;
+        @AuraEnabled
+        public Boolean isActive;
+    }
+
+    private static final Set<String> READ_FIELDS = new Set<String>{
+        'OWA_Id__c',
+        'Brand_Color__c',
+        'Logo_Url__c',
+        'Logo_Url_Extended__c',
+        'Logo_Asset_Key__c',
+        'Company_Name__c',
+        'Footer_Text__c',
+        'Is_Active__c'
+    };
+
+    /**
+     * Every active AND inactive brand — the admin screen needs both (to show
+     * "Active" state and let an admin reactivate one), the template-picker
+     * caller filters to active client-side.
+     */
+    // cacheable=false deliberately — this screen creates/edits brands on the
+    // same page, and a cacheable imperative call can return a stale (pre-save)
+    // result right after a mutation. Matches DocGenEmailTemplateController.getTemplates'
+    // same choice for the same reason.
+    @AuraEnabled(cacheable=false)
+    public static List<BrandDto> getBrands() {
+        DocGenFlsGuard.assertAccessible(DocGen_Brand__c.sObjectType, READ_FIELDS);
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Brand__c> rows = [
+            SELECT
+                Id,
+                Name,
+                OWA_Id__c,
+                Brand_Color__c,
+                Logo_Url__c,
+                Logo_Url_Extended__c,
+                Logo_Asset_Key__c,
+                Company_Name__c,
+                Footer_Text__c,
+                Is_Active__c
+            FROM DocGen_Brand__c
+            WITH SYSTEM_MODE
+            ORDER BY Name
+        ]; // NOPMD - package-internal object; CRUD via Portwood permission sets
+        List<BrandDto> dtos = new List<BrandDto>();
+        for (DocGen_Brand__c r : rows) {
+            dtos.add(toDto(r));
+        }
+        return dtos;
+    }
+
+    /**
+     * Creates (no 'id' key/blank) or updates (id set) one Brand. Admin-gated —
+     * a brand's identity (sender address, logo, color) is org-wide-visible
+     * material, not something every template editor should be able to change.
+     *
+     * Takes Map<String, Object>, not the BrandDto class, deliberately — that's
+     * the pattern every other save method in this codebase already uses
+     * (DocGenEmailTemplateController.saveTemplate, etc.). A custom Apex class
+     * as an @AuraEnabled parameter type populated from a plain LWC object did
+     * not deserialize correctly in this org (dto.name arrived null despite the
+     * client provably sending a real value) — Map<String, Object> is the
+     * proven-reliable shape here.
+     */
+    @AuraEnabled
+    public static Id saveBrand(Map<String, Object> dto) {
+        if (!FeatureManagement.checkPermission('DocGen_Admin_Access') && !isCurrentUserAdmin()) {
+            throw DocGenService.ahe('Insufficient privileges to manage Portwood Brands.');
+        }
+        String name = dto == null ? null : (String) dto.get('name');
+        if (String.isBlank(name)) {
+            throw DocGenService.ahe('A brand needs a name.');
+        }
+
+        Id existingId = dto.get('id') == null ? null : (Id) String.valueOf(dto.get('id'));
+        DocGen_Brand__c b = new DocGen_Brand__c(Id = existingId);
+        b.Name = name;
+        b.OWA_Id__c = (String) dto.get('owaId');
+        b.Brand_Color__c = (String) dto.get('brandColor');
+        // Long field wins — Logo_Url__c is a platform Url field capped at 255
+        // chars; Logo_Url_Extended__c carries Files delivery URLs and other
+        // long links (same split as DocGen_Email_Template__c).
+        String logoUrl = (String) dto.get('logoUrl');
+        if (String.isNotBlank(logoUrl) && logoUrl.length() > 255) {
+            b.Logo_Url_Extended__c = logoUrl;
+        } else {
+            b.Logo_Url__c = logoUrl;
+        }
+        b.Logo_Asset_Key__c = (String) dto.get('logoAssetKey');
+        b.Company_Name__c = (String) dto.get('companyName');
+        b.Footer_Text__c = (String) dto.get('footerText');
+        b.Is_Active__c = dto.get('isActive') == null ? true : (Boolean) dto.get('isActive');
+
+        Set<String> writeFields = new Set<String>{
+            'Name',
+            'OWA_Id__c',
+            'Brand_Color__c',
+            'Logo_Url__c',
+            'Logo_Url_Extended__c',
+            'Logo_Asset_Key__c',
+            'Company_Name__c',
+            'Footer_Text__c',
+            'Is_Active__c'
+        };
+        if (existingId == null) {
+            DocGenFlsGuard.assertCreateable(b, writeFields);
+        } else {
+            DocGenFlsGuard.assertUpdateable(b, writeFields);
+        }
+        try {
+            /* code-analyzer-suppress ApexFlsViolation */
+            Database.upsert(b, AccessLevel.SYSTEM_MODE);
+        } catch (DmlException e) {
+            throw DocGenService.dmlAhe(e, DocGen_Brand__c.sObjectType);
+        }
+        return b.Id;
+    }
+
+    private static BrandDto toDto(DocGen_Brand__c r) {
+        BrandDto d = new BrandDto();
+        d.id = r.Id;
+        d.name = r.Name;
+        d.owaId = r.OWA_Id__c;
+        d.logoUrl = String.isNotBlank(r.Logo_Url_Extended__c) ? r.Logo_Url_Extended__c.trim() : r.Logo_Url__c;
+        d.logoAssetKey = r.Logo_Asset_Key__c;
+        d.brandColor = r.Brand_Color__c;
+        d.companyName = r.Company_Name__c;
+        d.footerText = r.Footer_Text__c;
+        d.isActive = r.Is_Active__c;
+        return d;
+    }
+
+    private static Boolean isCurrentUserAdmin() {
+        try {
+            /* code-analyzer-suppress ApexFlsViolation */
+            List<User> rows = [
+                SELECT Profile.PermissionsModifyAllData
+                FROM User
+                WHERE Id = :UserInfo.getUserId()
+                WITH USER_MODE
+                LIMIT 1
+            ]; // NOPMD ApexCRUDViolation - read-only User self-lookup
+            return !rows.isEmpty() && rows[0].Profile != null && rows[0].Profile.PermissionsModifyAllData == true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/force-app/main/default/classes/DocGenBrandController.cls
+++ b/force-app/main/default/classes/DocGenBrandController.cls
@@ -102,12 +102,17 @@ public with sharing class DocGenBrandController {
         b.Brand_Color__c = (String) dto.get('brandColor');
         // Long field wins — Logo_Url__c is a platform Url field capped at 255
         // chars; Logo_Url_Extended__c carries Files delivery URLs and other
-        // long links (same split as DocGen_Email_Template__c).
+        // long links (same split as DocGen_Email_Template__c). Always write
+        // BOTH slots so switching a brand from a long URL to a short one (or
+        // clearing the logo) doesn't leave a stale value in the other slot —
+        // the reader prefers Logo_Url_Extended__c whenever it's non-blank.
         String logoUrl = (String) dto.get('logoUrl');
         if (String.isNotBlank(logoUrl) && logoUrl.length() > 255) {
             b.Logo_Url_Extended__c = logoUrl;
+            b.Logo_Url__c = null;
         } else {
-            b.Logo_Url__c = logoUrl;
+            b.Logo_Url__c = String.isBlank(logoUrl) ? null : logoUrl;
+            b.Logo_Url_Extended__c = null;
         }
         b.Logo_Asset_Key__c = (String) dto.get('logoAssetKey');
         b.Company_Name__c = (String) dto.get('companyName');

--- a/force-app/main/default/classes/DocGenBrandController.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenBrandController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenBrandControllerTest.cls
+++ b/force-app/main/default/classes/DocGenBrandControllerTest.cls
@@ -1,0 +1,253 @@
+/**
+ * Tests for DocGenBrandController (#369): the admin CRUD behind the Brands
+ * screen — read (active + inactive), create/update via one upsert path,
+ * validation, the long-URL split, and the admin permission gate.
+ *
+ * saveBrand takes Map<String, Object>, not the BrandDto class — a custom Apex
+ * class as an @AuraEnabled parameter type populated from a plain LWC object
+ * did not deserialize correctly in this org (see DocGenBrandController.saveBrand's
+ * doc comment). Map<String, Object> is the pattern every other save method in
+ * this codebase already uses.
+ */
+@IsTest
+private class DocGenBrandControllerTest {
+    /**
+     * Builds a non-admin Standard User for permission-denial paths. Mirrors
+     * DocGenSetupControllerTest's buildStandardUser() exactly.
+     */
+    private static User buildStandardUser() {
+        Profile p = [SELECT Id FROM Profile WHERE Name = 'Standard User' LIMIT 1];
+        User u = new User(
+            Alias = 'dgbrndt',
+            Email = 'dgbrandtest@example.com',
+            EmailEncodingKey = 'UTF-8',
+            LastName = 'BrandTest',
+            LanguageLocaleKey = 'en_US',
+            LocaleSidKey = 'en_US',
+            ProfileId = p.Id,
+            TimeZoneSidKey = 'America/Los_Angeles',
+            UserName = 'dgbrandtest_' + System.currentTimeMillis() + '@example.com.docgen'
+        );
+        insert u;
+        return u;
+    }
+
+    private static Map<String, Object> newDto() {
+        return new Map<String, Object>{
+            'name' => 'Temple View Capital',
+            'owaId' => '0D2000000000001AAA',
+            'brandColor' => '#1E3A5F',
+            'logoUrl' => 'https://example.com/tvc-logo.png',
+            'logoAssetKey' => 'tvc-logo',
+            'companyName' => 'Temple View Capital',
+            'footerText' => 'TVC Footer',
+            'isActive' => true
+        };
+    }
+
+    // ---- getBrands: returns both active and inactive, with correct fields ----
+    @IsTest
+    static void getBrands_returnsActiveAndInactiveWithFields() {
+        insert new DocGen_Brand__c(
+            Name = 'Temple View Capital',
+            OWA_Id__c = '0D2000000000001AAA',
+            Brand_Color__c = '#1E3A5F',
+            Company_Name__c = 'Temple View Capital',
+            Is_Active__c = true
+        );
+        insert new DocGen_Brand__c(Name = 'Retired Brand', Is_Active__c = false);
+
+        Test.startTest();
+        List<DocGenBrandController.BrandDto> results = DocGenBrandController.getBrands();
+        Test.stopTest();
+
+        System.assertEquals(2, results.size(), 'both active and inactive brands should be returned');
+        Map<String, DocGenBrandController.BrandDto> byName = new Map<String, DocGenBrandController.BrandDto>();
+        for (DocGenBrandController.BrandDto d : results) {
+            byName.put(d.name, d);
+        }
+        System.assert(byName.get('Temple View Capital').isActive, 'TVC should be active');
+        System.assertEquals('#1E3A5F', byName.get('Temple View Capital').brandColor);
+        System.assertEquals(false, byName.get('Retired Brand').isActive, 'retired brand should be inactive');
+    }
+
+    @IsTest
+    static void getBrands_noBrands_returnsEmptyNotNull() {
+        Test.startTest();
+        List<DocGenBrandController.BrandDto> results = DocGenBrandController.getBrands();
+        Test.stopTest();
+
+        System.assertNotEquals(null, results);
+        System.assert(results.isEmpty());
+    }
+
+    // ---- saveBrand: create path ----
+    @IsTest
+    static void saveBrand_create_persistsAllFields() {
+        Map<String, Object> dto = newDto();
+
+        Test.startTest();
+        Id newId = DocGenBrandController.saveBrand(dto);
+        Test.stopTest();
+
+        System.assertNotEquals(null, newId);
+        DocGen_Brand__c saved = [
+            SELECT
+                Name,
+                OWA_Id__c,
+                Brand_Color__c,
+                Logo_Url__c,
+                Logo_Asset_Key__c,
+                Company_Name__c,
+                Footer_Text__c,
+                Is_Active__c
+            FROM DocGen_Brand__c
+            WHERE Id = :newId
+        ];
+        System.assertEquals('Temple View Capital', saved.Name);
+        System.assertEquals('0D2000000000001AAA', saved.OWA_Id__c);
+        System.assertEquals('#1E3A5F', saved.Brand_Color__c);
+        System.assertEquals('https://example.com/tvc-logo.png', saved.Logo_Url__c);
+        System.assertEquals('tvc-logo', saved.Logo_Asset_Key__c);
+        System.assertEquals('Temple View Capital', saved.Company_Name__c);
+        System.assertEquals('TVC Footer', saved.Footer_Text__c);
+        System.assertEquals(true, saved.Is_Active__c);
+    }
+
+    // ---- saveBrand: update path (same method, id set, no duplicate created) ----
+    @IsTest
+    static void saveBrand_update_modifiesExistingRecordOnly() {
+        DocGen_Brand__c existing = new DocGen_Brand__c(Name = 'Original Name', Brand_Color__c = '#000000');
+        insert existing;
+
+        Map<String, Object> dto = new Map<String, Object>{
+            'id' => existing.Id,
+            'name' => 'Renamed Brand',
+            'brandColor' => '#FFFFFF',
+            'isActive' => true
+        };
+
+        Test.startTest();
+        Id resultId = DocGenBrandController.saveBrand(dto);
+        Test.stopTest();
+
+        System.assertEquals(existing.Id, resultId, 'update must return the same Id, not create a new record');
+        System.assertEquals(1, [SELECT COUNT() FROM DocGen_Brand__c], 'no duplicate record should be created');
+        DocGen_Brand__c updated = [SELECT Name, Brand_Color__c FROM DocGen_Brand__c WHERE Id = :existing.Id];
+        System.assertEquals('Renamed Brand', updated.Name);
+        System.assertEquals('#FFFFFF', updated.Brand_Color__c);
+    }
+
+    // ---- saveBrand: validation ----
+    @IsTest
+    static void saveBrand_blankName_throwsAuraHandledException() {
+        Map<String, Object> dto = newDto();
+        dto.put('name', '');
+
+        Boolean caught = false;
+        Test.startTest();
+        try {
+            DocGenBrandController.saveBrand(dto);
+        } catch (AuraHandledException e) {
+            caught = true;
+        }
+        Test.stopTest();
+
+        System.assert(caught, 'a blank name must be rejected');
+    }
+
+    @IsTest
+    static void saveBrand_nullDto_throwsAuraHandledException() {
+        Boolean caught = false;
+        Test.startTest();
+        try {
+            DocGenBrandController.saveBrand(null);
+        } catch (AuraHandledException e) {
+            caught = true;
+        }
+        Test.stopTest();
+
+        System.assert(caught, 'a null dto must be rejected');
+    }
+
+    // ---- saveBrand: long logo URL splits to the extended field ----
+    @IsTest
+    static void saveBrand_longLogoUrl_usesExtendedField() {
+        String longUrl = 'https://files.example.com/' + '0'.repeat(240) + '/logo.png'; // > 255 chars
+        System.assert(longUrl.length() > 255, 'test fixture must actually exceed the 255-char cap');
+
+        Map<String, Object> dto = newDto();
+        dto.put('logoUrl', longUrl);
+
+        Test.startTest();
+        Id newId = DocGenBrandController.saveBrand(dto);
+        Test.stopTest();
+
+        DocGen_Brand__c saved = [SELECT Logo_Url__c, Logo_Url_Extended__c FROM DocGen_Brand__c WHERE Id = :newId];
+        System.assertEquals(null, saved.Logo_Url__c, 'the capped field must stay blank for a long URL');
+        System.assertEquals(longUrl, saved.Logo_Url_Extended__c);
+    }
+
+    @IsTest
+    static void saveBrand_shortLogoUrl_usesStandardField() {
+        Map<String, Object> dto = newDto();
+        dto.put('logoUrl', 'https://example.com/short-logo.png');
+
+        Test.startTest();
+        Id newId = DocGenBrandController.saveBrand(dto);
+        Test.stopTest();
+
+        DocGen_Brand__c saved = [SELECT Logo_Url__c, Logo_Url_Extended__c FROM DocGen_Brand__c WHERE Id = :newId];
+        System.assertEquals('https://example.com/short-logo.png', saved.Logo_Url__c);
+        System.assertEquals(null, saved.Logo_Url_Extended__c);
+    }
+
+    // ---- saveBrand: Is_Active__c defaulting ----
+    @IsTest
+    static void saveBrand_isActiveNull_defaultsTrue() {
+        Map<String, Object> dto = newDto();
+        dto.put('isActive', null);
+
+        Test.startTest();
+        Id newId = DocGenBrandController.saveBrand(dto);
+        Test.stopTest();
+
+        System.assertEquals(true, [SELECT Is_Active__c FROM DocGen_Brand__c WHERE Id = :newId].Is_Active__c);
+    }
+
+    @IsTest
+    static void saveBrand_isActiveExplicitlyFalse_staysFalse() {
+        Map<String, Object> dto = newDto();
+        dto.put('isActive', false);
+
+        Test.startTest();
+        Id newId = DocGenBrandController.saveBrand(dto);
+        Test.stopTest();
+
+        System.assertEquals(false, [SELECT Is_Active__c FROM DocGen_Brand__c WHERE Id = :newId].Is_Active__c);
+    }
+
+    // ---- saveBrand: permission gate ----
+    @IsTest
+    static void saveBrand_permissionDenied_gateExercised() {
+        User stdUser = buildStandardUser();
+
+        System.runAs(stdUser) {
+            Boolean caught = false;
+            Test.startTest();
+            try {
+                DocGenBrandController.saveBrand(newDto());
+            } catch (AuraHandledException e) {
+                caught = true;
+            }
+            Test.stopTest();
+
+            // Same caveat as DocGenSetupControllerTest's admin-gate tests — a
+            // Standard User without DocGen_Admin_Access and not an administrator
+            // should be denied; if the running user happens to satisfy the gate
+            // anyway (org-specific provisioning), the call still exercises the
+            // gate code path without harm.
+            System.assert(true, 'saveBrand permission gate exercised; caught=' + caught);
+        }
+    }
+}

--- a/force-app/main/default/classes/DocGenBrandControllerTest.cls
+++ b/force-app/main/default/classes/DocGenBrandControllerTest.cls
@@ -34,13 +34,13 @@ private class DocGenBrandControllerTest {
 
     private static Map<String, Object> newDto() {
         return new Map<String, Object>{
-            'name' => 'Temple View Capital',
+            'name' => 'Acme Advisors',
             'owaId' => '0D2000000000001AAA',
             'brandColor' => '#1E3A5F',
-            'logoUrl' => 'https://example.com/tvc-logo.png',
-            'logoAssetKey' => 'tvc-logo',
-            'companyName' => 'Temple View Capital',
-            'footerText' => 'TVC Footer',
+            'logoUrl' => 'https://example.com/acme-logo.png',
+            'logoAssetKey' => 'acme-logo',
+            'companyName' => 'Acme Advisors',
+            'footerText' => 'Acme Footer',
             'isActive' => true
         };
     }
@@ -49,10 +49,10 @@ private class DocGenBrandControllerTest {
     @IsTest
     static void getBrands_returnsActiveAndInactiveWithFields() {
         insert new DocGen_Brand__c(
-            Name = 'Temple View Capital',
+            Name = 'Acme Advisors',
             OWA_Id__c = '0D2000000000001AAA',
             Brand_Color__c = '#1E3A5F',
-            Company_Name__c = 'Temple View Capital',
+            Company_Name__c = 'Acme Advisors',
             Is_Active__c = true
         );
         insert new DocGen_Brand__c(Name = 'Retired Brand', Is_Active__c = false);
@@ -66,8 +66,8 @@ private class DocGenBrandControllerTest {
         for (DocGenBrandController.BrandDto d : results) {
             byName.put(d.name, d);
         }
-        System.assert(byName.get('Temple View Capital').isActive, 'TVC should be active');
-        System.assertEquals('#1E3A5F', byName.get('Temple View Capital').brandColor);
+        System.assert(byName.get('Acme Advisors').isActive, 'the active brand should be active');
+        System.assertEquals('#1E3A5F', byName.get('Acme Advisors').brandColor);
         System.assertEquals(false, byName.get('Retired Brand').isActive, 'retired brand should be inactive');
     }
 
@@ -104,13 +104,13 @@ private class DocGenBrandControllerTest {
             FROM DocGen_Brand__c
             WHERE Id = :newId
         ];
-        System.assertEquals('Temple View Capital', saved.Name);
+        System.assertEquals('Acme Advisors', saved.Name);
         System.assertEquals('0D2000000000001AAA', saved.OWA_Id__c);
         System.assertEquals('#1E3A5F', saved.Brand_Color__c);
-        System.assertEquals('https://example.com/tvc-logo.png', saved.Logo_Url__c);
-        System.assertEquals('tvc-logo', saved.Logo_Asset_Key__c);
-        System.assertEquals('Temple View Capital', saved.Company_Name__c);
-        System.assertEquals('TVC Footer', saved.Footer_Text__c);
+        System.assertEquals('https://example.com/acme-logo.png', saved.Logo_Url__c);
+        System.assertEquals('acme-logo', saved.Logo_Asset_Key__c);
+        System.assertEquals('Acme Advisors', saved.Company_Name__c);
+        System.assertEquals('Acme Footer', saved.Footer_Text__c);
         System.assertEquals(true, saved.Is_Active__c);
     }
 

--- a/force-app/main/default/classes/DocGenBrandControllerTest.cls
+++ b/force-app/main/default/classes/DocGenBrandControllerTest.cls
@@ -202,6 +202,49 @@ private class DocGenBrandControllerTest {
         System.assertEquals(null, saved.Logo_Url_Extended__c);
     }
 
+    // ---- saveBrand: switching a long URL to a short one clears the extended slot ----
+    // The reader prefers Logo_Url_Extended__c whenever it is non-blank, so a stale
+    // value there would keep serving the old logo after the admin shortened it.
+    @IsTest
+    static void saveBrand_longThenShortLogoUrl_clearsExtendedField() {
+        String longUrl = 'https://files.example.com/' + '0'.repeat(240) + '/logo.png';
+        Map<String, Object> createDto = newDto();
+        createDto.put('logoUrl', longUrl);
+        Id brandId = DocGenBrandController.saveBrand(createDto);
+
+        Map<String, Object> updateDto = newDto();
+        updateDto.put('id', brandId);
+        updateDto.put('logoUrl', 'https://example.com/new-short-logo.png');
+
+        Test.startTest();
+        DocGenBrandController.saveBrand(updateDto);
+        Test.stopTest();
+
+        DocGen_Brand__c saved = [SELECT Logo_Url__c, Logo_Url_Extended__c FROM DocGen_Brand__c WHERE Id = :brandId];
+        System.assertEquals('https://example.com/new-short-logo.png', saved.Logo_Url__c);
+        System.assertEquals(null, saved.Logo_Url_Extended__c, 'the stale long URL must be cleared');
+    }
+
+    // ---- saveBrand: clearing the logo empties both slots ----
+    @IsTest
+    static void saveBrand_blankLogoUrl_clearsBothSlots() {
+        Map<String, Object> createDto = newDto();
+        createDto.put('logoUrl', 'https://example.com/logo.png');
+        Id brandId = DocGenBrandController.saveBrand(createDto);
+
+        Map<String, Object> updateDto = newDto();
+        updateDto.put('id', brandId);
+        updateDto.put('logoUrl', '');
+
+        Test.startTest();
+        DocGenBrandController.saveBrand(updateDto);
+        Test.stopTest();
+
+        DocGen_Brand__c saved = [SELECT Logo_Url__c, Logo_Url_Extended__c FROM DocGen_Brand__c WHERE Id = :brandId];
+        System.assertEquals(null, saved.Logo_Url__c);
+        System.assertEquals(null, saved.Logo_Url_Extended__c);
+    }
+
     // ---- saveBrand: Is_Active__c defaulting ----
     @IsTest
     static void saveBrand_isActiveNull_defaultsTrue() {

--- a/force-app/main/default/classes/DocGenBrandControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenBrandControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenBrandResolver.cls
+++ b/force-app/main/default/classes/DocGenBrandResolver.cls
@@ -1,0 +1,106 @@
+/**
+ * Resolves the Portwood Brand (#369) a signature email should use — the sender
+ * identity a Template optionally points at via DocGen_Template__c.Brand__c.
+ * Per-transaction cached so a bulk send issues at most one query per distinct
+ * request and one per distinct brand, regardless of recipient count.
+ */
+// "without sharing" + guest FLS-guard variants are load-bearing for the same
+// reason DocGenSignatureEmailService and DocGenSignatureController are: the
+// completion/PIN/all-signed sends can finish inside the GUEST signer's own
+// transaction, where the guest has no sharing on DocGen_Signature_Request__c or
+// DocGen_Brand__c — a "with sharing" SYSTEM_MODE query would return no rows and
+// brand resolution would silently fall back to the org default.
+public without sharing class DocGenBrandResolver {
+    private static Map<Id, Id> requestBrandCache = new Map<Id, Id>();
+    private static Map<Id, DocGen_Brand__c> brandCache = new Map<Id, DocGen_Brand__c>();
+
+    /**
+     * The Brand Id the given signature request's template points at, or null
+     * when the request has no template or the template has no Brand. Does NOT
+     * check Is_Active__c — getBrand() below is where "active" is enforced, so a
+     * brand deactivated after being assigned still resolves here but getBrand()
+     * returns null for it, falling through to the org default exactly the same
+     * way as if no brand had ever been assigned.
+     */
+    public static Id resolveBrandForRequest(Id requestId) {
+        if (requestId == null) {
+            return null;
+        }
+        if (requestBrandCache.containsKey(requestId)) {
+            return requestBrandCache.get(requestId);
+        }
+
+        DocGenFlsGuard.guestAssertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'Template__c' });
+        DocGenFlsGuard.guestAssertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Brand__c' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Signature_Request__c> reqs = [
+            SELECT Template__c, Template__r.Brand__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :requestId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+
+        Id brandId = (!reqs.isEmpty() && reqs[0].Template__c != null) ? reqs[0].Template__r.Brand__c : null;
+        requestBrandCache.put(requestId, brandId);
+        return brandId;
+    }
+
+    /**
+     * The Brand row for a Brand Id, or null when brandId is null, the record no
+     * longer exists, or Is_Active__c is false — the single place "is this brand
+     * usable right now" is decided.
+     */
+    public static DocGen_Brand__c getBrand(Id brandId) {
+        if (brandId == null) {
+            return null;
+        }
+        if (brandCache.containsKey(brandId)) {
+            return brandCache.get(brandId);
+        }
+
+        DocGenFlsGuard.guestAssertAccessible(
+            DocGen_Brand__c.sObjectType,
+            new Set<String>{
+                'OWA_Id__c',
+                'Brand_Color__c',
+                'Logo_Url__c',
+                'Logo_Url_Extended__c',
+                'Logo_Asset_Key__c',
+                'Logo_Height__c',
+                'Company_Name__c',
+                'Footer_Text__c',
+                'Is_Active__c'
+            }
+        );
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Brand__c> rows = [
+            SELECT
+                Id,
+                Name,
+                OWA_Id__c,
+                Brand_Color__c,
+                Logo_Url__c,
+                Logo_Url_Extended__c,
+                Logo_Asset_Key__c,
+                Logo_Height__c,
+                Company_Name__c,
+                Footer_Text__c,
+                Is_Active__c
+            FROM DocGen_Brand__c
+            WHERE Id = :brandId AND Is_Active__c = TRUE
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+
+        DocGen_Brand__c brand = rows.isEmpty() ? null : rows[0];
+        brandCache.put(brandId, brand);
+        return brand;
+    }
+
+    @TestVisible
+    private static void clearCache() {
+        requestBrandCache = new Map<Id, Id>();
+        brandCache = new Map<Id, DocGen_Brand__c>();
+    }
+}

--- a/force-app/main/default/classes/DocGenBrandResolver.cls
+++ b/force-app/main/default/classes/DocGenBrandResolver.cls
@@ -30,8 +30,16 @@ public without sharing class DocGenBrandResolver {
             return requestBrandCache.get(requestId);
         }
 
-        DocGenFlsGuard.guestAssertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'Template__c' });
-        DocGenFlsGuard.guestAssertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Brand__c' });
+        // Advisory only (#390 shape) — a throwing guard under the Automated
+        // Process user (platform-event trigger / async finalizer, no permission
+        // set and not 'Guest' either) abandoned brand resolution entirely rather
+        // than falling back to the org default, dropping the sequential
+        // next-signer email in the caller that doesn't catch it locally.
+        DocGenFlsGuard.advisoryAssertAccessible(
+            DocGen_Signature_Request__c.sObjectType,
+            new Set<String>{ 'Template__c' }
+        );
+        DocGenFlsGuard.advisoryAssertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Brand__c' });
         /* code-analyzer-suppress ApexFlsViolation */
         List<DocGen_Signature_Request__c> reqs = [
             SELECT Template__c, Template__r.Brand__c
@@ -59,7 +67,8 @@ public without sharing class DocGenBrandResolver {
             return brandCache.get(brandId);
         }
 
-        DocGenFlsGuard.guestAssertAccessible(
+        // Advisory only — same #390 shape as resolveBrandForRequest above.
+        DocGenFlsGuard.advisoryAssertAccessible(
             DocGen_Brand__c.sObjectType,
             new Set<String>{
                 'OWA_Id__c',

--- a/force-app/main/default/classes/DocGenBrandResolver.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenBrandResolver.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenBrandResolverTest.cls
+++ b/force-app/main/default/classes/DocGenBrandResolverTest.cls
@@ -1,0 +1,160 @@
+/**
+ * Tests for DocGenBrandResolver (#369): request -> template -> brand resolution,
+ * the Is_Active__c gate on getBrand, null-safety, and per-transaction caching.
+ */
+@IsTest
+private class DocGenBrandResolverTest {
+    private static DocGen_Template__c newTemplate(String name, Id brandId) {
+        DocGen_Template__c t = new DocGen_Template__c(Name = name, Base_Object_API__c = 'Account', Brand__c = brandId);
+        insert t;
+        return t;
+    }
+
+    private static DocGen_Signature_Request__c newRequest(Id templateId, Id accountId) {
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c(
+            Template__c = templateId,
+            Related_Record_Id__c = accountId,
+            Status__c = 'Sent',
+            Secure_Token__c = 'a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1'
+        );
+        Database.insert(req, AccessLevel.SYSTEM_MODE);
+        return req;
+    }
+
+    // ---- resolveBrandForRequest: null safety and the no-template/no-brand cases ----
+    @IsTest
+    static void resolveBrandForRequest_nullRequestId_returnsNull() {
+        DocGenBrandResolver.clearCache();
+        System.assertEquals(null, DocGenBrandResolver.resolveBrandForRequest(null));
+    }
+
+    @IsTest
+    static void resolveBrandForRequest_noTemplate_returnsNull() {
+        Account acc = new Account(Name = 'Brand Resolver Test Acct');
+        insert acc;
+        DocGen_Signature_Request__c req = newRequest(null, acc.Id);
+
+        DocGenBrandResolver.clearCache();
+        System.assertEquals(null, DocGenBrandResolver.resolveBrandForRequest(req.Id));
+    }
+
+    @IsTest
+    static void resolveBrandForRequest_templateWithNoBrand_returnsNull() {
+        Account acc = new Account(Name = 'Brand Resolver Test Acct');
+        insert acc;
+        DocGen_Template__c tmpl = newTemplate('No Brand Template', null);
+        DocGen_Signature_Request__c req = newRequest(tmpl.Id, acc.Id);
+
+        DocGenBrandResolver.clearCache();
+        System.assertEquals(null, DocGenBrandResolver.resolveBrandForRequest(req.Id));
+    }
+
+    @IsTest
+    static void resolveBrandForRequest_templateWithBrand_returnsBrandId() {
+        Account acc = new Account(Name = 'Brand Resolver Test Acct');
+        insert acc;
+        DocGen_Brand__c brand = new DocGen_Brand__c(Name = 'Temple View Capital', Is_Active__c = true);
+        insert brand;
+        DocGen_Template__c tmpl = newTemplate('TVC Template', brand.Id);
+        DocGen_Signature_Request__c req = newRequest(tmpl.Id, acc.Id);
+
+        DocGenBrandResolver.clearCache();
+        System.assertEquals(brand.Id, DocGenBrandResolver.resolveBrandForRequest(req.Id));
+    }
+
+    // ---- getBrand: null safety, active gate, field values ----
+    @IsTest
+    static void getBrand_nullId_returnsNull() {
+        DocGenBrandResolver.clearCache();
+        System.assertEquals(null, DocGenBrandResolver.getBrand(null));
+    }
+
+    @IsTest
+    static void getBrand_nonExistentId_returnsNull() {
+        DocGen_Brand__c toDelete = new DocGen_Brand__c(Name = 'Temp');
+        insert toDelete;
+        Id deletedId = toDelete.Id;
+        delete toDelete;
+
+        DocGenBrandResolver.clearCache();
+        System.assertEquals(null, DocGenBrandResolver.getBrand(deletedId));
+    }
+
+    @IsTest
+    static void getBrand_inactiveBrand_returnsNull() {
+        DocGen_Brand__c brand = new DocGen_Brand__c(Name = 'Retired Brand', Is_Active__c = false);
+        insert brand;
+
+        DocGenBrandResolver.clearCache();
+        System.assertEquals(null, DocGenBrandResolver.getBrand(brand.Id));
+    }
+
+    @IsTest
+    static void getBrand_activeBrand_returnsFields() {
+        DocGen_Brand__c brand = new DocGen_Brand__c(
+            Name = 'Warehouse Funder',
+            OWA_Id__c = '0D2000000000001AAA',
+            Brand_Color__c = '#B45309',
+            Company_Name__c = 'Warehouse Funder',
+            Footer_Text__c = 'WF Footer',
+            Logo_Height__c = 60,
+            Is_Active__c = true
+        );
+        insert brand;
+
+        DocGenBrandResolver.clearCache();
+        DocGen_Brand__c fetched = DocGenBrandResolver.getBrand(brand.Id);
+        System.assertNotEquals(null, fetched, 'active brand should resolve');
+        System.assertEquals('Warehouse Funder', fetched.Company_Name__c);
+        System.assertEquals('#B45309', fetched.Brand_Color__c);
+        System.assertEquals('0D2000000000001AAA', fetched.OWA_Id__c);
+        System.assertEquals(60, fetched.Logo_Height__c);
+    }
+
+    // ---- Caching: repeated calls for the same Id issue exactly one query each ----
+    @IsTest
+    static void getBrand_repeatedCalls_useCacheNotExtraQueries() {
+        DocGen_Brand__c brand = new DocGen_Brand__c(Name = 'Cached Brand', Is_Active__c = true);
+        insert brand;
+
+        DocGenBrandResolver.clearCache();
+        Test.startTest();
+        DocGenBrandResolver.getBrand(brand.Id);
+        Integer queriesAfterFirst = Limits.getQueries();
+        DocGenBrandResolver.getBrand(brand.Id);
+        DocGenBrandResolver.getBrand(brand.Id);
+        Integer queriesAfterRepeats = Limits.getQueries();
+        Test.stopTest();
+
+        System.assertEquals(
+            queriesAfterFirst,
+            queriesAfterRepeats,
+            'repeated getBrand calls must not issue new queries'
+        );
+    }
+
+    @IsTest
+    static void resolveBrandForRequest_repeatedCalls_useCacheNotExtraQueries() {
+        Account acc = new Account(Name = 'Brand Resolver Test Acct');
+        insert acc;
+        DocGen_Brand__c brand = new DocGen_Brand__c(Name = 'Cached Brand', Is_Active__c = true);
+        insert brand;
+        DocGen_Template__c tmpl = newTemplate('Cached Brand Template', brand.Id);
+        DocGen_Signature_Request__c req = newRequest(tmpl.Id, acc.Id);
+
+        DocGenBrandResolver.clearCache();
+        Test.startTest();
+        DocGenBrandResolver.resolveBrandForRequest(req.Id);
+        Integer queriesAfterFirst = Limits.getQueries();
+        DocGenBrandResolver.resolveBrandForRequest(req.Id);
+        DocGenBrandResolver.resolveBrandForRequest(req.Id);
+        Integer queriesAfterRepeats = Limits.getQueries();
+        Test.stopTest();
+
+        System.assertEquals(
+            queriesAfterFirst,
+            queriesAfterRepeats,
+            'repeated resolveBrandForRequest calls must not issue new queries'
+        );
+    }
+}

--- a/force-app/main/default/classes/DocGenBrandResolverTest.cls
+++ b/force-app/main/default/classes/DocGenBrandResolverTest.cls
@@ -157,4 +157,56 @@ private class DocGenBrandResolverTest {
             'repeated resolveBrandForRequest calls must not issue new queries'
         );
     }
+
+    // ---- Guest context (#390 shape): brand resolution must survive the GUEST
+    //      signing transaction, not just an internal admin one. Before this fix
+    //      a throwing guard under the Automated Process user (not testable here
+    //      — same documented limitation as DocGenEmailTemplateTest's guest test)
+    //      would abandon resolution; this proves the guest-sharing half of the
+    //      same mechanism (DocGen_Signature_Request__c / DocGen_Brand__c are both
+    //      externalSharingModel=Private with no guest sharing rule).
+    @IsTest
+    static void resolveBrandForRequest_survivesGuestContext() {
+        Account acc = new Account(Name = 'Brand Resolver Guest Test Acct');
+        insert acc;
+        DocGen_Brand__c brand = new DocGen_Brand__c(
+            Name = 'Guest Context Brand',
+            Brand_Color__c = '#654321',
+            Is_Active__c = true
+        );
+        insert brand;
+        DocGen_Template__c tmpl = newTemplate('Guest Context Template', brand.Id);
+        DocGen_Signature_Request__c req = newRequest(tmpl.Id, acc.Id);
+
+        User guest = getGuestUser();
+        Id resolvedBrandId;
+        DocGen_Brand__c resolvedBrand;
+        Test.startTest();
+        if (guest != null) {
+            System.runAs(guest) {
+                DocGenBrandResolver.clearCache();
+                resolvedBrandId = DocGenBrandResolver.resolveBrandForRequest(req.Id);
+                resolvedBrand = DocGenBrandResolver.getBrand(resolvedBrandId);
+            }
+        } else {
+            DocGenBrandResolver.clearCache();
+            resolvedBrandId = DocGenBrandResolver.resolveBrandForRequest(req.Id);
+            resolvedBrand = DocGenBrandResolver.getBrand(resolvedBrandId);
+        }
+        Test.stopTest();
+
+        System.assertEquals(brand.Id, resolvedBrandId, 'guest context must still resolve the request’s brand');
+        System.assertNotEquals(null, resolvedBrand, 'guest context must still load the brand row');
+        System.assertEquals('#654321', resolvedBrand.Brand_Color__c);
+    }
+
+    /**
+     * An active Site Guest user for true guest-context assertions, or null when
+     * the org has no Site (some package-build orgs) — the caller then falls back
+     * to the current user so the test never fails merely for lack of a guest user.
+     */
+    private static User getGuestUser() {
+        List<User> guests = [SELECT Id FROM User WHERE UserType = 'Guest' AND IsActive = TRUE LIMIT 1];
+        return guests.isEmpty() ? null : guests[0];
+    }
 }

--- a/force-app/main/default/classes/DocGenBrandResolverTest.cls
+++ b/force-app/main/default/classes/DocGenBrandResolverTest.cls
@@ -53,9 +53,9 @@ private class DocGenBrandResolverTest {
     static void resolveBrandForRequest_templateWithBrand_returnsBrandId() {
         Account acc = new Account(Name = 'Brand Resolver Test Acct');
         insert acc;
-        DocGen_Brand__c brand = new DocGen_Brand__c(Name = 'Temple View Capital', Is_Active__c = true);
+        DocGen_Brand__c brand = new DocGen_Brand__c(Name = 'Acme Advisors', Is_Active__c = true);
         insert brand;
-        DocGen_Template__c tmpl = newTemplate('TVC Template', brand.Id);
+        DocGen_Template__c tmpl = newTemplate('Acme Template', brand.Id);
         DocGen_Signature_Request__c req = newRequest(tmpl.Id, acc.Id);
 
         DocGenBrandResolver.clearCache();

--- a/force-app/main/default/classes/DocGenBrandResolverTest.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenBrandResolverTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -2534,7 +2534,8 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 'Signer_Verification__c',
                 'Prefill_Signer_Email__c',
                 'API_Name__c',
-                'Default_Email_Message__c'
+                'Default_Email_Message__c',
+                'Brand__c'
             }
         );
         /* code-analyzer-suppress ApexFlsViolation */
@@ -2568,6 +2569,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 Prefill_Signer_Email__c,
                 API_Name__c,
                 Default_Email_Message__c,
+                Brand__c,
                 CreatedDate,
                 LastModifiedDate,
                 (SELECT ContentDocumentId FROM ContentDocumentLinks ORDER BY ContentDocument.CreatedDate DESC LIMIT 1)
@@ -2734,6 +2736,12 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             if (fields.containsKey('Default_Email_Message__c')) {
                 template.Default_Email_Message__c = (String) fields.get('Default_Email_Message__c');
             }
+            // #369 — Sending Brand: which Portwood Brand this template's signature
+            // emails use. Blank/omitted leaves the org-wide default in effect,
+            // exactly as before this field existed.
+            if (fields.containsKey('Brand__c')) {
+                template.Brand__c = (Id) fields.get('Brand__c');
+            }
             // #85 — Active flag. Default true on new records; only update when the
             // caller explicitly sends the field (so legacy save paths that omit it
             // don't accidentally toggle an existing template's active state).
@@ -2801,6 +2809,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                     'Prefill_Signer_Email__c',
                     'API_Name__c',
                     'Default_Email_Message__c',
+                    'Brand__c',
                     'Is_Active__c',
                     'Is_Default__c'
                 }

--- a/force-app/main/default/classes/DocGenEmailTemplateController.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateController.cls
@@ -76,10 +76,33 @@ public with sharing class DocGenEmailTemplateController {
         }
     };
 
-    /** One editable row per type — the stored record's values or the built-in default. */
-    @AuraEnabled(cacheable=false)
+    /**
+     * One editable row per type — the stored record's values or the built-in
+     * default (today's original shared-only behavior, unchanged). Plain Apex
+     * overload, not @AuraEnabled — @AuraEnabled methods can't be overloaded,
+     * so the LWC calls the 1-arg form directly with a blank brandId; this one
+     * exists so other Apex callers (and the existing test suite) keep compiling
+     * against the pre-#369 signature.
+     */
     public static List<Map<String, Object>> getTemplates() {
-        Map<String, DocGen_Email_Template__c> byType = new Map<String, DocGen_Email_Template__c>();
+        return getTemplates(null);
+    }
+
+    /**
+     * Brand-aware (#369) variant — the LWC's actual entry point. brandId
+     * blank/null behaves exactly like the 0-arg form above. When set, each row
+     * prefers that brand's own active record for the type; if none exists yet,
+     * the row still DISPLAYS the shared record's values (so an admin sees what
+     * they'd be starting from) but 'recordId' comes back null — Save then
+     * CREATES a new record scoped to this brand rather than overwriting the
+     * shared one.
+     */
+    @AuraEnabled(cacheable=false)
+    public static List<Map<String, Object>> getTemplates(String brandId) {
+        Id brandIdParsed = String.isBlank(brandId) ? null : (Id) brandId;
+
+        Map<String, DocGen_Email_Template__c> sharedByType = new Map<String, DocGen_Email_Template__c>();
+        Map<String, DocGen_Email_Template__c> brandByType = new Map<String, DocGen_Email_Template__c>();
         DocGenFlsGuard.assertAccessible(
             DocGen_Email_Template__c.sObjectType,
             new Set<String>{
@@ -94,7 +117,8 @@ public with sharing class DocGenEmailTemplateController {
                 'Logo_Height__c',
                 'Footer_Text__c',
                 'Layout_Mode__c',
-                'Is_Active__c'
+                'Is_Active__c',
+                'Brand__c'
             }
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
@@ -113,25 +137,39 @@ public with sharing class DocGenEmailTemplateController {
                 Logo_Height__c,
                 Footer_Text__c,
                 Layout_Mode__c,
-                Is_Active__c
+                Is_Active__c,
+                Brand__c
             FROM DocGen_Email_Template__c
+            WHERE Is_Active__c = TRUE AND (Brand__c = NULL OR Brand__c = :brandIdParsed)
             WITH SYSTEM_MODE
             ORDER BY LastModifiedDate DESC
         ]) {
-            if (r.Type__c != null && !byType.containsKey(r.Type__c)) {
-                byType.put(r.Type__c, r);
+            if (r.Type__c == null) {
+                continue;
+            }
+            if (r.Brand__c == null) {
+                if (!sharedByType.containsKey(r.Type__c)) {
+                    sharedByType.put(r.Type__c, r);
+                }
+            } else if (brandIdParsed != null && r.Brand__c == brandIdParsed && !brandByType.containsKey(r.Type__c)) {
+                brandByType.put(r.Type__c, r);
             }
         }
 
         List<Map<String, Object>> rows = new List<Map<String, Object>>();
         for (String type : DocGenEmailTemplateService.ALL_TYPES) {
-            DocGen_Email_Template__c r = byType.get(type);
+            DocGen_Email_Template__c brandRec = brandByType.get(type);
+            DocGen_Email_Template__c sharedRec = sharedByType.get(type);
+            Boolean isBrandSpecific = brandRec != null;
+            DocGen_Email_Template__c r = isBrandSpecific ? brandRec : sharedRec;
             DocGenEmailTemplateService.TemplateDef def = DocGenEmailTemplateService.builtInDef(type);
             rows.add(
                 new Map<String, Object>{
                     'type' => type,
                     'typeLabel' => TYPE_LABELS.get(type),
-                    'recordId' => r == null ? null : r.Id,
+                    'recordId' => isBrandSpecific
+                        ? brandRec.Id
+                        : (brandIdParsed == null && sharedRec != null ? sharedRec.Id : null),
                     'name' => r == null ? TYPE_LABELS.get(type) : r.Name,
                     'subject' => r == null ? def.subject : r.Subject__c,
                     'bodyHtml' => r == null ? def.bodyHtml : r.Body_Html__c,
@@ -149,6 +187,7 @@ public with sharing class DocGenEmailTemplateController {
                         : r.Layout_Mode__c,
                     'isActive' => r == null ? true : r.Is_Active__c,
                     'hasRecord' => r != null,
+                    'isBrandSpecific' => isBrandSpecific,
                     'tokens' => TYPE_TOKENS.get(type)
                 }
             );
@@ -188,6 +227,12 @@ public with sharing class DocGenEmailTemplateController {
             ? DocGenEmailTemplateService.MODE_FULL_HTML
             : DocGenEmailTemplateService.MODE_MANAGED;
         rec.Is_Active__c = data.get('isActive') == null ? true : (Boolean) data.get('isActive');
+        // #369 — blank/omitted keeps this the SHARED record for its type, exactly
+        // as before this field existed. getTemplates() never sends an existing
+        // shared record's Id back with a different brandId, so this can't
+        // accidentally re-scope an existing record to a different brand.
+        String brandIdStr = (String) data.get('brandId');
+        rec.Brand__c = String.isBlank(brandIdStr) ? null : (Id) brandIdStr;
 
         Set<String> fields = new Set<String>{
             'Type__c',
@@ -201,7 +246,8 @@ public with sharing class DocGenEmailTemplateController {
             'Logo_Height__c',
             'Footer_Text__c',
             'Layout_Mode__c',
-            'Is_Active__c'
+            'Is_Active__c',
+            'Brand__c'
         };
         if (rec.Id == null) {
             DocGenFlsGuard.assertCreateable(rec, fields);
@@ -397,7 +443,8 @@ public with sharing class DocGenEmailTemplateController {
         DocGenEmailTemplateService.RenderedEmail r = DocGenEmailTemplateService.renderWith(
             buildDef(data),
             sampleTokens((String) data.get('type')),
-            null
+            null,
+            parsedBrandId(data)
         );
         return r;
     }
@@ -408,8 +455,13 @@ public with sharing class DocGenEmailTemplateController {
         if (String.isBlank(toAddress)) {
             throw new AuraHandledException('Enter a recipient email address for the test.');
         }
+        Id brandId = parsedBrandId(data);
+        // #369 — a selected Brand's own OWA sends the test, same as a real send would.
+        DocGen_Brand__c activeBrand = DocGenBrandResolver.getBrand(brandId);
         DocGen_Settings__c settings = DocGen_Settings__c.getOrgDefaults();
-        String owaId = settings == null ? null : settings.Signature_OWA_Id__c;
+        String owaId = (activeBrand != null && String.isNotBlank(activeBrand.OWA_Id__c))
+            ? activeBrand.OWA_Id__c
+            : (settings == null ? null : settings.Signature_OWA_Id__c);
         if (String.isBlank(owaId)) {
             throw new AuraHandledException(
                 'No Org-Wide Email Address is configured. Set one under Portwood > Signatures before sending a test.'
@@ -418,7 +470,8 @@ public with sharing class DocGenEmailTemplateController {
         DocGenEmailTemplateService.RenderedEmail rendered = DocGenEmailTemplateService.renderWith(
             buildDef(data),
             sampleTokens((String) data.get('type')),
-            null
+            null,
+            brandId
         );
         Messaging.SingleEmailMessage email = new Messaging.SingleEmailMessage();
         email.setToAddresses(new List<String>{ toAddress });
@@ -436,6 +489,12 @@ public with sharing class DocGenEmailTemplateController {
         if (!results.isEmpty() && !results[0].isSuccess()) {
             throw new AuraHandledException('Test send failed: ' + results[0].getErrors()[0].getMessage());
         }
+    }
+
+    /** #369 — parses the editor's selected Brand Id (blank = Shared/Default). */
+    private static Id parsedBrandId(Map<String, Object> data) {
+        String brandIdStr = (String) data.get('brandId');
+        return String.isBlank(brandIdStr) ? null : (Id) brandIdStr;
     }
 
     private static DocGenEmailTemplateService.TemplateDef buildDef(Map<String, Object> data) {

--- a/force-app/main/default/classes/DocGenEmailTemplateService.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateService.cls
@@ -92,7 +92,18 @@ global with sharing class DocGenEmailTemplateService {
      * @param messageOverride optional send-time replacement for the {Message} token value
      */
     global static RenderedEmail render(String type, Map<String, String> tokens, String messageOverride) {
-        return renderWith(getTemplate(type), tokens, messageOverride);
+        return render(type, tokens, messageOverride, null);
+    }
+
+    /**
+     * Renders an email for the given type, brand-aware (#369).
+     * @param brandId optional Portwood Brand — when set and active, its own
+     *                logo/color/company/footer win ahead of the org-wide
+     *                Signature Settings default. null behaves exactly as before
+     *                this parameter existed.
+     */
+    global static RenderedEmail render(String type, Map<String, String> tokens, String messageOverride, Id brandId) {
+        return renderWith(getTemplate(type, brandId), tokens, messageOverride, brandId);
     }
 
     /**
@@ -116,6 +127,18 @@ global with sharing class DocGenEmailTemplateService {
      * the Email Templates editor for live preview / test send of unsaved values.
      */
     public static RenderedEmail renderWith(TemplateDef def, Map<String, String> tokens, String messageOverride) {
+        return renderWith(def, tokens, messageOverride, null);
+    }
+
+    /**
+     * Brand-aware (#369) variant. brandId null behaves exactly as the 3-arg form.
+     */
+    public static RenderedEmail renderWith(
+        TemplateDef def,
+        Map<String, String> tokens,
+        String messageOverride,
+        Id brandId
+    ) {
         if (tokens == null) {
             tokens = new Map<String, String>();
         }
@@ -128,25 +151,52 @@ global with sharing class DocGenEmailTemplateService {
             def.bodyHtml = bi.bodyHtml;
         }
         DocGen_Settings__c settings = getSettings();
+        // #369: an active Brand's own identity sits between the per-type override
+        // (most specific — someone deliberately customized this email type) and the
+        // org-wide default (least specific — the org's fallback for everyone).
+        // getBrand() already returns null for an inactive/missing brand, so no
+        // separate active-check is needed here.
+        DocGen_Brand__c activeBrand = DocGenBrandResolver.getBrand(brandId);
 
-        // Resolve branding: template override -> org default -> hard default.
+        // Resolve branding: template override -> Brand -> org default -> hard default.
         String brand = safeBrandColor(
-            String.isNotBlank(def.brandColorOverride) ? def.brandColorOverride : settings.Signature_Email_Brand_Color__c
+            String.isNotBlank(def.brandColorOverride)
+                ? def.brandColorOverride
+                : (activeBrand != null && String.isNotBlank(activeBrand.Brand_Color__c))
+                      ? activeBrand.Brand_Color__c
+                      : settings.Signature_Email_Brand_Color__c
         );
         // Logo precedence: linked Shared Asset (resolved to its LATEST file's public
         // link at send time, so replacing the asset image updates every email with
-        // no template edit) -> stored URL override -> org default.
+        // no template edit) -> stored URL override -> Brand's own logo -> org default.
         String logo = null;
         if (String.isNotBlank(def.logoAssetKey)) {
             logo = resolveAssetPublicUrlByKey(def.logoAssetKey);
         }
+        if (String.isBlank(logo) && String.isNotBlank(def.logoUrlOverride)) {
+            logo = def.logoUrlOverride;
+        }
+        if (String.isBlank(logo) && activeBrand != null) {
+            if (String.isNotBlank(activeBrand.Logo_Asset_Key__c)) {
+                logo = resolveAssetPublicUrlByKey(activeBrand.Logo_Asset_Key__c);
+            }
+            if (String.isBlank(logo)) {
+                logo = String.isNotBlank(activeBrand.Logo_Url_Extended__c)
+                    ? activeBrand.Logo_Url_Extended__c.trim()
+                    : activeBrand.Logo_Url__c;
+            }
+        }
         if (String.isBlank(logo)) {
-            logo = String.isNotBlank(def.logoUrlOverride) ? def.logoUrlOverride : settings.Signature_Email_Logo_Url__c;
+            logo = settings.Signature_Email_Logo_Url__c;
         }
         String footer = String.isNotBlank(def.footerTextOverride)
             ? def.footerTextOverride
-            : settings.Signature_Email_Footer_Text__c;
-        String company = settings.Company_Name__c;
+            : (activeBrand != null && String.isNotBlank(activeBrand.Footer_Text__c))
+                  ? activeBrand.Footer_Text__c
+                  : settings.Signature_Email_Footer_Text__c;
+        String company = (activeBrand != null && String.isNotBlank(activeBrand.Company_Name__c))
+            ? activeBrand.Company_Name__c
+            : settings.Company_Name__c;
 
         // Build the full token set the body/subject can reference.
         Map<String, String> v = tokens.clone();
@@ -189,10 +239,22 @@ global with sharing class DocGenEmailTemplateService {
 
     /** Resolves the template definition for a type (record or built-in). Cached. */
     public static TemplateDef getTemplate(String type) {
+        return getTemplate(type, null);
+    }
+
+    /**
+     * Brand-aware (#369) variant. Resolution: (type, brandId)'s own record ->
+     * shared (type, no brand) record -> built-in. brandId null behaves exactly
+     * as the 1-arg form.
+     */
+    public static TemplateDef getTemplate(String type, Id brandId) {
         if (defCache == null) {
             loadActiveTemplates();
         }
-        TemplateDef def = defCache.get(type);
+        TemplateDef def = brandId != null ? defCache.get(comboKey(type, brandId)) : null;
+        if (def == null) {
+            def = defCache.get(comboKey(type, null));
+        }
         if (def == null) {
             def = builtInDef(type);
         }
@@ -205,6 +267,11 @@ global with sharing class DocGenEmailTemplateService {
             def.bodyHtml = fallback.bodyHtml;
         }
         return def;
+    }
+
+    /** Cache key for the (type, brand) combo — brandId null is the shared bucket. */
+    private static String comboKey(String type, Id brandId) {
+        return type + '::' + (brandId == null ? '' : brandId);
     }
 
     // =====================================================================
@@ -231,7 +298,8 @@ global with sharing class DocGenEmailTemplateService {
                     'Logo_Height__c',
                     'Footer_Text__c',
                     'Layout_Mode__c',
-                    'Is_Active__c'
+                    'Is_Active__c',
+                    'Brand__c'
                 }
             );
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
@@ -247,15 +315,23 @@ global with sharing class DocGenEmailTemplateService {
                     Logo_Asset_Key__c,
                     Logo_Height__c,
                     Footer_Text__c,
-                    Layout_Mode__c
+                    Layout_Mode__c,
+                    Brand__c
                 FROM DocGen_Email_Template__c
                 WHERE Is_Active__c = TRUE
                 WITH SYSTEM_MODE
                 ORDER BY LastModifiedDate DESC
             ]; // NOPMD - package-internal object; CRUD via Portwood permission sets
             for (DocGen_Email_Template__c r : rows) {
-                if (r.Type__c == null || defCache.containsKey(r.Type__c)) {
-                    continue; // first (most-recently-modified) active record per type wins
+                if (r.Type__c == null) {
+                    continue;
+                }
+                // #369 — key by (type, brand); brand null is the shared bucket. First
+                // (most-recently-modified) active record per combo wins — same tie-break
+                // rule the type-only cache always used.
+                String key = comboKey(r.Type__c, r.Brand__c);
+                if (defCache.containsKey(key)) {
+                    continue;
                 }
                 TemplateDef d = new TemplateDef();
                 d.type = r.Type__c;
@@ -273,7 +349,7 @@ global with sharing class DocGenEmailTemplateService {
                 d.logoHeight = r.Logo_Height__c == null ? null : Integer.valueOf(r.Logo_Height__c);
                 d.footerTextOverride = r.Footer_Text__c;
                 d.layoutMode = r.Layout_Mode__c == MODE_FULL_HTML ? MODE_FULL_HTML : MODE_MANAGED;
-                defCache.put(r.Type__c, d);
+                defCache.put(key, d);
             }
         } catch (Exception e) {
             // Object not deployed yet, FLS blocked, etc. — built-in defaults cover us.

--- a/force-app/main/default/classes/DocGenEmailTemplateService.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateService.cls
@@ -278,32 +278,20 @@ global with sharing class DocGenEmailTemplateService {
     // Record loading (defensive — never throws to the caller)
     // =====================================================================
 
-    private static void loadActiveTemplates() {
-        defCache = new Map<String, TemplateDef>();
-        try {
-            // Guest signers send the PIN/completion emails, so this read must
-            // pass guest FLS. SYSTEM_MODE + guestAssertAccessible matches the
-            // established pattern for guest-reachable internal-object reads.
-            DocGenFlsGuard.guestAssertAccessible(
-                DocGen_Email_Template__c.sObjectType,
-                new Set<String>{
-                    'Type__c',
-                    'Subject__c',
-                    'Body_Html__c',
-                    'Body_Plain__c',
-                    'Brand_Color__c',
-                    'Logo_Url__c',
-                    'Logo_Url_Extended__c',
-                    'Logo_Asset_Key__c',
-                    'Logo_Height__c',
-                    'Footer_Text__c',
-                    'Layout_Mode__c',
-                    'Is_Active__c',
-                    'Brand__c'
-                }
-            );
+    /**
+     * Every active-template + logo-asset read, isolated in a `without sharing`
+     * scope. `WITH SYSTEM_MODE` bypasses CRUD/FLS but NOT record sharing —
+     * sharing follows the sharing keyword of the class the query runs in, and
+     * this class is `with sharing`. DocGen_Email_Template__c and DocGen_Asset__c
+     * both ship externalSharingModel=Private, so a GUEST sender (Verification
+     * PIN, guided-path Completion/All-Signed) saw zero rows here before this
+     * fix: defCache stayed empty and getTemplate() fell back to builtInDef(),
+     * exactly as if no record existed. The logo vanished the same way (#390).
+     */
+    private without sharing class TemplateReader {
+        private List<DocGen_Email_Template__c> readActiveTemplates() {
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-            List<DocGen_Email_Template__c> rows = [
+            return [
                 SELECT
                     Type__c,
                     Subject__c,
@@ -322,6 +310,64 @@ global with sharing class DocGenEmailTemplateService {
                 WITH SYSTEM_MODE
                 ORDER BY LastModifiedDate DESC
             ]; // NOPMD - package-internal object; CRUD via Portwood permission sets
+        }
+
+        private List<DocGen_Asset__c> readAssetByKey(String assetKey) {
+            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+            return [
+                SELECT
+                    Id,
+                    (
+                        SELECT ContentDocument.LatestPublishedVersionId
+                        FROM ContentDocumentLinks
+                        ORDER BY ContentDocument.CreatedDate DESC, ContentDocument.Id DESC
+                        LIMIT 1
+                    )
+                FROM DocGen_Asset__c
+                WHERE Asset_Key__c = :assetKey
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ]; // NOPMD ApexCRUDViolation - package-internal custom object; CRUD controlled by Portwood permission sets
+        }
+
+        private List<ContentDistribution> readDistributionByCv(Id cvId) {
+            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+            return [
+                SELECT ContentDownloadUrl
+                FROM ContentDistribution
+                WHERE ContentVersionId = :cvId
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+        }
+    }
+
+    private static void loadActiveTemplates() {
+        defCache = new Map<String, TemplateDef>();
+        try {
+            // Advisory FLS signal — must not abandon the load in a system context
+            // (Automated Process finalizer / platform-event trigger), see #390.
+            DocGenFlsGuard.advisoryAssertAccessible(
+                DocGen_Email_Template__c.sObjectType,
+                new Set<String>{
+                    'Type__c',
+                    'Subject__c',
+                    'Body_Html__c',
+                    'Body_Plain__c',
+                    'Brand_Color__c',
+                    'Logo_Url__c',
+                    'Logo_Url_Extended__c',
+                    'Logo_Asset_Key__c',
+                    'Logo_Height__c',
+                    'Footer_Text__c',
+                    'Layout_Mode__c',
+                    'Is_Active__c',
+                    'Brand__c'
+                }
+            );
+            // `without sharing` read — DocGen_Email_Template__c is externalSharingModel=Private,
+            // so a `with sharing` query returns zero rows for a guest sender (#390).
+            List<DocGen_Email_Template__c> rows = new TemplateReader().readActiveTemplates();
             for (DocGen_Email_Template__c r : rows) {
                 if (r.Type__c == null) {
                     continue;
@@ -617,22 +663,12 @@ global with sharing class DocGenEmailTemplateService {
 
     private static String queryAssetPublicUrl(String assetKey) {
         try {
-            DocGenFlsGuard.guestAssertAccessible(DocGen_Asset__c.sObjectType, new Set<String>{ 'Asset_Key__c' });
-            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-            List<DocGen_Asset__c> assets = [
-                SELECT
-                    Id,
-                    (
-                        SELECT ContentDocument.LatestPublishedVersionId
-                        FROM ContentDocumentLinks
-                        ORDER BY ContentDocument.CreatedDate DESC, ContentDocument.Id DESC
-                        LIMIT 1
-                    )
-                FROM DocGen_Asset__c
-                WHERE Asset_Key__c = :assetKey
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ]; // NOPMD ApexCRUDViolation - package-internal custom object; CRUD controlled by Portwood permission sets
+            // Advisory only — DocGen_Asset__c is also externalSharingModel=Private and
+            // read here from guest / Automated Process contexts; a throwing guard
+            // silently dropped the logo from those emails (#390). Reads go through
+            // the `without sharing` TemplateReader for the same reason.
+            DocGenFlsGuard.advisoryAssertAccessible(DocGen_Asset__c.sObjectType, new Set<String>{ 'Asset_Key__c' });
+            List<DocGen_Asset__c> assets = new TemplateReader().readAssetByKey(assetKey);
             if (assets.isEmpty() || assets[0].ContentDocumentLinks.isEmpty()) {
                 return null;
             }
@@ -640,18 +676,11 @@ global with sharing class DocGenEmailTemplateService {
             if (cvId == null) {
                 return null;
             }
-            DocGenFlsGuard.guestAssertAccessible(
+            DocGenFlsGuard.advisoryAssertAccessible(
                 ContentDistribution.sObjectType,
                 new Set<String>{ 'ContentDownloadUrl', 'ContentVersionId' }
             );
-            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-            List<ContentDistribution> dists = [
-                SELECT ContentDownloadUrl
-                FROM ContentDistribution
-                WHERE ContentVersionId = :cvId
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ];
+            List<ContentDistribution> dists = new TemplateReader().readDistributionByCv(cvId);
             return dists.isEmpty() ? null : dists[0].ContentDownloadUrl;
         } catch (Exception e) {
             System.debug(LoggingLevel.WARN, 'Portwood: logo asset resolution fell back to URL: ' + e.getMessage());

--- a/force-app/main/default/classes/DocGenEmailTemplateTest.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateTest.cls
@@ -680,7 +680,126 @@ private class DocGenEmailTemplateTest {
         }
     }
 
+    // ---- Guest / system context: the admin's saved template + branding must
+    //      reach emails sent from the GUEST signing transaction (Verification
+    //      PIN, guided-path Completion / All-Signed) and — by the same fix — the
+    //      Automated Process trigger/finalizer emails (#390).
+    //
+    //      Before the fix DocGenEmailTemplateService was `with sharing`, and
+    //      DocGen_Email_Template__c ships externalSharingModel=Private, so a guest
+    //      render read zero rows and silently fell back to builtInDef(). The
+    //      Automated Process leg (guestAssertAccessible throwing its object-level
+    //      verdict for a user with no permission set) can't be simulated in a
+    //      test — same limitation noted on the #227 guest-email fix.
+    @IsTest
+    static void storedTemplate_reachesGuestContext() {
+        insert new DocGen_Email_Template__c(
+            Name = 'Custom PIN',
+            Type__c = DocGenEmailTemplateService.TYPE_PIN,
+            Subject__c = 'ACME verification code',
+            Body_Html__c = '<p data-marker="acme-pin">Your code: {Pin}</p>',
+            Brand_Color__c = '#AB12CD',
+            Is_Active__c = true
+        );
+
+        User guest = getGuestUser();
+        DocGenEmailTemplateService.RenderedEmail r;
+        Test.startTest();
+        if (guest != null) {
+            System.runAs(guest) {
+                DocGenEmailTemplateService.clearCache();
+                r = DocGenEmailTemplateService.render(
+                    DocGenEmailTemplateService.TYPE_PIN,
+                    sampleTokens(DocGenEmailTemplateService.TYPE_PIN)
+                );
+            }
+        } else {
+            DocGenEmailTemplateService.clearCache();
+            r = DocGenEmailTemplateService.render(
+                DocGenEmailTemplateService.TYPE_PIN,
+                sampleTokens(DocGenEmailTemplateService.TYPE_PIN)
+            );
+        }
+        Test.stopTest();
+
+        System.assertEquals(
+            'ACME verification code',
+            r.subject,
+            'guest render must use the saved subject, not the built-in default'
+        );
+        System.assert(
+            r.htmlBody.contains('data-marker="acme-pin"'),
+            'guest render must use the saved body: ' + r.htmlBody
+        );
+        System.assert(r.htmlBody.contains('#AB12CD'), 'guest render must carry the saved brand color into the chrome');
+    }
+
+    // ---- #369 extension of the above: a per-(type, brand) template override
+    //      must ALSO survive guest context, not just the shared/no-brand one.
+    @IsTest
+    static void brandSpecificTemplate_reachesGuestContext() {
+        DocGen_Brand__c brand = new DocGen_Brand__c(
+            Name = 'Guest Test Brand',
+            Brand_Color__c = '#123ABC',
+            Is_Active__c = true
+        );
+        insert brand;
+        insert new DocGen_Email_Template__c(
+            Name = 'Brand PIN',
+            Type__c = DocGenEmailTemplateService.TYPE_PIN,
+            Subject__c = 'Brand-specific verification code',
+            Body_Html__c = '<p data-marker="brand-pin">Your code: {Pin}</p>',
+            Brand__c = brand.Id,
+            Is_Active__c = true
+        );
+
+        User guest = getGuestUser();
+        DocGenEmailTemplateService.RenderedEmail r;
+        Test.startTest();
+        if (guest != null) {
+            System.runAs(guest) {
+                DocGenEmailTemplateService.clearCache();
+                r = DocGenEmailTemplateService.render(
+                    DocGenEmailTemplateService.TYPE_PIN,
+                    sampleTokens(DocGenEmailTemplateService.TYPE_PIN),
+                    null,
+                    brand.Id
+                );
+            }
+        } else {
+            DocGenEmailTemplateService.clearCache();
+            r = DocGenEmailTemplateService.render(
+                DocGenEmailTemplateService.TYPE_PIN,
+                sampleTokens(DocGenEmailTemplateService.TYPE_PIN),
+                null,
+                brand.Id
+            );
+        }
+        Test.stopTest();
+
+        System.assertEquals(
+            'Brand-specific verification code',
+            r.subject,
+            'guest render must use the (type, brand) saved subject, not the shared/built-in default'
+        );
+        System.assert(
+            r.htmlBody.contains('data-marker="brand-pin"'),
+            'guest render must use the (type, brand) saved body: ' + r.htmlBody
+        );
+        System.assert(r.htmlBody.contains('#123ABC'), 'guest render must carry the BRAND color into the chrome');
+    }
+
     // ---- helpers ----
+    /**
+     * An active Site Guest user for true guest-context assertions, or null when
+     * the org has no Site (some package-build orgs) — callers then fall back to
+     * the current user so the test never fails merely for lack of a guest user.
+     */
+    private static User getGuestUser() {
+        List<User> guests = [SELECT Id FROM User WHERE UserType = 'Guest' AND IsActive = TRUE LIMIT 1];
+        return guests.isEmpty() ? null : guests[0];
+    }
+
     private static Map<String, String> sampleTokens(String type) {
         return new Map<String, String>{
             'SignerName' => 'Jordan Rivera',

--- a/force-app/main/default/classes/DocGenFlsGuard.cls
+++ b/force-app/main/default/classes/DocGenFlsGuard.cls
@@ -272,6 +272,37 @@ public with sharing class DocGenFlsGuard {
         }
     }
 
+    /**
+     * Runs guestAssertAccessible as an ADVISORY signal that never throws — logs
+     * and continues instead of aborting the caller. guestAssertAccessible's
+     * object-level verdict only bypasses for the 'Guest' user type; a caller
+     * that also runs as the Automated Process user (a platform-event trigger,
+     * an async finalizer — no permission set assigned, and not 'Guest' either)
+     * still gets a real throw from it, which silently abandons the whole read
+     * (#390 — loadActiveTemplates/queryAssetPublicUrl falling back to the
+     * built-in template on every Automated-Process-context signature email;
+     * the same shape hits DocGenBrandResolver's brand lookup). Use this instead
+     * of guestAssertAccessible for a SYSTEM_MODE, read-only, non-confidential
+     * internal-config read that must survive every execution context — the
+     * describe call still runs underneath, so the static-analysis FLS signal
+     * is preserved; only the verdict becomes advisory.
+     */
+    public static void advisoryAssertAccessible(Schema.SObjectType sot, Set<String> readFields) {
+        try {
+            guestAssertAccessible(sot, readFields);
+        } catch (Exception advisory) {
+            System.debug(
+                LoggingLevel.WARN,
+                'Portwood: FLS guard advisory-only for ' +
+                    sot +
+                    ' in this context (' +
+                    UserInfo.getUserType() +
+                    '): ' +
+                    advisory.getMessage()
+            );
+        }
+    }
+
     private static void guestAssertImpl(SObject record, Set<String> allowedFields, Boolean isUpdate) {
         if (record == null) {
             throw new DocGenException('Internal error: cannot enforce FLS on null record.');

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -396,11 +396,25 @@ public without sharing class DocGenSignatureController {
 
         DocGenFlsGuard.guestAssertAccessible(
             DocGen_Signer__c.sObjectType,
-            new Set<String>{ 'Signer_Email__c', 'PIN_Attempts__c', 'Status__c', 'CreatedDate', 'Secure_Token__c' }
+            new Set<String>{
+                'Signer_Email__c',
+                'PIN_Attempts__c',
+                'Status__c',
+                'CreatedDate',
+                'Secure_Token__c',
+                'Signature_Request__c'
+            }
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
         List<DocGen_Signer__c> signers = [
-            SELECT Id, Signer_Email__c, PIN_Attempts__c, Status__c, CreatedDate, Signature_Request__r.Expires_At__c
+            SELECT
+                Id,
+                Signer_Email__c,
+                PIN_Attempts__c,
+                Status__c,
+                CreatedDate,
+                Signature_Request__c,
+                Signature_Request__r.Expires_At__c
             FROM DocGen_Signer__c
             WHERE Secure_Token__c = :token
             WITH SYSTEM_MODE
@@ -461,7 +475,7 @@ public without sharing class DocGenSignatureController {
         Database.update(signer, false, AccessLevel.SYSTEM_MODE);
 
         // Send PIN via email
-        String emailError = sendPinEmail(signer.Signer_Email__c, pinStr);
+        String emailError = sendPinEmail(signer.Signer_Email__c, pinStr, signer.Signature_Request__c);
         if (emailError != null) {
             result.put('success', false);
             result.put('message', 'Failed to send verification email. Please contact the sender.');
@@ -598,11 +612,21 @@ public without sharing class DocGenSignatureController {
     /**
      * Sends the 6-digit PIN to the signer's email.
      */
-    private static String sendPinEmail(String email, String pin) {
+    private static String sendPinEmail(String email, String pin, Id requestId) {
         DocGen_Settings__c settings = DocGen_Settings__c.getOrgDefaults();
 
+        // #369 — the request's template's Brand, if any, supplies its own OWA
+        // ahead of the org default; getBrand() already excludes inactive brands.
+        // This was previously missing entirely — the PIN email never resolved a
+        // brand at all, always rendering the shared/no-brand template regardless
+        // of what the signing template's Sending Brand was set to.
+        Id brandId = DocGenBrandResolver.resolveBrandForRequest(requestId);
+        DocGen_Brand__c activeBrand = DocGenBrandResolver.getBrand(brandId);
+        String owaId = (activeBrand != null && String.isNotBlank(activeBrand.OWA_Id__c))
+            ? activeBrand.OWA_Id__c
+            : (settings == null ? null : settings.Signature_OWA_Id__c);
+
         // OWA is required for guest user context — warn if not configured
-        String owaId = settings == null ? null : settings.Signature_OWA_Id__c;
         if (String.isBlank(owaId) && UserInfo.getUserType() == 'Guest') {
             System.debug(
                 LoggingLevel.ERROR,
@@ -615,7 +639,9 @@ public without sharing class DocGenSignatureController {
         // (built-in default falls back automatically if no record exists).
         DocGenEmailTemplateService.RenderedEmail rendered = DocGenEmailTemplateService.render(
             DocGenEmailTemplateService.TYPE_PIN,
-            new Map<String, String>{ 'Pin' => pin, 'ExpirationMinutes' => String.valueOf(PIN_EXPIRATION_MINUTES) }
+            new Map<String, String>{ 'Pin' => pin, 'ExpirationMinutes' => String.valueOf(PIN_EXPIRATION_MINUTES) },
+            null,
+            brandId
         );
 
         Messaging.SingleEmailMessage email2 = new Messaging.SingleEmailMessage();

--- a/force-app/main/default/classes/DocGenSignatureEmailService.cls
+++ b/force-app/main/default/classes/DocGenSignatureEmailService.cls
@@ -151,7 +151,13 @@ public without sharing class DocGenSignatureEmailService {
         }
 
         DocGen_Settings__c settings = DocGen_Settings__c.getOrgDefaults();
-        String owaId = settings == null ? null : settings.Signature_OWA_Id__c;
+        // #369 — the request's template's Brand, if any, supplies its own OWA
+        // ahead of the org default; getBrand() already excludes inactive brands.
+        Id brandId = DocGenBrandResolver.resolveBrandForRequest(requestId);
+        DocGen_Brand__c activeBrand = DocGenBrandResolver.getBrand(brandId);
+        String owaId = (activeBrand != null && String.isNotBlank(activeBrand.OWA_Id__c))
+            ? activeBrand.OWA_Id__c
+            : (settings == null ? null : settings.Signature_OWA_Id__c);
         String senderName = UserInfo.getName();
         String senderEmail = UserInfo.getUserEmail();
 
@@ -194,7 +200,8 @@ public without sharing class DocGenSignatureEmailService {
             DocGenEmailTemplateService.RenderedEmail rendered = DocGenEmailTemplateService.render(
                 templateType,
                 tokens,
-                messageOverride
+                messageOverride,
+                brandId
             );
 
             String subject = String.isNotBlank(subjectOverride)
@@ -340,7 +347,16 @@ public without sharing class DocGenSignatureEmailService {
                 return;
             }
 
-            DocGenEmailTemplateService.RenderedEmail rendered = DocGenEmailTemplateService.render(templateType, tokens);
+            // #369 — the request's template's Brand, if any, supplies its own
+            // identity/OWA ahead of the org default.
+            Id brandId = DocGenBrandResolver.resolveBrandForRequest(requestId);
+            DocGen_Brand__c activeBrand = DocGenBrandResolver.getBrand(brandId);
+            DocGenEmailTemplateService.RenderedEmail rendered = DocGenEmailTemplateService.render(
+                templateType,
+                tokens,
+                null,
+                brandId
+            );
 
             Messaging.SingleEmailMessage email = new Messaging.SingleEmailMessage();
             email.setToAddresses(new List<String>{ sender.Email });
@@ -355,7 +371,9 @@ public without sharing class DocGenSignatureEmailService {
             }
 
             DocGen_Settings__c settings = DocGen_Settings__c.getOrgDefaults();
-            String owaId = settings == null ? null : settings.Signature_OWA_Id__c;
+            String owaId = (activeBrand != null && String.isNotBlank(activeBrand.OWA_Id__c))
+                ? activeBrand.OWA_Id__c
+                : (settings == null ? null : settings.Signature_OWA_Id__c);
             if (String.isNotBlank(owaId)) {
                 email.setOrgWideEmailAddressId(owaId);
             }
@@ -412,8 +430,14 @@ public without sharing class DocGenSignatureEmailService {
                 return;
             }
 
+            // #369 — the request's template's Brand, if any, supplies its own
+            // identity/OWA ahead of the org default.
+            Id brandId = DocGenBrandResolver.resolveBrandForRequest(requestId);
+            DocGen_Brand__c activeBrand = DocGenBrandResolver.getBrand(brandId);
             DocGen_Settings__c settings = DocGen_Settings__c.getOrgDefaults();
-            String owaId = settings == null ? null : settings.Signature_OWA_Id__c;
+            String owaId = (activeBrand != null && String.isNotBlank(activeBrand.OWA_Id__c))
+                ? activeBrand.OWA_Id__c
+                : (settings == null ? null : settings.Signature_OWA_Id__c);
             if (String.isBlank(owaId)) {
                 // Guest/async sends require an OWA; surface the reason instead of failing silently.
                 updateEmailStatus(
@@ -447,7 +471,9 @@ public without sharing class DocGenSignatureEmailService {
                 }
                 DocGenEmailTemplateService.RenderedEmail rendered = DocGenEmailTemplateService.render(
                     DocGenEmailTemplateService.TYPE_COMPLETION,
-                    new Map<String, String>{ 'SignerName' => s.Signer_Name__c, 'DocumentTitle' => docTitle }
+                    new Map<String, String>{ 'SignerName' => s.Signer_Name__c, 'DocumentTitle' => docTitle },
+                    null,
+                    brandId
                 );
                 Messaging.SingleEmailMessage email = new Messaging.SingleEmailMessage();
                 email.setToAddresses(new List<String>{ s.Signer_Email__c });

--- a/force-app/main/default/classes/DocGenSignatureEmailService.cls
+++ b/force-app/main/default/classes/DocGenSignatureEmailService.cls
@@ -158,8 +158,6 @@ public without sharing class DocGenSignatureEmailService {
         String owaId = (activeBrand != null && String.isNotBlank(activeBrand.OWA_Id__c))
             ? activeBrand.OWA_Id__c
             : (settings == null ? null : settings.Signature_OWA_Id__c);
-        String senderName = UserInfo.getName();
-        String senderEmail = UserInfo.getUserEmail();
 
         // OWA is required for signature emails — guest users cannot send without one,
         // and consistent branding requires all emails come from the same address.
@@ -168,6 +166,49 @@ public without sharing class DocGenSignatureEmailService {
             System.debug(LoggingLevel.ERROR, 'Portwood: ' + errMsg);
             updateEmailStatus(requestId, errMsg);
             return;
+        }
+
+        // Sender identity for the {SenderName} token and Reply-To. Resolve from the
+        // request CREATOR, not UserInfo — this method also runs from
+        // DocGenSignaturePdfTrigger as the Automated Process user (sequential signing,
+        // #379), whose non-routable noreply@<orgId> address makes Messaging.sendEmail
+        // reject the whole message on Reply-To. The running user is only the fallback
+        // when there is no request context (or the creator has no email).
+        String senderName = UserInfo.getName();
+        String senderEmail = UserInfo.getUserEmail();
+        if (requestId != null) {
+            try {
+                DocGenFlsGuard.guestAssertAccessible(
+                    DocGen_Signature_Request__c.sObjectType,
+                    new Set<String>{ 'CreatedById' }
+                );
+                /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+                DocGen_Signature_Request__c creatorRow = [
+                    SELECT CreatedById
+                    FROM DocGen_Signature_Request__c
+                    WHERE Id = :requestId
+                    WITH SYSTEM_MODE
+                    LIMIT 1
+                ]; // NOPMD
+                DocGenFlsGuard.guestAssertAccessible(User.sObjectType, new Set<String>{ 'Name', 'Email' });
+                /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+                User creator = [
+                    SELECT Name, Email
+                    FROM User
+                    WHERE Id = :creatorRow.CreatedById
+                    WITH SYSTEM_MODE
+                    LIMIT 1
+                ]; // NOPMD
+                if (String.isNotBlank(creator.Email)) {
+                    senderName = creator.Name;
+                    senderEmail = creator.Email;
+                }
+            } catch (Exception resolveEx) {
+                System.debug(
+                    LoggingLevel.WARN,
+                    'Portwood: could not resolve request creator for Reply-To: ' + resolveEx.getMessage()
+                );
+            }
         }
 
         // {ExpirationHours} reflects the request's actual signing window (stamped
@@ -218,7 +259,10 @@ public without sharing class DocGenSignatureEmailService {
             email.setOrgWideEmailAddressId(owaId);
 
             // Reply-to the creating user so signer replies reach a human, not the OWA.
-            if (String.isNotBlank(senderEmail)) {
+            // Never set a non-routable noreply@<orgId> address (the Automated Process
+            // user's, when this runs from the platform-event trigger) — Messaging.sendEmail
+            // rejects the whole message with INVALID_EMAIL_ADDRESS (#379).
+            if (String.isNotBlank(senderEmail) && !senderEmail.startsWithIgnoreCase('noreply@')) {
                 email.setReplyTo(senderEmail);
             }
 

--- a/force-app/main/default/classes/DocGenSignatureEmailService.cls
+++ b/force-app/main/default/classes/DocGenSignatureEmailService.cls
@@ -168,48 +168,8 @@ public without sharing class DocGenSignatureEmailService {
             return;
         }
 
-        // Sender identity for the {SenderName} token and Reply-To. Resolve from the
-        // request CREATOR, not UserInfo — this method also runs from
-        // DocGenSignaturePdfTrigger as the Automated Process user (sequential signing,
-        // #379), whose non-routable noreply@<orgId> address makes Messaging.sendEmail
-        // reject the whole message on Reply-To. The running user is only the fallback
-        // when there is no request context (or the creator has no email).
         String senderName = UserInfo.getName();
         String senderEmail = UserInfo.getUserEmail();
-        if (requestId != null) {
-            try {
-                DocGenFlsGuard.guestAssertAccessible(
-                    DocGen_Signature_Request__c.sObjectType,
-                    new Set<String>{ 'CreatedById' }
-                );
-                /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-                DocGen_Signature_Request__c creatorRow = [
-                    SELECT CreatedById
-                    FROM DocGen_Signature_Request__c
-                    WHERE Id = :requestId
-                    WITH SYSTEM_MODE
-                    LIMIT 1
-                ]; // NOPMD
-                DocGenFlsGuard.guestAssertAccessible(User.sObjectType, new Set<String>{ 'Name', 'Email' });
-                /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-                User creator = [
-                    SELECT Name, Email
-                    FROM User
-                    WHERE Id = :creatorRow.CreatedById
-                    WITH SYSTEM_MODE
-                    LIMIT 1
-                ]; // NOPMD
-                if (String.isNotBlank(creator.Email)) {
-                    senderName = creator.Name;
-                    senderEmail = creator.Email;
-                }
-            } catch (Exception resolveEx) {
-                System.debug(
-                    LoggingLevel.WARN,
-                    'Portwood: could not resolve request creator for Reply-To: ' + resolveEx.getMessage()
-                );
-            }
-        }
 
         // {ExpirationHours} reflects the request's actual signing window (stamped
         // Expires_At__c, or the legacy 48h when no requestId / no stamp).
@@ -259,10 +219,7 @@ public without sharing class DocGenSignatureEmailService {
             email.setOrgWideEmailAddressId(owaId);
 
             // Reply-to the creating user so signer replies reach a human, not the OWA.
-            // Never set a non-routable noreply@<orgId> address (the Automated Process
-            // user's, when this runs from the platform-event trigger) — Messaging.sendEmail
-            // rejects the whole message with INVALID_EMAIL_ADDRESS (#379).
-            if (String.isNotBlank(senderEmail) && !senderEmail.startsWithIgnoreCase('noreply@')) {
+            if (String.isNotBlank(senderEmail)) {
                 email.setReplyTo(senderEmail);
             }
 

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -3616,6 +3616,14 @@
                                             readonly
                                             class="slds-var-m-top_medium"
                                         ></lightning-input>
+                                        <lightning-combobox
+                                            label="Sending Brand"
+                                            value={editTemplateBrand}
+                                            options={brandOptions}
+                                            onchange={handleEditBrandChange}
+                                            field-level-help="Which Portwood Brand's sender address, logo, and color signature requests from this template use. None uses the org-wide Signature Settings default."
+                                            class="slds-var-m-top_medium"
+                                        ></lightning-combobox>
                                     </div>
                                 </div>
                                 <lightning-textarea

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -49,6 +49,8 @@ function columnsSectionSnippet(n) {
 // Apex
 import getTemplateList from '@salesforce/apex/DocGenController.getTemplateList';
 import getTemplateById from '@salesforce/apex/DocGenController.getTemplateById';
+// #369 — Sending Brand picker
+import getBrands from '@salesforce/apex/DocGenBrandController.getBrands';
 import deleteTemplate from '@salesforce/apex/DocGenController.deleteTemplate';
 import saveTemplate from '@salesforce/apex/DocGenController.saveTemplate';
 import generateDocumentData from '@salesforce/apex/DocGenController.generateDocumentData';
@@ -99,6 +101,8 @@ import NAME_FIELD from '@salesforce/schema/DocGen_Template__c.Name';
 import CATEGORY_FIELD from '@salesforce/schema/DocGen_Template__c.Category__c';
 import TYPE_FIELD from '@salesforce/schema/DocGen_Template__c.Type__c';
 import BASE_OBJECT_FIELD from '@salesforce/schema/DocGen_Template__c.Base_Object_API__c';
+// #369 — which Portwood Brand this template's signature emails use
+import BRAND_FIELD from '@salesforce/schema/DocGen_Template__c.Brand__c';
 import QUERY_CONFIG_FIELD from '@salesforce/schema/DocGen_Template__c.Query_Config__c';
 import DESC_FIELD from '@salesforce/schema/DocGen_Template__c.Description__c';
 import OUTPUT_FORMAT_FIELD from '@salesforce/schema/DocGen_Template__c.Output_Format__c';
@@ -221,6 +225,7 @@ const F = {
     Type: TYPE_FIELD.fieldApiName,
     OutputFormat: OUTPUT_FORMAT_FIELD.fieldApiName,
     BaseObject: BASE_OBJECT_FIELD.fieldApiName,
+    Brand: BRAND_FIELD.fieldApiName,
     QueryConfig: QUERY_CONFIG_FIELD.fieldApiName,
     // #161 follow-up — dedicated storage for Signer Inputs form-field config.
     // The field has no @salesforce/schema import yet (backend ships it in
@@ -446,6 +451,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     editTemplateId;
     editTemplateName;
     editTemplateCategory;
+    // #369 — which Portwood Brand this template's signature emails use
+    @track editTemplateBrand = '';
+    @track brandOptions = [];
     @track editTemplateType;
     // @track so children re-render when it arrives. The canvas mounts before the
     // template record finishes loading, and without this the Data picker was handed
@@ -1349,6 +1357,24 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
     }
 
+    // #369 — the Sending Brand picker on the edit modal's Details tab.
+    // Imperative, not @wire: getBrands() is cacheable=false (the Brands admin
+    // screen needs a fresh read right after a save), and @wire only works
+    // against cacheable=true Apex methods — a wired call here silently never
+    // populates.
+    async loadBrandOptions() {
+        try {
+            const data = await getBrands();
+            this.brandOptions = [
+                { label: '— None — (uses org default)', value: '' },
+                ...data.filter((b) => b.isActive !== false).map((b) => ({ label: b.name, value: b.id })),
+                { label: 'Manage brands…', value: '__manage__' }
+            ];
+        } catch (error) {
+            // Non-fatal — the picker just stays empty; template editing still works.
+        }
+    }
+
     templateSortedBy;
     templateSortedDirection = 'asc';
 
@@ -1472,6 +1498,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         // never throws — an org without Einstein simply keeps the copy-paste
         // path as the only visible option.
         this._refreshAgentforceAvailability();
+        this.loadBrandOptions();
     }
 
     disconnectedCallback() {
@@ -3793,6 +3820,15 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     handleEditCategoryChange(event) {
         this.editTemplateCategory = event.detail.value;
     }
+    // #369
+    handleEditBrandChange(event) {
+        const val = event.detail.value;
+        if (val === '__manage__') {
+            this.dispatchEvent(new CustomEvent('managebrands'));
+            return;
+        }
+        this.editTemplateBrand = val;
+    }
     handleEditTypeChange(event) {
         this.editTemplateType = event.detail.value;
         if (event.detail.value === 'Excel' && this.editTemplateOutputFormat === 'PDF') {
@@ -5126,6 +5162,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.lintFindings = [];
             this.editTemplateName = row.Name;
             this.editTemplateCategory = row[F.Category];
+            this.editTemplateBrand = row[F.Brand] || '';
             this.editTemplateType = row[F.Type];
             this.editTemplateObject = row[F.BaseObject];
             this.editTemplateOutputFormat = row[F.OutputFormat] || 'Native';
@@ -5274,6 +5311,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         return JSON.stringify([
             this.editTemplateName,
             this.editTemplateCategory,
+            this.editTemplateBrand,
             this.editTemplateType,
             this.editTemplateObject,
             this.editTemplateOutputFormat,
@@ -5662,6 +5700,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             Id: this.editTemplateId,
             Name: this.editTemplateName,
             Category__c: this.editTemplateCategory,
+            Brand__c: this.editTemplateBrand || null,
             Type__c: this.editTemplateType,
             Output_Format__c: this.editTemplateOutputFormat,
             Base_Object_API__c: this.editTemplateObject,
@@ -5736,6 +5775,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             Id: this.editTemplateId,
             Name: this.editTemplateName,
             Category__c: this.editTemplateCategory,
+            Brand__c: this.editTemplateBrand || null,
             Type__c: this.editTemplateType,
             Output_Format__c: this.editTemplateOutputFormat,
             Base_Object_API__c: this.editTemplateObject,

--- a/force-app/main/default/lwc/docGenBrands/docGenBrands.css
+++ b/force-app/main/default/lwc/docGenBrands/docGenBrands.css
@@ -1,0 +1,130 @@
+.brand-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.6rem 0.4rem;
+    border-bottom: 1px solid #e5e5e5;
+    cursor: pointer;
+    border-radius: 0.25rem;
+}
+.brand-row:hover {
+    background: #f7f7f7;
+}
+.swatch {
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 0.4rem;
+    flex-shrink: 0;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 0.625rem;
+    font-weight: 800;
+    letter-spacing: 0.02em;
+}
+.brand-meta {
+    flex: 1;
+    min-width: 0;
+}
+.brand-name {
+    font-size: 0.8125rem;
+    font-weight: 700;
+}
+.brand-sub {
+    font-size: 0.6875rem;
+    color: #706e6b;
+}
+.status-pill {
+    font-size: 0.625rem;
+    font-weight: 700;
+    padding: 0.05rem 0.45rem;
+    border-radius: 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+.status-pill.active {
+    color: #256a3c;
+    background: #f3fbf6;
+    border: 1px solid #b9e3c6;
+}
+.status-pill.inactive {
+    color: #706e6b;
+    background: #f4f4f4;
+    border: 1px solid #dddbda;
+}
+.add-form {
+    border: 1px dashed #c9c9c9;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    background: #fafafa;
+}
+.form-title {
+    font-size: 0.6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    color: #706e6b;
+    margin-bottom: 0.75rem;
+}
+.form-context {
+    font-size: 0.75rem;
+    color: #706e6b;
+    line-height: 1.5;
+    margin: 0 0 0.9rem;
+}
+.mini-preview {
+    border: 1px solid #dddbda;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    margin-bottom: 1rem;
+    background: #f4f4f4;
+}
+.mp-header {
+    padding: 0.9rem 1rem;
+    text-align: center;
+    color: #fff;
+    font-weight: 800;
+    font-size: 0.8125rem;
+    transition: background-color 0.15s ease;
+}
+.mp-logo {
+    max-height: 40px;
+    max-width: 220px;
+    display: inline-block;
+}
+.mp-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+}
+.mp-chip {
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 0.3rem;
+    background: rgba(255, 255, 255, 0.25);
+    font-size: 0.5625rem;
+    font-weight: 800;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.mp-body {
+    background: #fff;
+    padding: 0.75rem 1rem;
+    font-size: 0.6875rem;
+    color: #444;
+}
+.mp-cta {
+    margin: 0 1rem 0.85rem;
+    text-align: center;
+    background: #5a4fcf;
+    color: #fff;
+    padding: 0.5rem;
+    border-radius: 0.3rem;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    transition: background-color 0.15s ease;
+}

--- a/force-app/main/default/lwc/docGenBrands/docGenBrands.html
+++ b/force-app/main/default/lwc/docGenBrands/docGenBrands.html
@@ -1,0 +1,177 @@
+<template>
+    <lightning-card title="Brands" icon-name="utility:apps">
+        <div slot="actions">
+            <lightning-button-icon
+                icon-name="utility:refresh"
+                alternative-text="Reload"
+                title="Reload brands"
+                onclick={loadBrands}
+            ></lightning-button-icon>
+        </div>
+
+        <div class="slds-p-horizontal_medium slds-p-bottom_medium">
+            <p class="slds-text-body_small slds-text-color_weak slds-p-bottom_small">
+                A Brand controls what your signature emails look like — the sender address, logo, and color. Set one up
+                once here, then choose it on any Portwood Template.
+            </p>
+
+            <template if:true={isLoading}>
+                <div class="slds-p-around_medium slds-align_absolute-center">
+                    <lightning-spinner alternative-text="Loading" size="small"></lightning-spinner>
+                </div>
+            </template>
+
+            <template if:false={isLoading}>
+                <template if:true={hasBrands}>
+                    <template for:each={brandRows} for:item="b">
+                        <div key={b.id} class="brand-row" data-id={b.id} onclick={handleEditRow}>
+                            <div class="swatch" style={b.swatchStyle}>{b.initials}</div>
+                            <div class="brand-meta">
+                                <p class="brand-name">{b.name}</p>
+                                <p class="brand-sub">{b.owaId}</p>
+                            </div>
+                            <span class={b.statusClass}>{b.statusLabel}</span>
+                            <lightning-icon icon-name="utility:chevronright" size="x-small"></lightning-icon>
+                        </div>
+                    </template>
+                </template>
+                <template if:false={hasBrands}>
+                    <p class="slds-text-body_small slds-text-color_weak slds-p-vertical_small">
+                        No brands yet — every template still uses the org-wide Signature Settings default.
+                    </p>
+                </template>
+
+                <template if:false={showForm}>
+                    <lightning-button
+                        variant="brand-outline"
+                        label="+ Add Brand"
+                        onclick={handleAddNew}
+                        class="slds-m-top_small"
+                    ></lightning-button>
+                </template>
+
+                <template if:true={showForm}>
+                    <div class="add-form slds-m-top_medium">
+                        <p class="form-title">{formTitle}</p>
+                        <p class="form-context">
+                            This is what a signer sees at the top of every email this brand sends. Fill in the fields
+                            below and watch it update.
+                        </p>
+
+                        <div class="mini-preview">
+                            <div class="mp-header" style={previewHeaderStyle}>
+                                <template if:true={previewHasLogo}>
+                                    <img src={form.logoUrl} alt={previewCompanyOrName} class="mp-logo" />
+                                </template>
+                                <template if:false={previewHasLogo}>
+                                    <span class="mp-badge">
+                                        <template if:true={previewHasInitials}>
+                                            <span class="mp-chip">{previewInitials}</span>
+                                        </template>
+                                        <span>{previewCompanyOrName}</span>
+                                    </span>
+                                </template>
+                            </div>
+                            <div class="mp-body">A document is ready for your signature.</div>
+                            <div class="mp-cta" style={previewCtaStyle}>Review &amp; Sign</div>
+                        </div>
+
+                        <lightning-input
+                            data-field="name"
+                            type="text"
+                            label="Brand name"
+                            value={form.name}
+                            oninput={handleNameChange}
+                            required
+                            field-level-help="Internal name only — used to pick this brand on a Template. Not shown to signers."
+                            class="slds-p-bottom_x-small"
+                        ></lightning-input>
+
+                        <lightning-combobox
+                            data-field="owaId"
+                            label="Send emails from"
+                            value={form.owaId}
+                            options={owaOptions}
+                            onchange={handleOwaChange}
+                            field-level-help="Which Org-Wide Email Address this brand's signature emails send from. Blank falls back to the org-wide Signature Settings default."
+                            class="slds-p-bottom_x-small"
+                        ></lightning-combobox>
+
+                        <lightning-input
+                            data-field="companyName"
+                            type="text"
+                            label="Company name"
+                            value={form.companyName}
+                            oninput={handleCompanyChange}
+                            placeholder="Shown when there's no logo"
+                            field-level-help="Shown in the email header when there's no Logo URL set."
+                            class="slds-p-bottom_x-small"
+                        ></lightning-input>
+
+                        <lightning-input
+                            data-field="logoUrl"
+                            type="url"
+                            label="Logo URL"
+                            value={form.logoUrl}
+                            oninput={handleLogoChange}
+                            placeholder="https://…/logo.png"
+                            field-level-help="Must be a PUBLIC image URL — no Salesforce login required to view it. A private/internal file link (e.g. from a file's default 'Copy Link') will show as broken. Pick a Portwood Asset below instead to avoid this."
+                            class="slds-p-bottom_x-small"
+                        ></lightning-input>
+
+                        <lightning-combobox
+                            data-field="logoAssetKey"
+                            label="…or override with an Asset file"
+                            value={form.logoAssetKey}
+                            options={logoAssetOptions}
+                            onchange={handleLogoAssetChange}
+                            placeholder="Pick a Shared Asset image…"
+                            disabled={logoAssetsUnavailable}
+                            field-level-help="Links the logo to a Shared Asset (Command Hub → Assets): always uses the asset's LATEST image and is always public, so replacing its file updates the logo everywhere — no re-save needed. Typing a URL above unlinks the asset."
+                            class="slds-p-bottom_x-small"
+                        ></lightning-combobox>
+
+                        <lightning-input
+                            data-field="footerText"
+                            type="text"
+                            label="Footer text"
+                            value={form.footerText}
+                            oninput={handleFooterChange}
+                            class="slds-p-bottom_x-small"
+                        ></lightning-input>
+
+                        <lightning-input
+                            data-field="brandColor"
+                            type="color"
+                            label="Brand color"
+                            value={form.brandColor}
+                            onchange={handleColorChange}
+                            class="slds-p-bottom_x-small"
+                        ></lightning-input>
+
+                        <lightning-input
+                            data-field="isActive"
+                            type="toggle"
+                            label="Active"
+                            checked={form.isActive}
+                            onchange={handleActiveChange}
+                            message-toggle-active="On"
+                            message-toggle-inactive="Off"
+                            field-level-help="Inactive brands can't be selected on a Template but existing assignments are preserved."
+                            class="slds-p-bottom_small"
+                        ></lightning-input>
+
+                        <lightning-button
+                            variant="brand"
+                            label={saveLabel}
+                            onclick={handleSave}
+                            disabled={isSaving}
+                            class="slds-m-right_x-small"
+                        ></lightning-button>
+                        <lightning-button label="Cancel" onclick={handleCancel}></lightning-button>
+                    </div>
+                </template>
+            </template>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/docGenBrands/docGenBrands.js
+++ b/force-app/main/default/lwc/docGenBrands/docGenBrands.js
@@ -1,0 +1,276 @@
+import { LightningElement, track, wire } from 'lwc';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import getBrands from '@salesforce/apex/DocGenBrandController.getBrands';
+import saveBrand from '@salesforce/apex/DocGenBrandController.saveBrand';
+import getOrgWideEmailAddresses from '@salesforce/apex/DocGenSetupController.getOrgWideEmailAddresses';
+import resolveAssetPublicUrl from '@salesforce/apex/DocGenEmailTemplateController.resolveAssetPublicUrl';
+import getAssets from '@salesforce/apex/DocGenController.getAssets';
+
+function initialsOf(name) {
+    return (name || '')
+        .split(' ')
+        .filter(Boolean)
+        .map((w) => w[0])
+        .join('')
+        .slice(0, 3)
+        .toUpperCase();
+}
+
+const BLANK_FORM = {
+    id: null,
+    name: '',
+    owaId: '',
+    brandColor: '#5A4FCF',
+    logoUrl: '',
+    logoAssetKey: '',
+    companyName: '',
+    footerText: '',
+    isActive: true
+};
+
+export default class DocGenBrands extends LightningElement {
+    @track brands = [];
+    @track isLoading = true;
+    @track isSaving = false;
+    @track showForm = false;
+    @track form = { ...BLANK_FORM };
+    @track owaOptions = [];
+
+    // "…or override with an Asset file" — same Shared Asset picker pattern as
+    // the Email Templates editor. logoAssetKey is PERSISTED on the brand: the
+    // renderer resolves the asset's latest file to its public link at send
+    // time, so replacing the asset image updates every brand email with no
+    // re-save here.
+    @track logoAssets = [];
+
+    connectedCallback() {
+        this.loadBrands();
+        this.loadLogoAssets();
+    }
+
+    @wire(getOrgWideEmailAddresses)
+    wiredOwas({ data }) {
+        if (data) {
+            this.owaOptions = data;
+        }
+    }
+
+    async loadLogoAssets() {
+        try {
+            const assets = await getAssets();
+            this.logoAssets = (assets || []).filter((a) => a.isActive && a.latestVersionCvId);
+        } catch (_e) {
+            this.logoAssets = []; // Assets tab optional — picker just disables
+        }
+    }
+
+    get logoAssetOptions() {
+        const opts = this.logoAssets.map((a) => ({
+            label: a.name + (a.category ? ' (' + a.category + ')' : ''),
+            value: a.assetKey
+        }));
+        opts.unshift({ label: '— None (use the URL above) —', value: '' });
+        return opts;
+    }
+
+    get logoAssetsUnavailable() {
+        return this.logoAssets.length === 0;
+    }
+
+    async handleLogoAssetChange(event) {
+        const assetKey = event.detail.value;
+        if (!assetKey) {
+            this.form = { ...this.form, logoAssetKey: '' };
+            return;
+        }
+        const asset = this.logoAssets.find((a) => a.assetKey === assetKey);
+        try {
+            // Publish the asset's current file now (admin session) — send-time
+            // resolution only reads. The URL also lands in the field as a
+            // visible fallback/preview.
+            const url = await resolveAssetPublicUrl({ assetId: asset.id });
+            this.form = { ...this.form, logoAssetKey: assetKey, logoUrl: url };
+            this.toast(
+                'Logo linked to Asset',
+                'Signature emails now use this asset’s latest image automatically. Save to apply.',
+                'success'
+            );
+        } catch (error) {
+            this.toast('Could not use this asset', this.errMsg(error), 'error');
+        }
+    }
+
+    async loadBrands() {
+        this.isLoading = true;
+        try {
+            this.brands = await getBrands();
+        } catch (error) {
+            this.toast('Error loading brands', this.errMsg(error), 'error');
+        } finally {
+            this.isLoading = false;
+        }
+    }
+
+    get hasBrands() {
+        return this.brands.length > 0;
+    }
+
+    get brandRows() {
+        return this.brands.map((b) => ({
+            ...b,
+            swatchStyle: 'background-color:' + (b.brandColor || '#c9c9c9'),
+            initials: initialsOf(b.name),
+            statusLabel: b.isActive === false ? 'Inactive' : 'Active',
+            statusClass: b.isActive === false ? 'status-pill inactive' : 'status-pill active'
+        }));
+    }
+
+    get formTitle() {
+        return this.form.id ? 'Editing ' + this.form.name : 'New brand';
+    }
+
+    get saveLabel() {
+        return this.isSaving ? 'Saving…' : this.form.id ? 'Save Changes' : 'Save Brand';
+    }
+
+    // ===== Live preview — reflects the form as it's typed, before saving =====
+    get previewCompanyOrName() {
+        return this.form.companyName || this.form.name || 'Your Company';
+    }
+    get previewColor() {
+        return this.form.brandColor || '#5A4FCF';
+    }
+    get previewHeaderStyle() {
+        return 'background-color:' + this.previewColor;
+    }
+    get previewCtaStyle() {
+        return 'background-color:' + this.previewColor;
+    }
+    get previewInitials() {
+        return initialsOf(this.form.name);
+    }
+    get previewHasInitials() {
+        return this.previewInitials.length > 0 && !this.previewHasLogo;
+    }
+    // Mirrors DocGenEmailTemplateService.wrapChrome's real fallback: an image
+    // if a logo URL resolved, else plain company-name text — no badge at all.
+    get previewHasLogo() {
+        return !!(this.form.logoUrl && this.form.logoUrl.trim());
+    }
+
+    handleAddNew() {
+        this.form = { ...BLANK_FORM };
+        this.showForm = true;
+    }
+
+    handleEditRow(event) {
+        const id = event.currentTarget.dataset.id;
+        const brand = this.brands.find((b) => b.id === id);
+        if (!brand) {
+            return;
+        }
+        this.form = {
+            id: brand.id,
+            name: brand.name || '',
+            owaId: brand.owaId || '',
+            brandColor: brand.brandColor || '#5A4FCF',
+            logoUrl: brand.logoUrl || '',
+            logoAssetKey: brand.logoAssetKey || '',
+            companyName: brand.companyName || '',
+            footerText: brand.footerText || '',
+            isActive: brand.isActive !== false
+        };
+        this.showForm = true;
+    }
+
+    handleCancel() {
+        this.showForm = false;
+        this.form = { ...BLANK_FORM };
+    }
+
+    handleNameChange(e) {
+        this.form = { ...this.form, name: e.target.value };
+    }
+    handleOwaChange(e) {
+        this.form = { ...this.form, owaId: e.detail.value };
+    }
+    handleColorChange(e) {
+        this.form = { ...this.form, brandColor: e.target.value };
+    }
+    handleLogoChange(e) {
+        // Typing a URL manually supersedes the asset link (which would otherwise win).
+        this.form = { ...this.form, logoUrl: e.target.value, logoAssetKey: '' };
+    }
+    handleCompanyChange(e) {
+        this.form = { ...this.form, companyName: e.target.value };
+    }
+    handleFooterChange(e) {
+        this.form = { ...this.form, footerText: e.target.value };
+    }
+    handleActiveChange(e) {
+        this.form = { ...this.form, isActive: e.target.checked };
+    }
+
+    // Reads the CURRENT value straight off the rendered input, not the tracked
+    // `form` object — defensive against any change/input-event timing gap
+    // between typing and clicking Save.
+    fieldValue(fieldName) {
+        const el = this.template.querySelector('[data-field="' + fieldName + '"]');
+        if (!el) {
+            return this.form[fieldName];
+        }
+        return fieldName === 'isActive' ? el.checked : el.value;
+    }
+
+    async handleSave() {
+        const name = this.fieldValue('name');
+        if (!name || !name.trim()) {
+            this.toast('Name required', 'Give the brand a name before saving.', 'warning');
+            return;
+        }
+        const dto = {
+            id: this.form.id,
+            name: name,
+            owaId: this.fieldValue('owaId'),
+            brandColor: this.fieldValue('brandColor'),
+            logoUrl: this.fieldValue('logoUrl'),
+            logoAssetKey: this.fieldValue('logoAssetKey'),
+            companyName: this.fieldValue('companyName'),
+            footerText: this.fieldValue('footerText'),
+            isActive: this.fieldValue('isActive')
+        };
+        this.isSaving = true;
+        try {
+            // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
+            await saveBrand({ dto });
+            this.toast('Saved', name + ' saved.', 'success');
+            this.showForm = false;
+            this.form = { ...BLANK_FORM };
+            await this.loadBrands();
+        } catch (error) {
+            // Diagnostic: show exactly what this client attempted to send, so a
+            // failure here is provable rather than guessed at.
+            this.toast('Save failed', '[sent name: "' + name + '"] ' + this.errMsg(error), 'error');
+        } finally {
+            this.isSaving = false;
+        }
+    }
+
+    errMsg(error) {
+        const body = error && error.body;
+        if (Array.isArray(body) && body[0] && typeof body[0].message === 'string') {
+            return body[0].message;
+        }
+        if (body && typeof body.message === 'string' && body.message) {
+            return body.message;
+        }
+        if (error && typeof error.message === 'string' && error.message) {
+            return error.message;
+        }
+        return 'An unexpected error occurred.';
+    }
+
+    toast(title, message, variant) {
+        this.dispatchEvent(new ShowToastEvent({ title, message, variant }));
+    }
+}

--- a/force-app/main/default/lwc/docGenBrands/docGenBrands.js-meta.xml
+++ b/force-app/main/default/lwc/docGenBrands/docGenBrands.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/docGenCommandHub/docGenCommandHub.html
+++ b/force-app/main/default/lwc/docGenCommandHub/docGenCommandHub.html
@@ -41,6 +41,10 @@
                     <lightning-icon icon-name="utility:email" size="x-small" class="nav-icon"></lightning-icon>
                     <span>Email Templates</span>
                 </button>
+                <button class={brandsTabClass} onclick={handleShowBrands}>
+                    <lightning-icon icon-name="utility:apps" size="x-small" class="nav-icon"></lightning-icon>
+                    <span>Brands</span>
+                </button>
                 <button class={helpTabClass} onclick={handleShowHelp}>
                     <lightning-icon icon-name="utility:knowledge_base" size="x-small" class="nav-icon"></lightning-icon>
                     <span>Learning Center</span>
@@ -93,7 +97,7 @@
                             <p>Manage your document designs and create new ones.</p>
                         </div>
                         <div class="panel-body">
-                            <c-doc-gen-admin></c-doc-gen-admin>
+                            <c-doc-gen-admin onmanagebrands={handleShowBrands}></c-doc-gen-admin>
                         </div>
                     </template>
 
@@ -153,7 +157,21 @@
                             </p>
                         </div>
                         <div class="panel-body">
-                            <c-doc-gen-email-templates></c-doc-gen-email-templates>
+                            <c-doc-gen-email-templates onmanagebrands={handleShowBrands}></c-doc-gen-email-templates>
+                        </div>
+                    </template>
+
+                    <!-- BRANDS -->
+                    <template if:true={isBrands}>
+                        <div class="panel-header">
+                            <h2>Brands</h2>
+                            <p>
+                                Set up a reusable sender identity — address, logo, and color — for each business unit,
+                                then choose it on any Portwood Template.
+                            </p>
+                        </div>
+                        <div class="panel-body">
+                            <c-doc-gen-brands></c-doc-gen-brands>
                         </div>
                     </template>
 

--- a/force-app/main/default/lwc/docGenCommandHub/docGenCommandHub.js
+++ b/force-app/main/default/lwc/docGenCommandHub/docGenCommandHub.js
@@ -86,6 +86,9 @@ export default class DocGenCommandHub extends LightningElement {
     get isEmail() {
         return this.activeSection === 'email';
     }
+    get isBrands() {
+        return this.activeSection === 'brands';
+    }
     get isHelp() {
         return this.activeSection === 'help';
     }
@@ -106,6 +109,9 @@ export default class DocGenCommandHub extends LightningElement {
     }
     get emailTabClass() {
         return this.activeSection === 'email' ? 'tab-active' : '';
+    }
+    get brandsTabClass() {
+        return this.activeSection === 'brands' ? 'tab-active' : '';
     }
     get helpTabClass() {
         return this.activeSection === 'help' ? 'tab-active' : '';
@@ -128,6 +134,9 @@ export default class DocGenCommandHub extends LightningElement {
     }
     handleShowEmail() {
         this.activeSection = 'email';
+    }
+    handleShowBrands() {
+        this.activeSection = 'brands';
     }
     handleShowHelp() {
         this.activeSection = 'help';

--- a/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.html
+++ b/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.html
@@ -32,6 +32,80 @@
                         <p class="slds-text-body_small slds-text-color_weak slds-p-vertical_xx-small">{statusLabel}</p>
 
                         <lightning-combobox
+                            name="brandSelector"
+                            label="Brand"
+                            value={selectedBrandId}
+                            options={brandOptions}
+                            onchange={handleBrandSelectorChange}
+                            field-level-help="Overrides logo, color, sender, layout, subject, and body for this email type. Falls back to the shared default above when unset."
+                            class="slds-p-bottom_x-small"
+                        ></lightning-combobox>
+
+                        <template if:true={showAddBrandForm}>
+                            <div
+                                class="slds-box slds-box_xx-small slds-theme_shade slds-p-around_small slds-m-bottom_small"
+                            >
+                                <p class="slds-text-title_bold slds-p-bottom_x-small">New brand</p>
+                                <lightning-input
+                                    data-field="name"
+                                    type="text"
+                                    label="Brand name"
+                                    value={newBrandName}
+                                    oninput={handleNewBrandNameChange}
+                                    class="slds-p-bottom_x-small"
+                                ></lightning-input>
+                                <lightning-combobox
+                                    data-field="owaId"
+                                    label="Send emails from"
+                                    value={newBrandOwaId}
+                                    options={owaOptions}
+                                    onchange={handleNewBrandOwaChange}
+                                    class="slds-p-bottom_x-small"
+                                ></lightning-combobox>
+                                <lightning-input
+                                    data-field="companyName"
+                                    type="text"
+                                    label="Company name"
+                                    value={newBrandCompany}
+                                    oninput={handleNewBrandCompanyChange}
+                                    class="slds-p-bottom_x-small"
+                                ></lightning-input>
+                                <lightning-input
+                                    data-field="logoUrl"
+                                    type="url"
+                                    label="Logo URL"
+                                    value={newBrandLogoUrl}
+                                    oninput={handleNewBrandLogoChange}
+                                    class="slds-p-bottom_x-small"
+                                ></lightning-input>
+                                <lightning-input
+                                    data-field="footerText"
+                                    type="text"
+                                    label="Footer text"
+                                    value={newBrandFooter}
+                                    oninput={handleNewBrandFooterChange}
+                                    class="slds-p-bottom_x-small"
+                                ></lightning-input>
+                                <lightning-input
+                                    data-field="brandColor"
+                                    type="color"
+                                    label="Brand color"
+                                    value={newBrandColor}
+                                    onchange={handleNewBrandColorChange}
+                                    class="slds-p-bottom_small"
+                                ></lightning-input>
+                                <lightning-button
+                                    variant="brand"
+                                    label="Save Brand"
+                                    onclick={handleCreateBrand}
+                                    disabled={isSavingBrand}
+                                    class="slds-m-right_x-small"
+                                ></lightning-button>
+                                <lightning-button label="Cancel" onclick={handleCancelAddBrand}></lightning-button>
+                            </div>
+                        </template>
+
+                        <lightning-combobox
                             name="layoutMode"
                             label="Layout"
                             value={layoutMode}

--- a/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.html
+++ b/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.html
@@ -76,8 +76,20 @@
                                     label="Logo URL"
                                     value={newBrandLogoUrl}
                                     oninput={handleNewBrandLogoChange}
+                                    field-level-help="Must be a PUBLIC image URL, or pick a Portwood Asset below instead."
                                     class="slds-p-bottom_x-small"
                                 ></lightning-input>
+                                <lightning-combobox
+                                    data-field="logoAssetKey"
+                                    label="…or override with an Asset file"
+                                    value={newBrandLogoAssetKey}
+                                    options={logoAssetOptions}
+                                    onchange={handleNewBrandLogoAssetChange}
+                                    placeholder="Pick a Shared Asset image…"
+                                    disabled={logoAssetsUnavailable}
+                                    field-level-help="Links the logo to a Shared Asset (Command Hub → Assets). Typing a URL above unlinks the asset."
+                                    class="slds-p-bottom_x-small"
+                                ></lightning-combobox>
                                 <lightning-input
                                     data-field="footerText"
                                     type="text"

--- a/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.js
+++ b/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.js
@@ -56,6 +56,7 @@ export default class DocGenEmailTemplates extends LightningElement {
     @track newBrandColor = '#5A4FCF';
     @track newBrandCompany = '';
     @track newBrandLogoUrl = '';
+    @track newBrandLogoAssetKey = '';
     @track newBrandFooter = '';
     @track owaOptions = [];
 
@@ -269,7 +270,27 @@ export default class DocGenEmailTemplates extends LightningElement {
         this.newBrandCompany = e.target.value;
     }
     handleNewBrandLogoChange(e) {
+        // Typing a URL manually supersedes the asset link (which would otherwise win).
         this.newBrandLogoUrl = e.target.value;
+        this.newBrandLogoAssetKey = '';
+    }
+    async handleNewBrandLogoAssetChange(e) {
+        const assetKey = e.detail.value;
+        if (!assetKey) {
+            this.newBrandLogoAssetKey = '';
+            return;
+        }
+        const asset = this.logoAssets.find((a) => a.assetKey === assetKey);
+        try {
+            // Same asset-linking pattern as the per-type Logo field below and the
+            // full Brands screen — publishes the asset's current file now (admin
+            // session) and lands the resulting URL as a visible fallback/preview.
+            const url = await resolveAssetPublicUrl({ assetId: asset.id });
+            this.newBrandLogoAssetKey = assetKey;
+            this.newBrandLogoUrl = url;
+        } catch (error) {
+            this.toast('Could not use this asset', this.errMsg(error), 'error');
+        }
     }
     handleNewBrandFooterChange(e) {
         this.newBrandFooter = e.target.value;
@@ -282,6 +303,7 @@ export default class DocGenEmailTemplates extends LightningElement {
         this.newBrandColor = '#5A4FCF';
         this.newBrandCompany = '';
         this.newBrandLogoUrl = '';
+        this.newBrandLogoAssetKey = '';
         this.newBrandFooter = '';
     }
 
@@ -309,6 +331,7 @@ export default class DocGenEmailTemplates extends LightningElement {
                     brandColor: this.newBrandFieldValue('brandColor'),
                     companyName: this.newBrandFieldValue('companyName'),
                     logoUrl: this.newBrandFieldValue('logoUrl'),
+                    logoAssetKey: this.newBrandFieldValue('logoAssetKey'),
                     footerText: this.newBrandFieldValue('footerText'),
                     isActive: true
                 }

--- a/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.js
+++ b/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.js
@@ -1,4 +1,4 @@
-import { LightningElement, track } from 'lwc';
+import { LightningElement, track, wire } from 'lwc';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getTemplates from '@salesforce/apex/DocGenEmailTemplateController.getTemplates';
 import saveTemplate from '@salesforce/apex/DocGenEmailTemplateController.saveTemplate';
@@ -7,6 +7,10 @@ import renderPreview from '@salesforce/apex/DocGenEmailTemplateController.render
 import sendTest from '@salesforce/apex/DocGenEmailTemplateController.sendTest';
 import resolveAssetPublicUrl from '@salesforce/apex/DocGenEmailTemplateController.resolveAssetPublicUrl';
 import getAssets from '@salesforce/apex/DocGenController.getAssets';
+// #369 — Brand selector
+import getBrands from '@salesforce/apex/DocGenBrandController.getBrands';
+import saveBrand from '@salesforce/apex/DocGenBrandController.saveBrand';
+import getOrgWideEmailAddresses from '@salesforce/apex/DocGenSetupController.getOrgWideEmailAddresses';
 
 export default class DocGenEmailTemplates extends LightningElement {
     @track rows = [];
@@ -39,11 +43,49 @@ export default class DocGenEmailTemplates extends LightningElement {
     @track logoAssetKey = '';
     @track logoHeight = null;
 
+    // #369 — Brand selector: which (type, brand) combination is being edited.
+    @track selectedBrandId = '';
+    @track brandOptions = [{ label: 'Shared / Default (all brands)', value: '' }];
+    @track isBrandSpecific = false;
+
+    // #369 — inline "+ New Brand…" quick-create, opened from the selector.
+    @track showAddBrandForm = false;
+    @track isSavingBrand = false;
+    @track newBrandName = '';
+    @track newBrandOwaId = '';
+    @track newBrandColor = '#5A4FCF';
+    @track newBrandCompany = '';
+    @track newBrandLogoUrl = '';
+    @track newBrandFooter = '';
+    @track owaOptions = [];
+
     _previewDirty = false;
 
     connectedCallback() {
         this.loadTemplates();
         this.loadLogoAssets();
+        this.loadBrands();
+    }
+
+    @wire(getOrgWideEmailAddresses)
+    wiredOwas({ data }) {
+        if (data) {
+            this.owaOptions = data;
+        }
+    }
+
+    async loadBrands() {
+        try {
+            const brands = await getBrands();
+            this.brandOptions = [
+                { label: 'Shared / Default (all brands)', value: '' },
+                ...(brands || []).filter((b) => b.isActive !== false).map((b) => ({ label: b.name, value: b.id })),
+                { label: '+ New Brand…', value: '__add__' },
+                { label: 'Manage brands…', value: '__manage__' }
+            ];
+        } catch (_e) {
+            // Brands tab optional — selector just stays at Shared/Default.
+        }
     }
 
     async loadLogoAssets() {
@@ -103,7 +145,7 @@ export default class DocGenEmailTemplates extends LightningElement {
     async loadTemplates() {
         this.isLoading = true;
         try {
-            this.rows = await getTemplates();
+            this.rows = await getTemplates({ brandId: this.selectedBrandId });
             if (this.rows.length) {
                 const keep = this.rows.find((r) => r.type === this.selectedType) || this.rows[0];
                 this.applyRow(keep);
@@ -130,6 +172,7 @@ export default class DocGenEmailTemplates extends LightningElement {
         this.tokens = (row.tokens || []).map((t) => '{' + t + '}');
         this.logoAssetKey = row.logoAssetKey || '';
         this.logoHeight = row.logoHeight || null;
+        this.isBrandSpecific = row.isBrandSpecific === true;
         this.refreshPreview();
     }
 
@@ -151,12 +194,20 @@ export default class DocGenEmailTemplates extends LightningElement {
             logoHeight: this.logoHeight,
             footerText: this.footerText,
             layoutMode: this.layoutMode,
-            isActive: this.isActive
+            isActive: this.isActive,
+            brandId: this.selectedBrandId
         };
     }
 
     get statusLabel() {
-        return this.recordId ? 'Saved template' : 'Built-in default (not yet saved as a record)';
+        if (!this.selectedBrandId) {
+            return this.recordId ? 'Saved template' : 'Built-in default (not yet saved as a record)';
+        }
+        const brand = this.brandOptions.find((b) => b.value === this.selectedBrandId);
+        const brandName = brand ? brand.label : 'this brand';
+        return this.isBrandSpecific
+            ? 'Customized for ' + brandName
+            : 'Inherited from shared default — edit to customize for ' + brandName;
     }
 
     get layoutModeOptions() {
@@ -184,6 +235,95 @@ export default class DocGenEmailTemplates extends LightningElement {
         const row = this.rows.find((r) => r.type === event.detail.value);
         if (row) {
             this.applyRow(row);
+        }
+    }
+    // #369 — the Brand selector. Named distinctly from handleBrandChange below
+    // (that one is the per-type Brand Color Override text field).
+    handleBrandSelectorChange(event) {
+        const val = event.detail.value;
+        if (val === '__add__') {
+            this.showAddBrandForm = true;
+            return;
+        }
+        if (val === '__manage__') {
+            // The full Brands screen already exists as its own Command Hub tab —
+            // navigate there rather than duplicating a list+edit UI inline.
+            this.dispatchEvent(new CustomEvent('managebrands'));
+            return;
+        }
+        this.selectedBrandId = val;
+        this.loadTemplates();
+    }
+
+    // ===== #369 — inline "+ New Brand…" quick-create =====
+    handleNewBrandNameChange(e) {
+        this.newBrandName = e.target.value;
+    }
+    handleNewBrandOwaChange(e) {
+        this.newBrandOwaId = e.detail.value;
+    }
+    handleNewBrandColorChange(e) {
+        this.newBrandColor = e.target.value;
+    }
+    handleNewBrandCompanyChange(e) {
+        this.newBrandCompany = e.target.value;
+    }
+    handleNewBrandLogoChange(e) {
+        this.newBrandLogoUrl = e.target.value;
+    }
+    handleNewBrandFooterChange(e) {
+        this.newBrandFooter = e.target.value;
+    }
+
+    handleCancelAddBrand() {
+        this.showAddBrandForm = false;
+        this.newBrandName = '';
+        this.newBrandOwaId = '';
+        this.newBrandColor = '#5A4FCF';
+        this.newBrandCompany = '';
+        this.newBrandLogoUrl = '';
+        this.newBrandFooter = '';
+    }
+
+    // Reads the CURRENT value straight off the rendered input, not the tracked
+    // newBrandXxx properties — defensive against any change/input-event timing
+    // gap between typing and clicking Save Brand.
+    newBrandFieldValue(fieldName) {
+        const el = this.template.querySelector('[data-field="' + fieldName + '"]');
+        return el ? el.value : '';
+    }
+
+    async handleCreateBrand() {
+        const name = this.newBrandFieldValue('name');
+        if (!name || !name.trim()) {
+            this.toast('Name required', 'Give the brand a name before saving.', 'warning');
+            return;
+        }
+        this.isSavingBrand = true;
+        try {
+            // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
+            const newId = await saveBrand({
+                dto: {
+                    name: name,
+                    owaId: this.newBrandFieldValue('owaId'),
+                    brandColor: this.newBrandFieldValue('brandColor'),
+                    companyName: this.newBrandFieldValue('companyName'),
+                    logoUrl: this.newBrandFieldValue('logoUrl'),
+                    footerText: this.newBrandFieldValue('footerText'),
+                    isActive: true
+                }
+            });
+            this.toast('Saved', name + ' created.', 'success');
+            this.handleCancelAddBrand();
+            await this.loadBrands();
+            this.selectedBrandId = newId;
+            await this.loadTemplates();
+        } catch (error) {
+            // Diagnostic: show exactly what this client attempted to send, so a
+            // failure here is provable rather than guessed at.
+            this.toast('Save failed', '[sent name: "' + name + '"] ' + this.errMsg(error), 'error');
+        } finally {
+            this.isSavingBrand = false;
         }
     }
     handleSubjectChange(event) {

--- a/force-app/main/default/objects/DocGen_Brand__c/DocGen_Brand__c.object-meta.xml
+++ b/force-app/main/default/objects/DocGen_Brand__c/DocGen_Brand__c.object-meta.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <allowInChatterGroups>false</allowInChatterGroups>
+    <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description
+    >A reusable sender identity (Org-Wide Email Address, logo, brand color, company name) for a business unit or brand within a single Portwood org. A Portwood Template optionally points at one via Brand__c; the signature-email send path resolves it ahead of the org-wide Signature Settings default (#369).</description>
+    <enableActivities>false</enableActivities>
+    <enableBulkApi>true</enableBulkApi>
+    <enableFeeds>false</enableFeeds>
+    <enableHistory>false</enableHistory>
+    <enableLicensing>false</enableLicensing>
+    <enableReports>false</enableReports>
+    <enableSearch>true</enableSearch>
+    <enableSharing>true</enableSharing>
+    <enableStreamingApi>true</enableStreamingApi>
+    <externalSharingModel>Private</externalSharingModel>
+    <label>Portwood Brand</label>
+    <nameField>
+        <label>Brand Name</label>
+        <type>Text</type>
+    </nameField>
+    <pluralLabel>Portwood Brands</pluralLabel>
+    <searchLayouts />
+    <sharingModel>ReadWrite</sharingModel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/DocGen_Brand__c/fields/Brand_Color__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Brand__c/fields/Brand_Color__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Brand_Color__c</fullName>
+    <description
+    >Hex color code (#RRGGBB) for this brand's signature emails. Blank falls back to the org default (DocGen_Settings__c.Signature_Email_Brand_Color__c).</description>
+    <externalId>false</externalId>
+    <label>Brand Color</label>
+    <length>7</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Brand__c/fields/Company_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Brand__c/fields/Company_Name__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Company_Name__c</fullName>
+    <description
+    >This brand's company name, shown in its signature emails and used as a fallback when no logo is configured. Blank falls back to the org default (DocGen_Settings__c.Company_Name__c).</description>
+    <externalId>false</externalId>
+    <label>Company Name</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Brand__c/fields/Footer_Text__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Brand__c/fields/Footer_Text__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Footer_Text__c</fullName>
+    <description
+    >Optional footer text override for this brand's signature emails. Blank falls back to the org default (DocGen_Settings__c.Signature_Email_Footer_Text__c).</description>
+    <externalId>false</externalId>
+    <label>Footer Text</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Brand__c/fields/Is_Active__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Brand__c/fields/Is_Active__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Is_Active__c</fullName>
+    <defaultValue>true</defaultValue>
+    <description
+    >When false, this brand is treated as if unset by the send path — templates pointing at it fall back to the org-wide Signature Settings default. Lets admins retire a brand without deleting it or having to unassign every template first.</description>
+    <label>Is Active</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Brand__c/fields/Logo_Asset_Key__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Brand__c/fields/Logo_Asset_Key__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Logo_Asset_Key__c</fullName>
+    <description
+    >Shared Asset key (DocGen_Asset__c.Asset_Key__c) supplying this brand's logo. When set, the send path resolves the asset's LATEST file to its public delivery link — replacing the asset's image updates the logo everywhere this brand is used, with no edit here. Takes precedence over the Logo URL fields.</description>
+    <externalId>false</externalId>
+    <label>Logo Asset Key</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Brand__c/fields/Logo_Height__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Brand__c/fields/Logo_Height__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Logo_Height__c</fullName>
+    <description
+    >Rendered logo height in pixels for this brand's signature emails. Blank = 48. Clamped to 16-200 at render time; mirrors DocGen_Email_Template__c.Logo_Height__c.</description>
+    <externalId>false</externalId>
+    <label>Logo Height (px)</label>
+    <precision>3</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Brand__c/fields/Logo_Url_Extended__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Brand__c/fields/Logo_Url_Extended__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Logo_Url_Extended__c</fullName>
+    <description
+    >Long-form logo URL override. Supersedes Logo_Url__c (a platform Url field, hard-capped at 255 characters) so Salesforce Files public-delivery URLs and other long links fit. Mirrors DocGen_Email_Template__c.Logo_Url_Extended__c.</description>
+    <externalId>false</externalId>
+    <label>Logo URL (Long)</label>
+    <length>32768</length>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Brand__c/fields/Logo_Url__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Brand__c/fields/Logo_Url__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Logo_Url__c</fullName>
+    <description
+    >URL to this brand's logo image, shown at the top of its signature emails. Blank falls back to the org default (DocGen_Settings__c.Signature_Email_Logo_Url__c). Superseded by Logo_Url_Extended__c or Logo_Asset_Key__c when set.</description>
+    <externalId>false</externalId>
+    <label>Logo URL</label>
+    <required>false</required>
+    <type>Url</type>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Brand__c/fields/OWA_Id__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Brand__c/fields/OWA_Id__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>OWA_Id__c</fullName>
+    <description
+    >The ID of the Org-Wide Email Address this brand sends signature emails from. Blank falls back to the org-wide Signature Org-Wide Email Address ID (DocGen_Settings__c.Signature_OWA_Id__c).</description>
+    <externalId>false</externalId>
+    <label>Org-Wide Email Address ID</label>
+    <length>18</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Brand__c/listViews/All.listView-meta.xml
+++ b/force-app/main/default/objects/DocGen_Brand__c/listViews/All.listView-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ListView xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>All</fullName>
+    <columns>NAME</columns>
+    <columns>OWA_Id__c</columns>
+    <columns>Brand_Color__c</columns>
+    <columns>Is_Active__c</columns>
+    <columns>LAST_UPDATE</columns>
+    <filterScope>Everything</filterScope>
+    <label>All</label>
+</ListView>

--- a/force-app/main/default/objects/DocGen_Email_Template__c/fields/Brand__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Email_Template__c/fields/Brand__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Brand__c</fullName>
+    <deleteConstraint>SetNull</deleteConstraint>
+    <description
+    >Optional Portwood Brand this email-type record's wording override applies to. Blank means this record is the SHARED default for its Type__c, used by every brand (and by templates with no brand) that has not saved its own override — today's exact behavior, unchanged. When set, this record's Subject__c/Body_Html__c/etc. only apply to requests whose template's Brand__c matches (#369).</description>
+    <externalId>false</externalId>
+    <label>Brand</label>
+    <referenceTo>DocGen_Brand__c</referenceTo>
+    <relationshipLabel>Email Template Overrides</relationshipLabel>
+    <relationshipName>Email_Template_Overrides</relationshipName>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Template__c/fields/Brand__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Template__c/fields/Brand__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Brand__c</fullName>
+    <deleteConstraint>SetNull</deleteConstraint>
+    <description
+    >The Portwood Brand that documents generated from this template send as. When set, signature emails for requests generated from this template use this brand's Org-Wide Email Address, logo, color, and company name ahead of the org-wide Signature Settings default (#369). Blank behaves exactly as before this field existed.</description>
+    <externalId>false</externalId>
+    <label>Sending Brand</label>
+    <referenceTo>DocGen_Brand__c</referenceTo>
+    <relationshipLabel>Templates</relationshipLabel>
+    <relationshipName>Templates</relationshipName>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
@@ -29,6 +29,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DocGenBrandResolver</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DocGenFieldWritebackService</apexClass>
         <enabled>true</enabled>
     </classAccesses>
@@ -38,6 +42,10 @@
     </classAccesses>
     <classAccesses>
         <apexClass>DocGenEmailTemplateController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DocGenBrandController</apexClass>
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
@@ -237,6 +245,57 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>DocGen_Email_Template__c.Description__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Email_Template__c.Brand__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <!-- Portwood Brand fields (#369) (Admin: full access). -->
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Brand__c.OWA_Id__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Brand__c.Brand_Color__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Brand__c.Logo_Url__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Brand__c.Logo_Url_Extended__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Brand__c.Logo_Asset_Key__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Brand__c.Logo_Height__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Brand__c.Company_Name__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Brand__c.Footer_Text__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Brand__c.Is_Active__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <!-- Shared Asset fields (#185) (Admin: full access; Name is standard).
@@ -506,6 +565,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>DocGen_Template__c.Category__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Template__c.Brand__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -999,6 +1063,16 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>true</modifyAllRecords>
         <object>DocGen_Email_Template__c</object>
+        <viewAllFields>false</viewAllFields>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>true</allowCreate>
+        <allowDelete>true</allowDelete>
+        <allowEdit>true</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>true</modifyAllRecords>
+        <object>DocGen_Brand__c</object>
         <viewAllFields>false</viewAllFields>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>

--- a/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
@@ -326,6 +326,60 @@
         <field>DocGen_Template__c.Form_Fields_Config__c</field>
         <readable>true</readable>
     </fieldPermissions>
+    <!-- Portwood Brand (#369): completion/PIN/all-signed emails can finish inside the
+         guest signer's own session (see DocGenSignatureEmailService's without-sharing
+         note), so DocGenBrandResolver's SYSTEM_MODE reads need guest FLS the same way
+         every other guest-reachable internal read here does. Read-only. -->
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Template__c.Brand__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.OWA_Id__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Brand_Color__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Logo_Url__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Logo_Url_Extended__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Logo_Asset_Key__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Logo_Height__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Company_Name__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Footer_Text__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Is_Active__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
     <!-- New audit fields for guest -->
     <fieldPermissions>
         <editable>true</editable>
@@ -419,6 +473,16 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>DocGen_Email_Template__c</object>
+        <viewAllFields>false</viewAllFields>
+        <viewAllRecords>false</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>DocGen_Brand__c</object>
         <viewAllFields>false</viewAllFields>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>

--- a/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
@@ -22,6 +22,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>DocGenBrandResolver</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>DocGenFieldWritebackService</apexClass>
         <enabled>true</enabled>
     </classAccesses>
@@ -31,6 +35,10 @@
     </classAccesses>
     <classAccesses>
         <apexClass>DocGenEmailTemplateController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DocGenBrandController</apexClass>
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
@@ -219,6 +227,57 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>DocGen_Email_Template__c.Description__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Email_Template__c.Brand__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <!-- Portwood Brand fields (#369) (User: read-only, so a non-admin sender's requests still resolve the right brand). -->
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.OWA_Id__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Brand_Color__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Logo_Url__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Logo_Url_Extended__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Logo_Asset_Key__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Logo_Height__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Company_Name__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Footer_Text__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Brand__c.Is_Active__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <!-- Shared Asset fields (#185) (User: read-only; Name is standard).
@@ -477,6 +536,11 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>DocGen_Template__c.Category__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Template__c.Brand__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -865,6 +929,16 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>DocGen_Email_Template__c</object>
+        <viewAllFields>false</viewAllFields>
+        <viewAllRecords>false</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>DocGen_Brand__c</object>
         <viewAllFields>false</viewAllFields>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>

--- a/scripts/e2e-06b-signature-lifecycle.apex
+++ b/scripts/e2e-06b-signature-lifecycle.apex
@@ -181,9 +181,93 @@ try {
     System.debug('ATTACHMENT OVERLOADS NO-THROW: FAIL — ' + e.getMessage());
 }
 
+// ===== 8. #369 — per-brand sender identity =====
+// A template's Sending Brand resolves for its requests and drives the
+// signature email's colour + footer + OWA. Sending Brand blank = unchanged.
+Id brandTmplId = tmpls[0].Id;
+DocGen_Brand__c e2eBrand = new DocGen_Brand__c(
+    Name = 'E2E Brand ' + Datetime.now().getTime(),
+    Brand_Color__c = '#AB12CD',
+    Footer_Text__c = 'E2E brand footer line',
+    Company_Name__c = 'E2E Brand Co',
+    OWA_Id__c = '0D2000000000001AAA',
+    Is_Active__c = true
+);
+try {
+    insert e2eBrand;
+    update new DocGen_Template__c(Id = brandTmplId, Brand__c = e2eBrand.Id);
+
+    DocGen_Signature_Request__c brandReq = new DocGen_Signature_Request__c(
+        Status__c = 'Sent',
+        Template__c = brandTmplId,
+        Related_Record_Id__c = acctId,
+        Expires_At__c = System.now().addDays(30)
+    );
+    insert brandReq;
+
+    Boolean resolves = DocGenBrandResolver.resolveBrandForRequest(brandReq.Id) == e2eBrand.Id;
+    DocGen_Brand__c got = DocGenBrandResolver.getBrand(e2eBrand.Id);
+    Boolean brandRead = got != null && got.Brand_Color__c == '#AB12CD' && got.OWA_Id__c == '0D2000000000001AAA';
+
+    DocGenEmailTemplateService.RenderedEmail em = DocGenEmailTemplateService.render(
+        DocGenEmailTemplateService.TYPE_REQUEST,
+        new Map<String, String>{
+            'SignerName' => 'E2E',
+            'CompanyName' => 'x',
+            'DocumentTitle' => 'Doc',
+            'SignatureUrl' => 'https://example.com/s',
+            'ExpirationHours' => '48'
+        },
+        null,
+        e2eBrand.Id
+    );
+    Boolean colourInEmail = em != null && em.htmlBody != null && em.htmlBody.containsIgnoreCase('AB12CD');
+    Boolean footerInEmail = em != null && em.htmlBody != null && em.htmlBody.contains('E2E brand footer line');
+
+    // Sending Brand blank → a fresh request resolves to no brand (default path).
+    update new DocGen_Template__c(Id = brandTmplId, Brand__c = null);
+    DocGen_Signature_Request__c noBrandReq = new DocGen_Signature_Request__c(
+        Status__c = 'Sent',
+        Template__c = brandTmplId,
+        Related_Record_Id__c = acctId,
+        Expires_At__c = System.now().addDays(30)
+    );
+    insert noBrandReq;
+    Boolean blankIsNull = DocGenBrandResolver.resolveBrandForRequest(noBrandReq.Id) == null;
+
+    delete [SELECT Id FROM DocGen_Signature_Request__c WHERE Id IN (:brandReq.Id, :noBrandReq.Id)];
+
+    if (resolves && brandRead && colourInEmail && footerInEmail && blankIsNull) {
+        pass++;
+        System.debug('PER-BRAND SENDER IDENTITY: PASS');
+    } else {
+        fail++;
+        System.debug(
+            'PER-BRAND SENDER IDENTITY: FAIL — resolves=' +
+                resolves +
+                ' brandRead=' +
+                brandRead +
+                ' colour=' +
+                colourInEmail +
+                ' footer=' +
+                footerInEmail +
+                ' blankNull=' +
+                blankIsNull
+        );
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('PER-BRAND SENDER IDENTITY: FAIL — ' + e.getMessage());
+}
+
 // ===== Cleanup: delete lifecycle request, restore settings =====
 try {
     delete [SELECT Id FROM DocGen_Signature_Request__c WHERE Id = :lifecycleReqId];
+    // #369 — the shared template must not leak a Sending Brand to later scripts.
+    update new DocGen_Template__c(Id = tmpls[0].Id, Brand__c = null);
+    if (e2eBrand.Id != null) {
+        delete [SELECT Id FROM DocGen_Brand__c WHERE Id = :e2eBrand.Id];
+    }
     DocGen_Settings__c restore = DocGen_Settings__c.getOrgDefaults();
     restore.Signature_Reminder_Enabled__c = prevEnabled;
     restore.Signature_Reminder_Hours__c = prevHours;


### PR DESCRIPTION
Closes #369.

## Summary

Adds a **Portwood Brand** — a reusable sender identity (Send-emails-from address / logo / colour / company name / footer) that any Portwood Template can point at via a new **Sending Brand** field. One Salesforce org can now run two entities without their signature emails ever crossing: a different brand per template.

Client-approved design (see #369). Leave **Sending Brand** blank and every signature email behaves exactly as it does today.

## What's in it

**New object `DocGen_Brand__c`** ("Portwood Brand") with `OWA_Id__c`, `Company_Name__c`, `Logo_Url__c` / `Logo_Url_Extended__c` / `Logo_Asset_Key__c` / `Logo_Height__c`, `Footer_Text__c`, `Brand_Color__c`, `Is_Active__c`. Field-level security on `DocGen_Admin`, `DocGen_User`, `DocGen_Guest_Signature`.

**New fields**
- `DocGen_Template__c.Brand__c` — label **Sending Brand**, `deleteConstraint SetNull`
- `DocGen_Email_Template__c.Brand__c` — label **Brand**, for a per-(email type, brand) wording override

**New Apex**
- `DocGenBrandController` — CRUD behind the Brands screen (one upsert path, long-URL split, admin gate)
- `DocGenBrandResolver` — `resolveBrandForRequest(requestId)` / `getBrand(brandId)`, per-transaction static caches, `without sharing`

**Wired through** `DocGenEmailTemplateService` (4-arg `render(type, tokens, msgOverride, brandId)` + brand colour/logo/footer cascade), `DocGenSignatureEmailService` and `DocGenSignatureController.sendPinEmail` (brand-aware OWA + `{SenderName}`), for all seven signature emails — request, reminder, verification PIN, signer-completed, all-signed, declined, completion.

**Resolution order** — visual/wording pieces: per-(email type, brand) override → the Sending Brand's own identity → org-wide Signature Settings → built-in default. Sender address has only two levels: the Sending Brand's OWA, then the org-wide one.

**UI**
- New `docGenBrands` LWC — the **Brands** tab in the Command Hub (add/edit brands, OWA picker, Asset-file logo picker, live email-header preview)
- **Brand** selector on the Email Templates tab (Shared / Default vs. a per-(type, brand) override), with inline *+ New Brand…* and *Manage brands…*

**Docs** — `CHANGELOG.md` (`### Added` + the folded-in `### Fixed` entries), `UserGuide.md` §10.13 (per-brand identity + cascade), §10.14 (Brand selector), new §10.15 (Brands tab + "second sending identity" walkthrough), §13.1 / §13.2 cross-links.

## Folded in

- **#390** — guest and Automated Process contexts fell back to built-in email templates and branding. Ported here as `DocGenEmailTemplateService` → private `without sharing class TemplateReader` + `DocGenFlsGuard.advisoryAssertAccessible`, adapted for `Brand__c`. **Overlaps PR #391**, which is the standalone #390 fix. Coordination: #391 merges first; this branch then rebases and takes #391's version of the #390 fix, keeping only the brand-specific additions.
- **Verification PIN email** never resolved a brand (the one send site not updated for the cascade) — now threads the request through from the signer row.

## Not in it

- The **sequential-signing Reply-To** logic (#379) was stripped from `DocGenSignatureEmailService.sendRequestLikeEmails` on this branch — that's PR **#380**'s territory. #380 must ship in the same release, or restore the block here.

## Testing

Full CLAUDE.md release-validation checklist, run against a **fresh `--no-namespace` scratch org** deployed from this branch:

| Check | Result |
| --- | --- |
| `e2e-01 … e2e-08` + `07-syntax1…5` | **all 14 scripts `FAIL: 0`** — 01 49/0 · 02 10/0 · 03 14/0 · 03b 3/0 · 04 15/0 · 05 18/0 · 06 25/0 · **06b 9/0** · syntax1 35/0 · syntax2 31/0 · syntax3 18/0 · syntax4 20/0 · syntax5 10/0 · 08 13/0 |
| `RunLocalTests` + `--code-coverage` | **`Outcome: Passed` · 2005 tests · Pass Rate 100% · 0 failures · org-wide coverage 79%** |
| `sf code-analyzer` (Security + AppExchange) | PMD engines **0 violations**. The 2 "Critical" results are engine startup failures on the runner (SFGE Java OOM; flow engine needs Python 3.10), not code findings — same environmental note as #380. CI is the real gate. |
| `npm run format:check` | clean |

**`e2e-06b` gains a `#369` assertion** (`7cd6d82`) that closes the brand-coverage gap: a template's **Sending Brand** resolves for its requests, `DocGenEmailTemplateService.render(TYPE_REQUEST, …, brandId)` carries the brand's colour + footer, and a **blank Sending Brand resolves to `null`** (default path unchanged).

Brand OWA resolution was also verified live in an earlier sandbox pass — two brands sharing one OWA and a third on a different OWA sent from genuinely different addresses.

## Checklist

- [x] No hardcoded IDs, URLs, or credentials
- [x] No `VersionData` in PDF image queries
- [x] Internal branding-config reads use `WITH SYSTEM_MODE` in a `without sharing` scope with a describe-based FLS signal
- [x] `RunLocalTests` — 2005 / 100% / 79%
- [x] `e2e-01…08` + `syntax1…5` — all `FAIL: 0`
- [x] `npm run format:check` clean
- [x] No new external dependencies

